### PR TITLE
Task03

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
 BreakInheritanceList: BeforeColon
-ColumnLimit: 120
+ColumnLimit: 160
 CompactNamespaces: false
 ContinuationIndentWidth: 8
 IndentCaseLabels: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 build
 cmake-build*
 .vs
+.vscode
+.cache
+compile_commands.json

--- a/libs/images/libimages/images.cpp
+++ b/libs/images/libimages/images.cpp
@@ -327,6 +327,14 @@ int ImageWindow::getMouseY() {
     return cimg_display->display.mouse_y();
 }
 
+int ImageWindow::getWheel() {
+    return cimg_display->display.wheel();
+}
+
+bool ImageWindow::resetWheel() {
+    return cimg_display->display.set_wheel();
+}
+
 size_t ImageWindow::width() {
     return cimg_display->display.window_width();
 }

--- a/libs/images/libimages/images.h
+++ b/libs/images/libimages/images.h
@@ -52,6 +52,8 @@ namespace images {
         mouse_click_t getMouseClick();
         int getMouseX();
         int getMouseY();
+        int getWheel();
+        bool resetWheel();
 
         size_t width();
         size_t height();

--- a/libs/utils/libutils/misc.h
+++ b/libs/utils/libutils/misc.h
@@ -23,8 +23,8 @@ namespace ocl {
 	public:
 		Kernel() {}
 
-		Kernel(const char *source_code, size_t source_code_length, std::string kernel_name,
-			   std::string defines = std::string())
+		Kernel(const char *source_code, size_t source_code_length, std::string const& kernel_name,
+			   std::string defines = std::string()) : kernel_name_(kernel_name)
 		{
 			init(source_code, source_code_length, kernel_name, defines);
 		}
@@ -43,6 +43,10 @@ namespace ocl {
 			kernel_->precompile(printLog);
 		}
 
+		std::string getKernelName() const{
+			return kernel_name_;
+		}
+
 		typedef ocl::OpenCLKernel::Arg Arg;
 
 		void exec(const gpu::WorkSize &ws, const Arg &arg0 = Arg(), const Arg &arg1 = Arg(), const Arg &arg2 = Arg(), const Arg &arg3 = Arg(), const Arg &arg4 = Arg(), const Arg &arg5 = Arg(), const Arg &arg6 = Arg(), const Arg &arg7 = Arg(), const Arg &arg8 = Arg(), const Arg &arg9 = Arg(), const Arg &arg10 = Arg(), const Arg &arg11 = Arg(), const Arg &arg12 = Arg(), const Arg &arg13 = Arg(), const Arg &arg14 = Arg(), const Arg &arg15 = Arg(), const Arg &arg16 = Arg(), const Arg &arg17 = Arg(), const Arg &arg18 = Arg(), const Arg &arg19 = Arg(), const Arg &arg20 = Arg(), const Arg &arg21 = Arg(), const Arg &arg22 = Arg(), const Arg &arg23 = Arg(), const Arg &arg24 = Arg(), const Arg &arg25 = Arg(), const Arg &arg26 = Arg(), const Arg &arg27 = Arg(), const Arg &arg28 = Arg(), const Arg &arg29 = Arg(), const Arg &arg30 = Arg(), const Arg &arg31 = Arg(), const Arg &arg32 = Arg(), const Arg &arg33 = Arg(), const Arg &arg34 = Arg(), const Arg &arg35 = Arg(), const Arg &arg36 = Arg(), const Arg &arg37 = Arg(), const Arg &arg38 = Arg(), const Arg &arg39 = Arg(), const Arg &arg40 = Arg())
@@ -55,5 +59,6 @@ namespace ocl {
 	private:
 		std::shared_ptr<ocl::ProgramBinaries> program_;
 		std::shared_ptr<ocl::KernelSource> kernel_;
+		std::string kernel_name_;
 	};
 }

--- a/libs/utils/libutils/misc.h
+++ b/libs/utils/libutils/misc.h
@@ -23,8 +23,8 @@ namespace ocl {
 	public:
 		Kernel() {}
 
-		Kernel(const char *source_code, size_t source_code_length, std::string const& kernel_name,
-			   std::string defines = std::string()) : kernel_name_(kernel_name)
+		Kernel(const char *source_code, size_t source_code_length, std::string kernel_name,
+			   std::string defines = std::string())
 		{
 			init(source_code, source_code_length, kernel_name, defines);
 		}
@@ -43,10 +43,6 @@ namespace ocl {
 			kernel_->precompile(printLog);
 		}
 
-		std::string getKernelName() const{
-			return kernel_name_;
-		}
-
 		typedef ocl::OpenCLKernel::Arg Arg;
 
 		void exec(const gpu::WorkSize &ws, const Arg &arg0 = Arg(), const Arg &arg1 = Arg(), const Arg &arg2 = Arg(), const Arg &arg3 = Arg(), const Arg &arg4 = Arg(), const Arg &arg5 = Arg(), const Arg &arg6 = Arg(), const Arg &arg7 = Arg(), const Arg &arg8 = Arg(), const Arg &arg9 = Arg(), const Arg &arg10 = Arg(), const Arg &arg11 = Arg(), const Arg &arg12 = Arg(), const Arg &arg13 = Arg(), const Arg &arg14 = Arg(), const Arg &arg15 = Arg(), const Arg &arg16 = Arg(), const Arg &arg17 = Arg(), const Arg &arg18 = Arg(), const Arg &arg19 = Arg(), const Arg &arg20 = Arg(), const Arg &arg21 = Arg(), const Arg &arg22 = Arg(), const Arg &arg23 = Arg(), const Arg &arg24 = Arg(), const Arg &arg25 = Arg(), const Arg &arg26 = Arg(), const Arg &arg27 = Arg(), const Arg &arg28 = Arg(), const Arg &arg29 = Arg(), const Arg &arg30 = Arg(), const Arg &arg31 = Arg(), const Arg &arg32 = Arg(), const Arg &arg33 = Arg(), const Arg &arg34 = Arg(), const Arg &arg35 = Arg(), const Arg &arg36 = Arg(), const Arg &arg37 = Arg(), const Arg &arg38 = Arg(), const Arg &arg39 = Arg(), const Arg &arg40 = Arg())
@@ -59,6 +55,5 @@ namespace ocl {
 	private:
 		std::shared_ptr<ocl::ProgramBinaries> program_;
 		std::shared_ptr<ocl::KernelSource> kernel_;
-		std::string kernel_name_;
 	};
 }

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,13 +1,43 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(__global float *results, unsigned int width, unsigned int height, float fromX, float fromY,
+                         float sizeX, float sizeY, unsigned int iters, int smoothing) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    if (i >= width || j >= height) {
+        return;
+    }
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,85 @@
-// TODO
+
+__kernel void atomicAddSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    size_t gid = get_global_id(0);
+    atomic_add(sum, a[gid]);
+}
+
+
+#define SMALL_VALUES_PER_WORKITEM 4
+__kernel void smallLoopSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    size_t gid = get_global_id(0);
+    unsigned int res = 0;
+    for (int i = 0; i < SMALL_VALUES_PER_WORKITEM; i++) {
+        int idx = SMALL_VALUES_PER_WORKITEM * gid + i;
+        if (idx < n)
+            res += a[idx];
+    }
+
+    atomic_add(sum, res);
+}
+
+#define VALUES_PER_WORKITEM 32
+__kernel void loopSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    size_t gid = get_global_id(0);
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int idx = VALUES_PER_WORKITEM * gid + i;
+        if (idx < n)
+            res += a[idx];
+    }
+
+    atomic_add(sum, res);
+}
+
+__kernel void loopCoalesedSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    size_t lid = get_local_id(0);
+    size_t gr_id = get_group_id(0);
+    size_t grs = get_local_size(0);
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int idx = gr_id * grs * VALUES_PER_WORKITEM + grs * i + lid;
+        if (idx < n)
+            res += a[idx];
+    }
+
+    atomic_add(sum, res);
+}
+
+
+#define WORKGROUP_SIZE 64
+__kernel void localMemSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    __local unsigned int buffer[WORKGROUP_SIZE];
+    size_t lid = get_local_id(0);
+    size_t gid = get_global_id(0);
+    buffer[lid] = a[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int res = 0;
+        for (int i = 0; i < WORKGROUP_SIZE; i++) {
+            res += buffer[i];
+        }
+        atomic_add(sum, res);
+    }
+}
+
+__kernel void treeSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
+    __local unsigned int buffer[WORKGROUP_SIZE];
+    size_t lid = get_local_id(0);
+    size_t gid = get_global_id(0);
+
+    buffer[lid] = a[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (lid < nValues / 2) {
+            buffer[lid] += buffer[lid + nValues / 2];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        atomic_add(sum, buffer[0]);
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -33,8 +33,9 @@ __kernel void loopCoalesedSum(__global const unsigned int *a, __global unsigned 
     atomic_add(sum, res);
 }
 
-
-#define WORKGROUP_SIZE 64
+#ifndef WORKGROUP_SIZE
+    #define WORKGROUP_SIZE 64
+#endif
 __kernel void localMemSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
     __local unsigned int buffer[WORKGROUP_SIZE];
     size_t lid = get_local_id(0);

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -4,21 +4,9 @@ __kernel void atomicAddSum(__global const unsigned int *a, __global unsigned int
     atomic_add(sum, a[gid]);
 }
 
-
-#define SMALL_VALUES_PER_WORKITEM 4
-__kernel void smallLoopSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
-    size_t gid = get_global_id(0);
-    unsigned int res = 0;
-    for (int i = 0; i < SMALL_VALUES_PER_WORKITEM; i++) {
-        int idx = SMALL_VALUES_PER_WORKITEM * gid + i;
-        if (idx < n)
-            res += a[idx];
-    }
-
-    atomic_add(sum, res);
-}
-
-#define VALUES_PER_WORKITEM 32
+#ifndef VALUES_PER_WORKITEM
+    #define VALUES_PER_WORKITEM 32
+#endif
 __kernel void loopSum(__global const unsigned int *a, __global unsigned int *sum, unsigned int n) {
     size_t gid = get_global_id(0);
     unsigned int res = 0;

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,24 +1,20 @@
 #include <cmath>
 
-#include <libutils/misc.h>
-#include <libutils/timer.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
 #include <libimages/images.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+void mandelbrotCPU(float *results, unsigned int width, unsigned int height, float fromX, float fromY, float sizeX,
+                   float sizeY, unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -47,13 +43,29 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+double getRealIterationFraction(uint height, uint width, const float *results) {
+    double realIterationsFraction = 0.0;
+    for (int j = 0; j < height; ++j) {
+        for (int i = 0; i < width; ++i) {
+            realIterationsFraction += results[j * width + i];
+        }
+    }
+    return 100.0 * realIterationsFraction / (width * height);
+}
+
+double getGFlops(uint height, uint width, uint flopsInLoop, uint loops, double lapAvgTime) {
+    size_t gflops = 1000 * 1000 * 1000;
+    size_t maxApproximateFlops = width * height * loops * flopsInLoop;
+    return maxApproximateFlops / gflops / lapAvgTime;
+}
+
+
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     unsigned int benchmarkingIters = 10;
@@ -66,10 +78,10 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    //    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    //    float centralX = -0.5f;
+    //    float centralY = 0.0f;
+    //    float sizeX = 2.0f;
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -80,78 +92,82 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int i = 0; i < benchmarkingIters; ++i) {
-            mandelbrotCPU(cpu_results.ptr(),
-                          width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, false);
+            mandelbrotCPU(cpu_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX,
+                          sizeY, iterationsLimit, false);
             t.nextLap();
         }
         size_t flopsInLoop = 10;
-        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
-
-        double realIterationsFraction = 0.0;
-        for (int j = 0; j < height; ++j) {
-            for (int i = 0; i < width; ++i) {
-                realIterationsFraction += cpu_results.ptr()[j * width + i];
-            }
-        }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "CPU: " << getGFlops(height, width, flopsInLoop, iterationsLimit, t.lapAvg()) << " GFlops"
+                  << std::endl;
+        std::cout << "    Real iterations fraction: " << getRealIterationFraction(height, width, cpu_results.ptr())
+                  << "%" << std::endl;
 
         renderToColor(cpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
     }
 
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+        gpu::gpu_mem_32f res_gpu;
+        res_gpu.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), res_gpu, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << getGFlops(height, width, flopsInLoop, iterationsLimit, t.lapAvg()) << " GFlops"
+                  << std::endl;
+        std::cout << "    Real iterations fraction: " << getRealIterationFraction(height, width, cpu_results.ptr())
+                  << "%" << std::endl;
+
+        res_gpu.readN(gpu_results.ptr(), width * height);
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -159,8 +175,6 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
     float sizeX = 2.0f;
     float sizeY = sizeX * height / width;
-
-    float zoomingSpeed = 1.005f;
 
     images::Image<float> results(width, height, 1);
     images::Image<unsigned char> image(width, height, 3);
@@ -174,27 +188,36 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
     do {
         if (!useGPU) {
-            mandelbrotCPU(results.ptr(), width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
+            mandelbrotCPU(results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY,
                           iterationsLimit, true);
         } else {
-            kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
+            kernel.exec(gpu::WorkSize(16, 16, width, height), results_vram, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);
 
         window.display(image);
-        window.wait(30);
-
+        static bool isClicked = false;
         if (window.getMouseClick() == MOUSE_LEFT) {
-            centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
-            centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            if (!isClicked) {
+                isClicked = true;
+                centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
+                centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
+                std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
+            }
+        } else {
+            isClicked = false;
+        }
+        {
+            int counter = window.getWheel();
+            if (counter != 0) {
+                double speed = 10.;
+                double coef = speed / (speed - counter);
+                sizeX /= coef;
+                sizeY /= coef;
+                window.resetWheel();
+            }
         }
         if (window.isResized()) {
             window.resize();
@@ -211,16 +234,18 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
                 results_vram.resizeN(width * height);
             }
         }
-        sizeX /= zoomingSpeed;
-        sizeY /= zoomingSpeed;
+
     } while (!window.isClosed());
 }
 
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z) : x(x), y(y), z(z) {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +272,8 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +282,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,14 @@
+#include "cl/sum_cl.h"
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
+#include <cassert>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,12 +18,31 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+void execKernel(ocl::Kernel &kernel, gpu::gpu_mem_32u const &aGpu, gpu::gpu_mem_32u &resGPU, uint workGroupSize,
+                uint globalWorkSize, uint n, uint expectedSum, uint benchmarkingIters) {
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        uint actualSum = 0;
+        resGPU.writeN(&actualSum, 1);
+        kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), aGpu, resGPU, n);
+        resGPU.readN(&actualSum, 1);
+        EXPECT_THE_SAME(expectedSum, actualSum, "GPU (" + kernel.getKernelName() + ") result should be consistent!");
+        t.nextLap();
+    }
+
+    std::cout << "GPU (" << kernel.getKernelName() << "):     " << t.lapAvg() << "+-" << t.lapStd() << " s"
+              << std::endl;
+    std::cout << "GPU (" << kernel.getKernelName() << "):     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
+              << std::endl;
+}
+
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,14 +61,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +76,60 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u aGpu;
+        gpu::gpu_mem_32u resGPU;
+        unsigned int workGroupSize = 64;
+        unsigned int globalWorkSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        aGpu.resizeN(globalWorkSize);
+        as.resize(globalWorkSize);
+        resGPU.resizeN(1);
+        aGpu.writeN(as.data(), n);
+        {
+            ocl::Kernel atomicAddSum(sum_kernel, sum_kernel_length, "atomicAddSum");
+            execKernel(atomicAddSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
+                       benchmarkingIters);
+        }
+
+        uint valuesPerItem = 32;
+        {
+            assert(globalWorkSize % valuesPerItem == 0);
+            ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "loopSum");
+            execKernel(loopSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(), reference_sum,
+                       benchmarkingIters);
+        }
+        {
+            ocl::Kernel loopCoalesedSum(sum_kernel, sum_kernel_length, "loopCoalesedSum");
+            execKernel(loopCoalesedSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(),
+                       reference_sum, benchmarkingIters);
+        }
+
+        {
+            uint smallValuesPerItem = 4;
+            assert(globalWorkSize % smallValuesPerItem == 0);
+            ocl::Kernel smallLoopSum(sum_kernel, sum_kernel_length, "smallLoopSum");
+            execKernel(smallLoopSum, aGpu, resGPU, workGroupSize, globalWorkSize / smallValuesPerItem, as.size(),
+                       reference_sum, benchmarkingIters);
+        }
+
+        {
+            ocl::Kernel localMemSum(sum_kernel, sum_kernel_length, "localMemSum");
+            execKernel(localMemSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
+                       benchmarkingIters);
+        }
+
+                {
+            ocl::Kernel treeSum(sum_kernel, sum_kernel_length, "treeSum");
+            execKernel(treeSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
+                       benchmarkingIters);
+        }
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -6,6 +6,16 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 
+std::string to_string() {
+    return "";
+}
+
+template<typename T, typename... TAIL>
+std::string to_string(const T &t, TAIL... tail) {
+    std::stringstream ss;
+    ss << t << to_string(tail...);
+    return ss.str();
+}
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
@@ -18,22 +28,20 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-void execKernel(ocl::Kernel &kernel, gpu::gpu_mem_32u const &aGpu, gpu::gpu_mem_32u &resGPU, uint workGroupSize,
-                uint globalWorkSize, uint n, uint expectedSum, uint benchmarkingIters) {
+void execKernel(ocl::Kernel &kernel, gpu::gpu_mem_32u const &aGpu, gpu::gpu_mem_32u &resGPU, uint workGroupSize, uint globalWorkSize, uint n, uint expectedSum,
+                uint benchmarkingIters, std::string kernelName) {
     timer t;
     for (int iter = 0; iter < benchmarkingIters; ++iter) {
         uint actualSum = 0;
         resGPU.writeN(&actualSum, 1);
         kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), aGpu, resGPU, n);
         resGPU.readN(&actualSum, 1);
-        EXPECT_THE_SAME(expectedSum, actualSum, "GPU (" + kernel.getKernelName() + ") result should be consistent!");
+        EXPECT_THE_SAME(expectedSum, actualSum, "GPU (" + kernelName + ") result should be consistent!");
         t.nextLap();
     }
 
-    std::cout << "GPU (" << kernel.getKernelName() << "):     " << t.lapAvg() << "+-" << t.lapStd() << " s"
-              << std::endl;
-    std::cout << "GPU (" << kernel.getKernelName() << "):     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s"
-              << std::endl;
+    std::cout << "GPU (" << kernelName << "):     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU (" << kernelName << "):     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 }
 
 int main(int argc, char **argv) {
@@ -95,41 +103,51 @@ int main(int argc, char **argv) {
         aGpu.writeN(as.data(), n);
         {
             ocl::Kernel atomicAddSum(sum_kernel, sum_kernel_length, "atomicAddSum");
-            execKernel(atomicAddSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
-                       benchmarkingIters);
+            execKernel(atomicAddSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum, benchmarkingIters, "atomicAddSum");
         }
 
-        uint valuesPerItem = 32;
+        uint valuesPerItem = 64;
         {
             assert(globalWorkSize % valuesPerItem == 0);
-            ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "loopSum");
-            execKernel(loopSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(), reference_sum,
-                       benchmarkingIters);
+            ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "loopSum", to_string("-DVALUES_PER_WORKITEM=", valuesPerItem));
+            execKernel(loopSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(), reference_sum, benchmarkingIters,
+                       to_string("loopSum (", valuesPerItem, ")"));
         }
         {
-            ocl::Kernel loopCoalesedSum(sum_kernel, sum_kernel_length, "loopCoalesedSum");
-            execKernel(loopCoalesedSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(),
-                       reference_sum, benchmarkingIters);
+            ocl::Kernel loopCoalesedSum(sum_kernel, sum_kernel_length, "loopCoalesedSum", to_string("-DVALUES_PER_WORKITEM=", valuesPerItem));
+            execKernel(loopCoalesedSum, aGpu, resGPU, workGroupSize, globalWorkSize / valuesPerItem, as.size(), reference_sum, benchmarkingIters,
+                       "loopCoalesedSum (" + std::to_string(valuesPerItem) + ")");
         }
 
-        {
-            uint smallValuesPerItem = 4;
-            assert(globalWorkSize % smallValuesPerItem == 0);
-            ocl::Kernel smallLoopSum(sum_kernel, sum_kernel_length, "smallLoopSum");
-            execKernel(smallLoopSum, aGpu, resGPU, workGroupSize, globalWorkSize / smallValuesPerItem, as.size(),
-                       reference_sum, benchmarkingIters);
-        }
 
         {
             ocl::Kernel localMemSum(sum_kernel, sum_kernel_length, "localMemSum");
-            execKernel(localMemSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
-                       benchmarkingIters);
+            execKernel(localMemSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum, benchmarkingIters, "localMemSum");
         }
 
-                {
+        {
             ocl::Kernel treeSum(sum_kernel, sum_kernel_length, "treeSum");
-            execKernel(treeSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum,
-                       benchmarkingIters);
+            execKernel(treeSum, aGpu, resGPU, workGroupSize, globalWorkSize, as.size(), reference_sum, benchmarkingIters, "treeSum");
+        }
+
+        {
+            std::cout << "diff loop sizes:" << std::endl;
+            for (int valuesPerItem : std::vector<int>{1, 2, 4, 6, 8, 12, 16, 32, 128, 512}) {
+                int workSize = (globalWorkSize + valuesPerItem - 1) / valuesPerItem;
+                ocl::Kernel loopSum(sum_kernel, sum_kernel_length, "loopSum", to_string("-DVALUES_PER_WORKITEM=", valuesPerItem));
+                execKernel(loopSum, aGpu, resGPU, workGroupSize, workSize, as.size(), reference_sum, benchmarkingIters,
+                           "loopSum (" + std::to_string(valuesPerItem) + ")");
+            }
+        }
+
+        {
+            std::cout << "diff loop coalesed sizes:" << std::endl;
+            for (int valuesPerItem : std::vector<int>{1, 2, 4, 6, 8, 12, 16, 32, 128, 512}) {
+                int workSize = (globalWorkSize + valuesPerItem - 1) / valuesPerItem;
+                ocl::Kernel loopCoalesedSum(sum_kernel, sum_kernel_length, "loopCoalesedSum", to_string("-DVALUES_PER_WORKITEM=", valuesPerItem));
+                execKernel(loopCoalesedSum, aGpu, resGPU, workGroupSize, workSize, as.size(), reference_sum, benchmarkingIters,
+                           "loopCoalesedSum (" + std::to_string(valuesPerItem) + ")");
+            }
         }
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -39,7 +39,7 @@ void execKernel(ocl::Kernel &kernel, gpu::gpu_mem_32u const &aGpu, gpu::gpu_mem_
 int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-    int benchmarkingIters = 10;
+    int benchmarkingIters = 40;
 
     unsigned int reference_sum = 0;
     unsigned int n = 100 * 1000 * 1000;


### PR DESCRIPTION
### Фрактал Мандельброта

<details>
  <summary>Локальный вывод</summary>

```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15362 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: GPU. AMD Radeon Graphics (gfx90c:xnack+). Free memory: 134201970/512 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
CPU: 0.423918+-0.000607096 s
CPU: 4.7179 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.00517717+-1.06719e-06 s
GPU: 386.312 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%
```
</details>

<details>
<summary> Вывод CI </summary>

```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.7954+-0.0149986 s
CPU: 1.11396 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.126269+-0.00168752 s
GPU: 15.8393 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%
```
</details>

### Суммирование чисел
<details>
<summary>Локальный вывод (NVIDIA)</summary>

```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15362 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: GPU. AMD Radeon Graphics (gfx90c:xnack+). Free memory: 134213694/512 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
CPU:     0.230451+-0.0066658 s
CPU:     433.931 millions/s
CPU OMP: 0.0405627+-0.00259521 s
CPU OMP: 2465.32 millions/s
GPU (atomicAddSum):     0.0052625+-2.56011e-05 s
GPU (atomicAddSum):     19002.4 millions/s
GPU (loopSum (64)):     0.00831058+-0.000541062 s
GPU (loopSum (64)):     12032.8 millions/s
GPU (loopCoalesedSum (64)):     0.00217958+-4.93007e-07 s
GPU (loopCoalesedSum (64)):     45880.3 millions/s
GPU (localMemSum):     0.00471167+-3.72678e-06 s
GPU (localMemSum):     21223.9 millions/s
GPU (treeSum):     0.008468+-2.41178e-05 s
GPU (treeSum):     11809.2 millions/s
diff loop sizes:
GPU (loopSum (1)):     0.00431567+-5.80708e-06 s
GPU (loopSum (1)):     23171.4 millions/s
GPU (loopSum (2)):     0.00240317+-2.37463e-06 s
GPU (loopSum (2)):     41611.8 millions/s
GPU (loopSum (4)):     0.0021495+-2.25462e-06 s
GPU (loopSum (4)):     46522.4 millions/s
GPU (loopSum (6)):     0.00215042+-2.01901e-06 s
GPU (loopSum (6)):     46502.6 millions/s
GPU (loopSum (8)):     0.00232158+-2.21579e-06 s
GPU (loopSum (8)):     43074.1 millions/s
GPU (loopSum (12)):     0.00215317+-1.62447e-06 s
GPU (loopSum (12)):     46443.2 millions/s
GPU (loopSum (16)):     0.00422875+-1.20355e-05 s
GPU (loopSum (16)):     23647.7 millions/s
GPU (loopSum (32)):     0.00816692+-2.17043e-05 s
GPU (loopSum (32)):     12244.5 millions/s
GPU (loopSum (128)):     0.00826442+-3.78208e-05 s
GPU (loopSum (128)):     12100.1 millions/s
GPU (loopSum (512)):     0.0101005+-0.000901686 s
GPU (loopSum (512)):     9900.5 millions/s
GPU (loopSum (1024)):     0.00930983+-0.000140558 s
GPU (loopSum (1024)):     10741.3 millions/s
GPU (loopSum (4096)):     0.0104076+-0.0011489 s
GPU (loopSum (4096)):     9608.38 millions/s
GPU (loopSum (8192)):     0.0163364+-1.56549e-05 s
GPU (loopSum (8192)):     6121.29 millions/s
diff loop coalesed sizes:
GPU (loopCoalesedSum (1)):     0.0043515+-8.4113e-06 s
GPU (loopCoalesedSum (1)):     22980.6 millions/s
GPU (loopCoalesedSum (2)):     0.0023125+-7.08872e-06 s
GPU (loopCoalesedSum (2)):     43243.2 millions/s
GPU (loopCoalesedSum (4)):     0.00215108+-2.09993e-06 s
GPU (loopCoalesedSum (4)):     46488.2 millions/s
GPU (loopCoalesedSum (6)):     0.00216683+-5.85709e-06 s
GPU (loopCoalesedSum (6)):     46150.3 millions/s
GPU (loopCoalesedSum (8)):     0.00216492+-7.22794e-06 s
GPU (loopCoalesedSum (8)):     46191.2 millions/s
GPU (loopCoalesedSum (12)):     0.00216108+-4.55445e-06 s
GPU (loopCoalesedSum (12)):     46273.1 millions/s
GPU (loopCoalesedSum (16)):     0.00218483+-9.92332e-06 s
GPU (loopCoalesedSum (16)):     45770.1 millions/s
GPU (loopCoalesedSum (32)):     0.00220367+-1.61056e-05 s
GPU (loopCoalesedSum (32)):     45378.9 millions/s
GPU (loopCoalesedSum (128)):     0.00218342+-9.49086e-06 s
GPU (loopCoalesedSum (128)):     45799.8 millions/s
GPU (loopCoalesedSum (512)):     0.00219458+-4.03027e-06 s
GPU (loopCoalesedSum (512)):     45566.7 millions/s
GPU (loopCoalesedSum (1024)):     0.00217567+-9.05845e-06 s
GPU (loopCoalesedSum (1024)):     45962.9 millions/s
GPU (loopCoalesedSum (4096)):     0.00218083+-8.44426e-06 s
GPU (loopCoalesedSum (4096)):     45854 millions/s
GPU (loopCoalesedSum (8192)):     0.00217692+-3.96775e-06 s
GPU (loopCoalesedSum (8192)):     45936.5 millions/s
diff localMem sizes:
GPU (localMemSum (1)):     0.302537+-6.22754e-05 s
GPU (localMemSum (1)):     330.538 millions/s
GPU (localMemSum (2)):     0.156278+-6.23997e-05 s
GPU (localMemSum (2)):     639.887 millions/s
GPU (localMemSum (4)):     0.0772012+-6.87642e-05 s
GPU (localMemSum (4)):     1295.32 millions/s
GPU (localMemSum (6)):     0.0513706+-3.28468e-05 s
GPU (localMemSum (6)):     1946.64 millions/s
GPU (localMemSum (8)):     0.0391593+-2.32212e-05 s
GPU (localMemSum (8)):     2553.67 millions/s
GPU (localMemSum (12)):     0.026097+-2.13542e-05 s
GPU (localMemSum (12)):     3831.86 millions/s
GPU (localMemSum (16)):     0.0209467+-4.93499e-06 s
GPU (localMemSum (16)):     4774.01 millions/s
GPU (localMemSum (32)):     0.0107355+-9.51753e-06 s
GPU (localMemSum (32)):     9314.89 millions/s
GPU (localMemSum (64)):     0.00472742+-9.00424e-06 s
GPU (localMemSum (64)):     21153.2 millions/s
GPU (localMemSum (128)):     0.00479633+-9.80929e-06 s
GPU (localMemSum (128)):     20849.3 millions/s
GPU (localMemSum (192)):     0.00568075+-8.96405e-06 s
GPU (localMemSum (192)):     17603.3 millions/s
GPU (localMemSum (256)):     0.00933367+-1.45105e-05 s
GPU (localMemSum (256)):     10713.9 millions/s
diff tree sizes:
GPU (treeSum (1)):     0.302495+-0.000103931 s
GPU (treeSum (1)):     330.584 millions/s
GPU (treeSum (2)):     0.154801+-6.65338e-05 s
GPU (treeSum (2)):     645.99 millions/s
GPU (treeSum (4)):     0.0756359+-5.82158e-05 s
GPU (treeSum (4)):     1322.12 millions/s
GPU (treeSum (8)):     0.0445275+-2.42573e-05 s
GPU (treeSum (8)):     2245.8 millions/s
GPU (treeSum (16)):     0.0274913+-2.32247e-05 s
GPU (treeSum (16)):     3637.51 millions/s
GPU (treeSum (32)):     0.0142707+-1.53152e-05 s
GPU (treeSum (32)):     7007.38 millions/s
GPU (treeSum (64)):     0.00849992+-9.6907e-06 s
GPU (treeSum (64)):     11764.8 millions/s
GPU (treeSum (128)):     0.00804983+-1.64308e-05 s
GPU (treeSum (128)):     12422.6 millions/s
GPU (treeSum (256)):     0.00848033+-1.47158e-05 s
GPU (treeSum (256)):     11792 millions/s
```
</details>


<details>
<summary>Локальный вывод (CPU)</summary>

```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15362 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: GPU. AMD Radeon Graphics (gfx90c:xnack+). Free memory: 134217002/512 Mb
Using device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15362 Mb
CPU:     0.235937+-0.009767 s
CPU:     423.842 millions/s
CPU OMP: 0.0329797+-0.000389205 s
CPU OMP: 3032.17 millions/s
GPU (atomicAddSum):     0.852541+-0.000503372 s
GPU (atomicAddSum):     117.296 millions/s
GPU (loopSum (64)):     0.0164741+-1.40917e-05 s
GPU (loopSum (64)):     6070.14 millions/s
GPU (loopCoalesedSum (64)):     0.0172071+-0.000296491 s
GPU (loopCoalesedSum (64)):     5811.56 millions/s
GPU (localMemSum):     0.0206617+-0.000132124 s
GPU (localMemSum):     4839.86 millions/s
GPU (treeSum):     0.0408952+-5.94546e-05 s
GPU (treeSum):     2445.27 millions/s
diff loop sizes:
GPU (loopSum (1)):     0.848821+-0.000601252 s
GPU (loopSum (1)):     117.81 millions/s
GPU (loopSum (2)):     0.417666+-0.000224682 s
GPU (loopSum (2)):     239.426 millions/s
GPU (loopSum (4)):     0.209859+-0.00102884 s
GPU (loopSum (4)):     476.511 millions/s
GPU (loopSum (6)):     0.150618+-0.000883176 s
GPU (loopSum (6)):     663.931 millions/s
GPU (loopSum (8)):     0.106022+-0.000382609 s
GPU (loopSum (8)):     943.204 millions/s
GPU (loopSum (12)):     0.0770442+-0.000594107 s
GPU (loopSum (12)):     1297.96 millions/s
GPU (loopSum (16)):     0.0611019+-3.24229e-05 s
GPU (loopSum (16)):     1636.61 millions/s
GPU (loopSum (32)):     0.0320193+-9.85142e-05 s
GPU (loopSum (32)):     3123.11 millions/s
GPU (loopSum (128)):     0.0118082+-2.31089e-05 s
GPU (loopSum (128)):     8468.66 millions/s
GPU (loopSum (512)):     0.00958942+-2.4064e-05 s
GPU (loopSum (512)):     10428.2 millions/s
GPU (loopSum (1024)):     0.0102605+-0.000118591 s
GPU (loopSum (1024)):     9746.11 millions/s
GPU (loopSum (4096)):     0.0114139+-3.15501e-05 s
GPU (loopSum (4096)):     8761.23 millions/s
GPU (loopSum (8192)):     0.0115843+-7.64061e-05 s
GPU (loopSum (8192)):     8632.35 millions/s
diff loop coalesed sizes:
GPU (loopCoalesedSum (1)):     0.842208+-0.000661956 s
GPU (loopCoalesedSum (1)):     118.736 millions/s
GPU (loopCoalesedSum (2)):     0.419859+-0.000884289 s
GPU (loopCoalesedSum (2)):     238.175 millions/s
GPU (loopCoalesedSum (4)):     0.217685+-0.000546168 s
GPU (loopCoalesedSum (4)):     459.38 millions/s
GPU (loopCoalesedSum (6)):     0.146644+-0.000634749 s
GPU (loopCoalesedSum (6)):     681.924 millions/s
GPU (loopCoalesedSum (8)):     0.1131+-0.000499684 s
GPU (loopCoalesedSum (8)):     884.173 millions/s
GPU (loopCoalesedSum (12)):     0.0794203+-0.000476949 s
GPU (loopCoalesedSum (12)):     1259.12 millions/s
GPU (loopCoalesedSum (16)):     0.0604584+-0.000741397 s
GPU (loopCoalesedSum (16)):     1654.03 millions/s
GPU (loopCoalesedSum (32)):     0.0327349+-0.000674313 s
GPU (loopCoalesedSum (32)):     3054.84 millions/s
GPU (loopCoalesedSum (128)):     0.0106391+-0.000108233 s
GPU (loopCoalesedSum (128)):     9399.31 millions/s
GPU (loopCoalesedSum (512)):     0.0101848+-6.11948e-05 s
GPU (loopCoalesedSum (512)):     9818.52 millions/s
GPU (loopCoalesedSum (1024)):     0.0110756+-1.53648e-05 s
GPU (loopCoalesedSum (1024)):     9028.87 millions/s
GPU (loopCoalesedSum (4096)):     0.0142886+-0.000119453 s
GPU (loopCoalesedSum (4096)):     6998.59 millions/s
GPU (loopCoalesedSum (8192)):     0.0176892+-0.000137698 s
GPU (loopCoalesedSum (8192)):     5653.18 millions/s
diff localMem sizes:
GPU (localMemSum (1)):     0.972245+-0.000801346 s
GPU (localMemSum (1)):     102.855 millions/s
GPU (localMemSum (2)):     0.501973+-0.00071253 s
GPU (localMemSum (2)):     199.214 millions/s
GPU (localMemSum (4)):     0.244124+-0.000728036 s
GPU (localMemSum (4)):     409.628 millions/s
GPU (localMemSum (6)):     0.163198+-0.000741728 s
GPU (localMemSum (6)):     612.754 millions/s
GPU (localMemSum (8)):     0.12267+-0.000184373 s
GPU (localMemSum (8)):     815.192 millions/s
GPU (localMemSum (12)):     0.0966556+-0.00052915 s
GPU (localMemSum (12)):     1034.6 millions/s
GPU (localMemSum (16)):     0.0621126+-3.32778e-05 s
GPU (localMemSum (16)):     1609.98 millions/s
GPU (localMemSum (32)):     0.0316979+-1.99351e-05 s
GPU (localMemSum (32)):     3154.78 millions/s
GPU (localMemSum (64)):     0.0206713+-0.000137355 s
GPU (localMemSum (64)):     4837.64 millions/s
GPU (localMemSum (128)):     0.0148575+-0.000571411 s
GPU (localMemSum (128)):     6730.61 millions/s
GPU (localMemSum (192)):     0.0125841+-0.000226884 s
GPU (localMemSum (192)):     7946.55 millions/s
GPU (localMemSum (256)):     0.0116131+-2.2754e-05 s
GPU (localMemSum (256)):     8610.98 millions/s
diff tree sizes:
GPU (treeSum (1)):     0.971074+-0.00096969 s
GPU (treeSum (1)):     102.979 millions/s
GPU (treeSum (2)):     0.52628+-0.000909549 s
GPU (treeSum (2)):     190.013 millions/s
GPU (treeSum (4)):     0.321877+-0.00185152 s
GPU (treeSum (4)):     310.678 millions/s
GPU (treeSum (8)):     0.164066+-0.00205942 s
GPU (treeSum (8)):     609.512 millions/s
GPU (treeSum (16)):     0.0828026+-0.000750543 s
GPU (treeSum (16)):     1207.69 millions/s
GPU (treeSum (32)):     0.0521449+-0.000855118 s
GPU (treeSum (32)):     1917.73 millions/s
GPU (treeSum (64)):     0.0409273+-3.98128e-05 s
GPU (treeSum (64)):     2443.35 millions/s
GPU (treeSum (128)):     0.0393924+-0.000126175 s
GPU (treeSum (128)):     2538.56 millions/s
GPU (treeSum (256)):     0.0429696+-0.000142348 s
GPU (treeSum (256)):     2327.23 millions/s
```
</details>

<details>
<summary>Вывод CI</summary>

```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU:     0.0698795+-0.00122904 s
CPU:     1431.03 millions/s
CPU OMP: 0.0313767+-0.000202189 s
CPU OMP: 3187.08 millions/s
GPU (atomicAddSum):     1.81766+-0.0192716 s
GPU (atomicAddSum):     55.0158 millions/s
GPU (loopSum (64)):     0.0911517+-0.00140277 s
GPU (loopSum (64)):     1097.07 millions/s
GPU (loopCoalesedSum (64)):     0.0397152+-0.000372241 s
GPU (loopCoalesedSum (64)):     2517.93 millions/s
GPU (localMemSum):     0.0853808+-0.000465022 s
GPU (localMemSum):     1171.22 millions/s
GPU (treeSum):     0.127382+-0.00131521 s
GPU (treeSum):     785.043 millions/s
diff loop sizes:
GPU (loopSum (1)):     1.84673+-0.0390278 s
GPU (loopSum (1)):     54.1498 millions/s
GPU (loopSum (2)):     0.9599+-0.00446706 s
GPU (loopSum (2)):     104.178 millions/s
GPU (loopSum (4)):     0.392299+-0.00541093 s
GPU (loopSum (4)):     254.907 millions/s
GPU (loopSum (6)):     0.296302+-0.00455192 s
GPU (loopSum (6)):     337.494 millions/s
GPU (loopSum (8)):     0.295546+-0.00328989 s
GPU (loopSum (8)):     338.356 millions/s
GPU (loopSum (12)):     0.163906+-0.00145897 s
GPU (loopSum (12)):     610.107 millions/s
GPU (loopSum (16)):     0.181779+-0.00369002 s
GPU (loopSum (16)):     550.119 millions/s
GPU (loopSum (32)):     0.117973+-0.00243536 s
GPU (loopSum (32)):     847.649 millions/s
GPU (loopSum (128)):     0.0565808+-0.000898049 s
GPU (loopSum (128)):     1767.39 millions/s
GPU (loopSum (512)):     0.0456725+-0.000985484 s
GPU (loopSum (512)):     2189.5 millions/s
GPU (loopSum (1024)):     0.0410594+-0.0008634 s
GPU (loopSum (1024)):     2435.49 millions/s
GPU (loopSum (4096)):     0.0430733+-0.000888083 s
GPU (loopSum (4096)):     2321.63 millions/s
GPU (loopSum (8192)):     0.0440673+-0.00049255 s
GPU (loopSum (8192)):     2269.26 millions/s
diff loop coalesed sizes:
GPU (loopCoalesedSum (1)):     1.79701+-0.0141544 s
GPU (loopCoalesedSum (1)):     55.6481 millions/s
GPU (loopCoalesedSum (2)):     0.901017+-0.00690293 s
GPU (loopCoalesedSum (2)):     110.986 millions/s
GPU (loopCoalesedSum (4)):     0.472296+-0.00847892 s
GPU (loopCoalesedSum (4)):     211.731 millions/s
GPU (loopCoalesedSum (6)):     0.308726+-0.00349194 s
GPU (loopCoalesedSum (6)):     323.912 millions/s
GPU (loopCoalesedSum (8)):     0.227935+-0.00125975 s
GPU (loopCoalesedSum (8)):     438.721 millions/s
GPU (loopCoalesedSum (12)):     0.147003+-0.00112114 s
GPU (loopCoalesedSum (12)):     680.261 millions/s
GPU (loopCoalesedSum (16)):     0.117571+-0.000360942 s
GPU (loopCoalesedSum (16)):     850.553 millions/s
GPU (loopCoalesedSum (32)):     0.0679581+-0.000443195 s
GPU (loopCoalesedSum (32)):     1471.5 millions/s
GPU (loopCoalesedSum (128)):     0.0327508+-0.000132688 s
GPU (loopCoalesedSum (128)):     3053.36 millions/s
GPU (loopCoalesedSum (512)):     0.0305252+-0.000172302 s
GPU (loopCoalesedSum (512)):     3275.99 millions/s
GPU (loopCoalesedSum (1024)):     0.0308494+-0.0002616 s
GPU (loopCoalesedSum (1024)):     3241.55 millions/s
GPU (loopCoalesedSum (4096)):     0.0313151+-0.000227058 s
GPU (loopCoalesedSum (4096)):     3193.35 millions/s
GPU (loopCoalesedSum (8192)):     0.0349084+-0.00115608 s
GPU (loopCoalesedSum (8192)):     2864.64 millions/s
diff localMem sizes:
GPU (localMemSum (1)):     3.98771+-0.0614161 s
GPU (localMemSum (1)):     25.077 millions/s
GPU (localMemSum (2)):     2.0693+-0.020465 s
GPU (localMemSum (2)):     48.3255 millions/s
GPU (localMemSum (4)):     1.1246+-0.0194449 s
GPU (localMemSum (4)):     88.9203 millions/s
GPU (localMemSum (6)):     0.826229+-0.00786686 s
GPU (localMemSum (6)):     121.032 millions/s
GPU (localMemSum (8)):     0.644365+-0.000908066 s
GPU (localMemSum (8)):     155.192 millions/s
GPU (localMemSum (12)):     0.438157+-0.000794637 s
GPU (localMemSum (12)):     228.229 millions/s
GPU (localMemSum (16)):     0.327789+-0.000815285 s
GPU (localMemSum (16)):     305.074 millions/s
GPU (localMemSum (32)):     0.167988+-0.000363321 s
GPU (localMemSum (32)):     595.281 millions/s
GPU (localMemSum (64)):     0.0858089+-0.000232545 s
GPU (localMemSum (64)):     1165.38 millions/s
GPU (localMemSum (128)):     0.0628743+-0.000305485 s
GPU (localMemSum (128)):     1590.47 millions/s
GPU (localMemSum (192)):     0.0553884+-0.000253368 s
GPU (localMemSum (192)):     1805.43 millions/s
GPU (localMemSum (256)):     0.0507556+-0.000940102 s
GPU (localMemSum (256)):     1970.23 millions/s
diff tree sizes:
GPU (treeSum (1)):     4.03851+-0.0235339 s
GPU (treeSum (1)):     24.7616 millions/s
GPU (treeSum (2)):     2.29376+-0.0181053 s
GPU (treeSum (2)):     43.5965 millions/s
GPU (treeSum (4)):     1.31021+-0.00322195 s
GPU (treeSum (4)):     76.3236 millions/s
GPU (treeSum (8)):     0.802579+-0.00623905 s
GPU (treeSum (8)):     124.598 millions/s
GPU (treeSum (16)):     0.330428+-0.000676045 s
GPU (treeSum (16)):     302.638 millions/s
GPU (treeSum (32)):     0.182893+-0.00112147 s
GPU (treeSum (32)):     546.768 millions/s
GPU (treeSum (64)):     0.129117+-0.00104192 s
GPU (treeSum (64)):     774.492 millions/s
GPU (treeSum (128)):     0.111645+-0.000802772 s
GPU (treeSum (128)):     895.7 millions/s
GPU (treeSum (256)):     0.112396+-0.0011247 s
GPU (treeSum (256)):     889.711 millions/s

```
</details>

Как можно заметить по выводу, я сделал сравнение методов с различными параметрами, т.к. все методы, кроме первого, имеют какой то параметр. Для удобного анализа, я построил графики:

<details><summary>Суммирование с циклом</summary>
<p>

![loopSum](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/48640725/d176d6fe-75d9-41d7-a144-ca92f846e834)


</p>
</details> 


<details><summary>Суммирование с циклом и coalesced доступом</summary>
<p>

![loopCoalesedSum](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/48640725/d61431b1-276b-4997-bf97-594a5274255a)


</p>
</details> 

<details><summary>Суммирование с локальной памятью и главным потоком</summary>
<p>

![localMemSum](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/48640725/ac2c9322-d5b5-42d0-9b06-3cf2973afc37)


</p>
</details> 

<details><summary>Суммирование с деревом</summary>
<p>

![treeSum](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/48640725/41c43a58-1dde-465e-b0b2-f32c2a7a5b53)


</p>
</details> 