### PR TITLE
Task03 Юрий Иванов HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,11 +1,57 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+int getIter(int iters, float *x, float *y, float x0, float y0, const float threshold2) {
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = *x;
+        *x = *x * *x - *y * *y + x0;
+        *y = 2.0f * xPrev * *y + y0;
+        if ((*x * *x + *y * *y) > threshold2) {
+            break;
+        }
+    }
+    return iter;
+}
+
+__kernel void mandelbrot(__global float *results, const unsigned int width, const unsigned int height,
+                         const float fromX, const float fromY, const float sizeX, const float sizeY,
+                         const unsigned int iters, int smoothing) {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int anti_aliasing = 1;
+    if (anti_aliasing < 1){
+        anti_aliasing = 1;
+    }
+    int ix = get_global_id(0);
+    int iy = get_global_id(1);
+
+    if (ix < width && iy < height) {
+        int iter = 0;
+        float x = 0;
+        float y = 0;
+        for (int j = 0; j < anti_aliasing; ++j) {
+            for (int i = 0; i < anti_aliasing; ++i) {
+                float x0 = fromX + (ix + (anti_aliasing - 1 ? (float) i / (anti_aliasing - 1) : 0.5f)) * sizeX / width;
+                float y0 = fromY + (iy + (anti_aliasing - 1 ? (float) j / (anti_aliasing - 1) : 0.5f)) * sizeY / height;
+                x = x0;
+                y = y0;
+
+                iter += getIter(iters, &x, &y, x0, y0, threshold2);
+            }
+        }
+        float result = anti_aliasing ? iter / (anti_aliasing * anti_aliasing) : iter;
+        if (smoothing && iter != iters) {
+            result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+        }
+
+        result = 1.0f * result / iters;
+        results[iy * width + ix] = result;
+    }
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,95 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int index = get_global_id(0);
+    if (index >= n)
+        return;
+    atomic_add(c, a[index]);
+}
+
+#define VALUES_PER_WORKITEM 32
+__kernel void loop(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int index = get_global_id(0);
+    unsigned int sum = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = index * VALUES_PER_WORKITEM + i;
+        if (idx < n)
+            sum += a[idx];
+    }
+    atomic_add(c, sum);
+}
+
+__kernel void loop_coalesced(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+    unsigned int sum = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            sum += a[idx];
+        }
+    }
+    atomic_add(c, sum);
+}
+
+#define WORKGROUP_SIZE 128
+__kernel void sum_5(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = a[gid];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int sum = 0;
+        for (int i = 0; i < WORKGROUP_SIZE; ++i) {
+            sum += buf[i];
+        }
+        atomic_add(c, sum);
+    }
+}
+
+__kernel void sum_6(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    __local unsigned int sum[WORKGROUP_SIZE];
+    sum[lid] = gid < n ? a[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = sum[lid];
+            unsigned int b = sum[lid + nValues / 2];
+            sum[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        atomic_add(c, sum[0]);
+    }
+}
+
+__kernel void sum_7(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    __local unsigned int sum[WORKGROUP_SIZE];
+    sum[lid] = gid < n ? a[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = sum[lid];
+            unsigned int b = sum[lid + nValues / 2];
+            sum[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (lid == 0) {
+        c[wid] = sum[0];
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,24 +1,20 @@
 #include <cmath>
 
-#include <libutils/misc.h>
-#include <libutils/timer.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
 #include <libimages/images.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+void mandelbrotCPU(float *results, unsigned int width, unsigned int height, float fromX, float fromY, float sizeX,
+                   float sizeY, unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -47,13 +43,12 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     unsigned int benchmarkingIters = 10;
@@ -66,10 +61,10 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    //    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    //    float centralX = -0.5f;
+    //    float centralY = 0.0f;
+    //    float sizeX = 2.0f;
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -80,16 +75,13 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int i = 0; i < benchmarkingIters; ++i) {
-            mandelbrotCPU(cpu_results.ptr(),
-                          width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, false);
+            mandelbrotCPU(cpu_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX,
+                          sizeY, iterationsLimit, false);
             t.nextLap();
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -99,59 +91,87 @@ int main(int argc, char **argv)
                 realIterationsFraction += cpu_results.ptr()[j * width + i];
             }
         }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
 
         renderToColor(cpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    //    // Раскомментируйте это:
+    //
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        gpu::gpu_mem_32f results_vram;
+        results_vram.resizeN(width * height);
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), results_vram, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+            t.nextLap();
+        }
+        results_vram.readN(gpu_results.ptr(), width * height);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_cpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+    //    bool useGPU = true;
+    //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -174,16 +194,11 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
     do {
         if (!useGPU) {
-            mandelbrotCPU(results.ptr(), width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
+            mandelbrotCPU(results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY,
                           iterationsLimit, true);
         } else {
-            kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
+            kernel.exec(gpu::WorkSize(16, 16, width, height), results_vram, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);
@@ -194,7 +209,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();
@@ -218,9 +233,12 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z) : x(x), y(y), z(z) {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +265,8 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +275,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,13 @@
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,12 +17,11 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,14 +40,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +55,117 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, cs_gpu;
+        as_gpu.resizeN(n);
+        cs_gpu.resizeN(1);
+        as_gpu.writeN(as.data(), n);
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                cs_gpu.writeN(&sum, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, cs_gpu, n);
+                cs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU:     \t\t" << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU:     \t\t" << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "loop");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                cs_gpu.writeN(&sum, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, cs_gpu, n);
+                cs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU loop:      " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU loop:      " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "loop_coalesced");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                cs_gpu.writeN(&sum, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, cs_gpu, n);
+                cs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU loop2:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU loop2:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_5");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                cs_gpu.writeN(&sum, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, cs_gpu, n);
+                cs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU sum_5:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU sum_5:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_6");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int sum = 0;
+                cs_gpu.writeN(&sum, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, cs_gpu, n);
+                cs_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU sum_6:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU sum_6:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+        {
+            gpu::gpu_mem_32u bs_gpu;
+            bs_gpu.resizeN(n);
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_7");
+            kernel.compile();
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int res = 0;
+                for (int nValues = n; nValues > 1; nValues = (nValues + workGroupSize - 1) / workGroupSize) {
+                    kernel.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                            as_gpu, bs_gpu, nValues);
+                    bs_gpu.copyToN(as_gpu, nValues);
+                }
+                as_gpu.readN(&res, 1);
+                EXPECT_THE_SAME(reference_sum, res, "GPU(sum_tree) result should be constistent!");
+                t.nextLap();
+            }
+            std::cout << "GPU sum_7:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU sum_7:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
     }
 }


### PR DESCRIPTION
### Мандельброт
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1650. Total memory: 3894 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1650. Total memory: 3894 Mb
CPU: 0.28377+-0.0190823 s
CPU: 35.2398 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.00507383+-1.06719e-06 s
GPU: 1970.9 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.93722+-0.00204478 s
CPU: 5.16203 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.139385+-0.000188226 s
GPU: 71.7436 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

### Суммы
<details><summary>Локальный вывод</summary><p>

<pre>
CPU:     0.205086+-0.00122316 s
CPU:     487.601 millions/s
CPU OMP: 0.0293788+-0.000181059 s
CPU OMP: 3403.81 millions/s
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1650. Total memory: 3894 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1650. Total memory: 3894 Mb
GPU:     	0.004966+-4.96655e-06 s
GPU:     	20136.9 millions/s
GPU loop:      0.0103645+-0.000223552 s
GPU loop:      9648.32 millions/s
GPU loop2:     0.00224267+-7.13364e-06 s
GPU loop2:     44589.8 millions/s
GPU sum_5:     0.00443183+-1.06719e-06 s
GPU sum_5:     22564 millions/s
GPU sum_6:     0.00727+-1.63299e-06 s
GPU sum_6:     13755.2 millions/s
GPU sum_7:     0.043188+-0.000221502 s
GPU sum_7:     2315.46 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
CPU:     0.0747212+-0.000114774 s
CPU:     1338.31 millions/s
CPU OMP: 0.030894+-0.000663273 s
CPU OMP: 3236.87 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU:     	1.96745+-0.00525408 s
GPU:     	50.8273 millions/s
GPU loop:      0.129427+-0.00161119 s
GPU loop:      772.637 millions/s
GPU loop2:     0.0608092+-0.000495044 s
GPU loop2:     1644.49 millions/s
GPU sum_5:     0.0625197+-0.000559895 s
GPU sum_5:     1599.5 millions/s
GPU sum_6:     0.196986+-0.000529876 s
GPU sum_6:     507.65 millions/s
GPU sum_7:     0.257123+-0.00258326 s
GPU sum_7:     388.919 millions/s
</pre>

</p></details>

### Вывод

На видеокарте "самый дубовый вариант" получился однозначно лучшим по отношению результат/усилия.
А на сервере гита вообще в минус уходит эффективность.

Немного удивило что sum_5, не смотря на барьер, получился и там, и там самым быстрым из кернелов, хотя вроде говорилось, что особо ускорить не должен.

<pre>
#define WORKGROUP_SIZE 128
__kernel void sum_5(__global unsigned int *a, __global unsigned int *c, unsigned int n) {
    const unsigned int gid = get_global_id(0);
    const unsigned int lid = get_local_id(0);
    __local unsigned int buf[WORKGROUP_SIZE];
    buf[lid] = a[gid];
    barrier(CLK_LOCAL_MEM_FENCE);
    if (lid == 0) {
        unsigned int sum = 0;
        for (int i = 0; i < WORKGROUP_SIZE; ++i) {
            sum += buf[i];
        }
        atomic_add(c, sum);
    }
}
</pre>

Предполагаю, что это произошло из за размера рабочей группы, но не совсем понимаю почему так.
gid меняется от 0 до 100000126
lid от 0 до 31(размер варпа) или от 0 до 127(размер рабочий группы) (?)
Создаём локальный буфер buf[128] и заполняем его на всех рабочих группах (?), затем, после барьера, с шагом lid, они реактивно считают по буферам суммы и атомарно их в ответ складывают.

Update:
Уменьшив рабочее пространство всё встало на свои места, и цикл с coalesced получился лучшим.

