### PR TITLE
Task03 Скальт Альберт SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,41 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
+__kernel void mandelbrot(__global float *results, unsigned int width, unsigned int height, float fromX, float fromY,
+                         float sizeX, float sizeY, unsigned int iters, int smoothing) {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (i >= height || j >= width) return;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,92 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+// Same as in main.
+#define WORK_GROUP_SIZE 128
+#define VALUES_PER_WORKITEM 128
+
+// Baseline.
+__kernel void baseline(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n) {
+    const unsigned gid = get_global_id(0);
+    if (gid >= n) {
+        return;
+    }
+    atomic_add(sum, arr[gid]);
+}
+
+
+// Cycle with non coalesced access.
+__kernel void cycle(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n) {
+    const unsigned gid = get_global_id(0);
+
+    unsigned res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+// Cycle with coalesced access.
+__kernel void cycle_coalesced(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n) {
+    const unsigned lid = get_local_id(0);
+    const unsigned wid = get_group_id(0);
+    const unsigned grs = get_local_size(0);
+
+    unsigned res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+// Local memory.
+__kernel void local_mem(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n) {
+    const unsigned gid = get_global_id(0);
+    const unsigned lid = get_local_id(0);
+
+    __local unsigned buf[WORK_GROUP_SIZE];
+    buf[lid] = arr[gid];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned group_res = 0;
+        for (int i = 0; i < WORK_GROUP_SIZE; ++i) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+// Tree.
+__kernel void tree(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n) {
+    const unsigned gid = get_global_id(0);
+    const unsigned lid = get_local_id(0);
+
+    __local unsigned buf[WORK_GROUP_SIZE];
+    buf[lid] = gid < n ? arr[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORK_GROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned a = buf[lid];
+            unsigned b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -17,7 +17,7 @@ void mandelbrotCPU(float* results,
 {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
+
     #pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
@@ -66,10 +66,10 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    //    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    //    float centralX = -0.5f;
+    //    float centralY = 0.0f;
+    //    float sizeX = 2.0f;
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -89,7 +89,7 @@ int main(int argc, char **argv)
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -106,46 +106,75 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        std::cout << std::endl;
+        bool printLog = true;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        gpu::gpu_mem_32f result_gpu;
+        result_gpu.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), result_gpu, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << device.name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << device.name << ": " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        // Прогрузим последний результат.
+        result_gpu.readN(gpu_results.ptr(), width * height);
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl << std::endl;
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+
+    //bool useGPU = true;
+    //renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
@@ -248,7 +277,7 @@ vec3f cos(const vec3f &a) {
 }
 
 void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
+                   unsigned int width, unsigned int height)
 {
     #pragma omp parallel for
     for (int j = 0; j < height; ++j) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,15 @@
+#include "cl/sum_cl.h"
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
+#define WORK_GROUP_SIZE 128
+#define VALUES_PER_WORKITEM 128
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,12 +19,11 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -38,27 +41,91 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "[CPU]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "[CPU]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
             EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "[CPU OMP]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "[CPU OMP]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+    }
+
+    // Choose device.
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    // Create context.
+    gpu::Context ctx;
+    ctx.init(device.device_id_opencl);
+    ctx.activate();
+
+    // Create global buffer for array.
+    gpu::gpu_mem_32u as_gpu;
+    as_gpu.resizeN(as.size());
+    as_gpu.writeN(as.data(), as.size());
+
+    gpu::gpu_mem_32u res_gpu;
+    res_gpu.resizeN(1);
+
+    auto gpu_bench = [&](const std::string &kernel_name, gpu::WorkSize sz) {
+        // Create and compile kernel.
+        ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+        kernel.compile(false);
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int result = 0;
+            // Set result to 0.
+            res_gpu.writeN(&result, 1);
+            kernel.exec(sz, as_gpu, res_gpu, n);
+            res_gpu.readN(&result, 1);
+            EXPECT_THE_SAME(reference_sum, result, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "[" << kernel_name << "]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "[" << kernel_name << "]: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << std::endl;
+    };
+
+    {
+        unsigned int workGroupSize = WORK_GROUP_SIZE;
+        unsigned int globalWorkSize = (as.size() + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu_bench("baseline", gpu::WorkSize(workGroupSize, globalWorkSize));
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        unsigned int workGroupSize = WORK_GROUP_SIZE;
+        unsigned int needToCover = (as.size() + VALUES_PER_WORKITEM - 1) / VALUES_PER_WORKITEM;
+        unsigned int globalWorkSize = (needToCover + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu_bench("cycle", gpu::WorkSize(workGroupSize, globalWorkSize));
+    }
+
+    {
+        unsigned int workGroupSize = WORK_GROUP_SIZE;
+        unsigned int needToCover = (as.size() + VALUES_PER_WORKITEM - 1) / VALUES_PER_WORKITEM;
+        unsigned int globalWorkSize = (needToCover + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu_bench("cycle_coalesced", gpu::WorkSize(workGroupSize, globalWorkSize));
+    }
+
+    // Necessarily use WORK_GROUP_SIZE below.
+    {
+        unsigned int workGroupSize = WORK_GROUP_SIZE;
+        unsigned int globalWorkSize = (as.size() + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu_bench("local_mem", gpu::WorkSize(workGroupSize, globalWorkSize));
+    }
+
+    {
+        unsigned int workGroupSize = WORK_GROUP_SIZE;
+        unsigned int globalWorkSize = (as.size() + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu_bench("tree", gpu::WorkSize(workGroupSize, globalWorkSize));
     }
 }


### PR DESCRIPTION
### Множество Мандельброта 

#### Локальный вывод
```bash
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
CPU: 0.839934+-0.0228262 s
CPU: 11.9057 GFlops
    Real iterations fraction: 56.2638%

Building kernels for Intel(R) Iris(R) Xe Graphics... 
Kernels compilation done in 0.259897 seconds
Device 1
	Program build log:


Intel(R) Iris(R) Xe Graphics: 0.0164082+-4.3748e-06 s
Intel(R) Iris(R) Xe Graphics: 609.453 GFlops
    Real iterations fraction: 56.0919%

GPU vs CPU average results difference: 1.0902%
```

#### CI 
```bash
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.93921+-0.00419544 s
CPU: 5.15674 GFlops
    Real iterations fraction: 56.2638%

Building kernels for Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz... 
Kernels compilation done in 0.04809 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (16)
Done.

Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz: 0.14695+-0.000318357 s
Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz: 68.0503 GFlops
    Real iterations fraction: 56.0919%

GPU vs CPU average results difference: 1.0902%
```

### Суммы 

#### Локально 
```bash
[CPU]: 0.329414+-0.000266633 s
[CPU]: 303.57 millions/s
[CPU OMP]: 0.0915437+-0.00185624 s
[CPU OMP]: 1092.37 millions/s
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
[baseline]: 0.009626+-4.41437e-05 s
[baseline]: 10388.5 millions/s

[cycle]: 0.0150552+-0.000299461 s
[cycle]: 6642.24 millions/s

[cycle_coalesced]: 0.0195787+-7.30403e-05 s
[cycle_coalesced]: 5107.6 millions/s

[local_mem]: 0.00960467+-0.00015751 s
[local_mem]: 10411.6 millions/s

[tree]: 0.00963983+-3.65167e-05 s
[tree]: 10373.6 millions/s
```

#### CI
```bash
[CPU]: 0.0753767+-2.85988e-05 s
[CPU]: 1326.67 millions/s
[CPU OMP]: 0.0325435+-0.00028695 s
[CPU OMP]: 3072.81 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
[baseline]: 2.09588+-0.00332319 s
[baseline]: 47.7127 millions/s

[cycle]: 0.0463993+-0.000435454 s
[cycle]: 2155.2 millions/s

[cycle_coalesced]: 0.0302212+-0.000107804 s
[cycle_coalesced]: 3308.94 millions/s

[local_mem]: 0.0565505+-0.000127192 s
[local_mem]: 1768.33 millions/s

[tree]: 0.167987+-0.000511298 s
[tree]: 595.284 millions/s
```

### Выводы
Неожиданно, но локально цикл с coalesced доступом отработал хуже цикла с разрозненным доступом.
Можно видеть, что базовая реализация оказывается самой эффективной (разница с деревом и локальной памятью скорее является погрешностью).

На серверном cpu результат ожидаемый и coalesced доступ эффективнее на 50%. А также является в принципе самым быстрым (видимо, из-за векторизации кернела).