### PR TITLE
Task03 Николай Стойко ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,41 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+__kernel void mandelbrot(__global float *results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, const unsigned int smoothing) {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const unsigned int index_y = get_global_id(1);
+    if (index_y >= height)
+        return;
+
+    const unsigned int index_x = get_global_id(0);
+
+    float x0 = fromX + (index_x + 0.5f) * sizeX / width;
+    float y0 = fromY + (index_y + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[index_y * width + index_x] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,108 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void kernel_sum1(__global const unsigned int* as,
+                   __global unsigned int* sum,
+                   unsigned int n)
+{
+    const unsigned int index = get_global_id(0);
+
+    if (index >= n)
+        return;
+
+    atomic_add(sum, as[index]);
+}
+
+
+__kernel void kernel_sum2(__global const unsigned int* as,
+                   __global unsigned int* sum,
+                   const unsigned int values_per_workitem,
+                   unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+    for(int i = 0; i < values_per_workitem; ++i) {
+        int index = gid * values_per_workitem + i;
+        if (index < n) {
+            res += as[index];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+__kernel void kernel_sum3(__global const unsigned int* as,
+                   __global unsigned int* sum,
+                   const unsigned int values_per_workitem,
+                   unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int gls = get_local_size(0);
+
+    unsigned int res = 0;
+    for(int i = 0; i < values_per_workitem; ++i) {
+        int index = wid * gls * values_per_workitem + i * gls + lid;
+        if (index < n) {
+            res += as[index];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+#define WORKGROUP_SIZE 128
+__kernel void kernel_sum4(__global const unsigned int* as,
+                   __global unsigned int* sum,
+                   unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int res = 0;
+        for(int i = 0; i < WORKGROUP_SIZE; ++i) {
+            res += buf[i];
+        }
+        atomic_add(sum, res);
+    }
+}
+
+
+__kernel void kernel_sum5(__global const unsigned int* as,
+                   __global unsigned int* sum,
+                   unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? as[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues >>= 1) {
+        if ((lid << 1) < nValues) {
+            buf[lid] += buf[lid + (nValues >> 1)];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        sum[wid] = buf[0];
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -105,41 +105,74 @@ int main(int argc, char **argv)
         image.savePNG("mandelbrot_cpu.png");
     }
 
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+        gpu::gpu_mem_32f result;
+        unsigned int workGroupSizeX = 8;
+        unsigned int workGroupSizeY = 8;
+        unsigned int global_work_size_x = (width + workGroupSizeX - 1) / workGroupSizeX * workGroupSizeX;
+        unsigned int global_work_size_y = (height + workGroupSizeY - 1) / workGroupSizeY * workGroupSizeY;
+        unsigned int size = global_work_size_x * global_work_size_y;
+        result.resizeN(size);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSizeX, workGroupSizeY, global_work_size_x, global_work_size_y),
+                        result,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, 0);
+            t.nextLap();
+        }
+        result.readN(gpu_results.ptr(), size);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = size * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
@@ -194,7 +227,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,11 @@
+#include "cl/sum_cl.h"
+
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
+
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 
 template<typename T>
@@ -17,16 +22,18 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
-    int benchmarkingIters = 10;
-
-    unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    constexpr int benchmarkingIters = 20;
+    constexpr unsigned int n = 200*1000*1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
+
+    unsigned int reference_sum = 0;
     for (int i = 0; i < n; ++i) {
         as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
         reference_sum += as[i];
     }
+
+    std::cout << "Generated " << n / 1000 / 1000 << " million numbers" << std::endl << std::endl;
 
     {
         timer t;
@@ -39,7 +46,7 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
     }
 
     {
@@ -54,11 +61,238 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+    }
+
+    constexpr unsigned int workGroupSize = 128;
+    constexpr unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+    {
+        // 3.2.1 Суммирование с глобальным атомарным добавлением (просто как бейзлайн)
+        std::cout << "3.2.1  GPU baseline (atomic_add)" << std::endl;
+
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        sum_gpu.resizeN(1);
+
+        ocl::Kernel kernel_sum1(sum_kernel, sum_kernel_length, "kernel_sum1");
+        kernel_sum1.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+            sum_gpu.write(&sum, sizeof(unsigned int));
+
+            kernel_sum1.exec(gpu::WorkSize(workGroupSize, global_work_size)
+                      , as_gpu
+                      , sum_gpu
+                      , n);
+
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        // 3.2.2 Суммирование с циклом
+        std::cout << "3.2.2  GPU sum with cycle" << std::endl;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        sum_gpu.resizeN(1);
+
+        ocl::Kernel kernel_sum2(sum_kernel, sum_kernel_length, "kernel_sum2");
+        kernel_sum2.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+            sum_gpu.write(&sum, sizeof(unsigned int));
+
+            kernel_sum2.exec(gpu::WorkSize(workGroupSize, global_work_size / workGroupSize)
+                    , as_gpu
+                    , sum_gpu
+                    , workGroupSize
+                    , n);
+
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+    }
+
+    {
+        // 3.2.3 Суммирование с циклом и coalesced доступом (интересно сравнение по скорости с не-coalesced версией)
+        std::cout << "3.2.3  GPU sum with cycle and coalesced access" << std::endl;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        sum_gpu.resizeN(1);
+
+        ocl::Kernel kernel_sum3(sum_kernel, sum_kernel_length, "kernel_sum3");
+        kernel_sum3.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+            sum_gpu.write(&sum, sizeof(unsigned int));
+
+            kernel_sum3.exec(gpu::WorkSize(workGroupSize, global_work_size / workGroupSize)
+                    , as_gpu
+                    , sum_gpu
+                    , workGroupSize
+                    , n);
+
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+    }
+
+    {
+        //3.2.4 Суммирование с локальной памятью и главным потоком
+        std::cout << "3.2.4  GPU sum with local memory and main thread" << std::endl;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        sum_gpu.resizeN(1);
+
+        ocl::Kernel kernel_sum4(sum_kernel, sum_kernel_length, "kernel_sum4");
+        kernel_sum4.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sum = 0;
+            sum_gpu.write(&sum, sizeof(unsigned int));
+
+            kernel_sum4.exec(gpu::WorkSize(workGroupSize, global_work_size)
+                    , as_gpu
+                    , sum_gpu
+                    , n);
+
+            sum_gpu.readN(&sum, 1);
+            EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+    }
+
+    {
+        //3.2.5 Суммирование с деревом
+        std::cout << "3.2.5  GPU sum with tree" << std::endl;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+
+        ocl::Kernel kernel_sum5(sum_kernel, sum_kernel_length, "kernel_sum5");
+        kernel_sum5.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int current_size = n;
+            std::vector<unsigned int> sum(current_size / workGroupSize + (current_size % workGroupSize ? 1 : 0), 0);
+            sum_gpu.resizeN(sum.size());
+
+            kernel_sum5.exec(gpu::WorkSize(workGroupSize, current_size)
+                    , as_gpu
+                    , sum_gpu
+                    , current_size);
+
+            sum_gpu.readN(sum.data(), sum.size());
+            unsigned int result_sum = 0;
+            for(const auto& v: sum) {
+                result_sum += v;
+            }
+            EXPECT_THE_SAME(reference_sum, result_sum, "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+    }
+
+    {
+        //3.2.5* Суммирование с деревом рекурсивно
+        std::cout << "3.2.5*  GPU recursive sum with tree" << std::endl;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu, sum_gpu;
+
+        ocl::Kernel kernel_sum5(sum_kernel, sum_kernel_length, "kernel_sum5");
+        kernel_sum5.compile();
+
+        as_gpu.resizeN(n);
+        sum_gpu.resizeN(n / workGroupSize + (n % workGroupSize ? 1 : 0));
+
+        constexpr unsigned int threshold = 2 * workGroupSize;
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+
+            t.stop();
+            as_gpu.writeN(as.data(), n);
+            t.start();
+
+            unsigned int current_size = n;
+
+            while(current_size >= threshold) {
+                kernel_sum5.exec(gpu::WorkSize(workGroupSize, current_size)
+                        , as_gpu
+                        , sum_gpu
+                        , current_size);
+                current_size = current_size / workGroupSize + (current_size % workGroupSize ? 1 : 0);
+                sum_gpu.copyToN(as_gpu, current_size);
+            }
+
+            std::vector<unsigned int> sum(workGroupSize, 0);
+            sum_gpu.readN(sum.data(), current_size);
+            for(int i = 1; i < current_size; ++i) {
+                sum[0] += sum[i];
+            }
+            EXPECT_THE_SAME(reference_sum, sum[0], "GPU result should be consistent!");
+            t.nextLap();
+        }
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
     }
 }


### PR DESCRIPTION
### Задание 3.1. Фрактал Мандельброта

<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
CPU: 0.328333+-0.00932142 s
CPU: 6.09137 GFlops
    Real iterations fraction: 56.2617%
GPU: 0.00483333+-0.00684146 s
GPU: 413.793 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.924079%
</pre>
</p></details>


<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        CPU: 1.553+-0.00288285 s
        CPU: 6.43916 GFlops
        Real iterations fraction: 56.2638%
GPU: 0.112457+-0.000218706 s
        GPU: 88.9233 GFlops
        Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>
</p></details>

__Вывод__: 
Вычисление фракталов хорошо параллелится, так как вычисление не зависят от чтения данных. 


### Задание 3.2. Суммирование
<details><summary>Локальный вывод</summary><p>
<pre>
Generated 200 million numbers

CPU:     0.347833+-0.00484481 s
CPU:     574.988 millions/s

CPU OMP: 0.0704167+-0.00485555 s
CPU OMP: 2840.24 millions/s

3.2.1  GPU baseline (atomic_add)
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
GPU: 0.0961667+-0.00106719 s
GPU: 2079.72 millions/s

3.2.2  GPU sum with cycle
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
GPU: 0.07+-0.00204124 s
GPU: 2857.14 millions/s

3.2.3  GPU sum with cycle and coalesced access
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
GPU: 0.0113333+-0.000471405 s
GPU: 17647.1 millions/s

3.2.4  GPU sum with local memory and main thread
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
GPU: 0.02675+-0.000595119 s
GPU: 7476.64 millions/s

3.2.5  GPU sum with tree
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
GPU: 0.03825+-0.000433013 s
GPU: 5228.76 millions/s

3.2.5*  GPU recursive sum with tree
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12832959630251/3072 Mb
GPU: 0.0195+-0.0005 s
GPU: 10256.4 millions/s
</pre>
</p></details>


<details><summary>Вывод Github CI</summary><p>
<pre>
Generated 200 million numbers

CPU:     0.191064+-4.94505e-05 s
CPU:     1046.77 millions/s

CPU OMP: 0.0675252+-0.000454313 s
CPU OMP: 2961.86 millions/s

3.2.1  GPU baseline (atomic_add)
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 3.38786+-0.0191096 s
        GPU: 59.0343 millions/s

3.2.2  GPU sum with cycle
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 0.0954009+-0.000377045 s
        GPU: 2096.42 millions/s

3.2.3  GPU sum with cycle and coalesced access
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 0.0597519+-0.000223105 s
        GPU: 3347.17 millions/s

3.2.4  GPU sum with local memory and main thread
        OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 0.124575+-0.000487546 s
        GPU: 1605.45 millions/s

3.2.5  GPU sum with tree
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 0.164118+-0.000528272 s
        GPU: 1218.64 millions/s

3.2.5*  GPU recursive sum with tree
        OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        GPU: 0.163628+-0.000476479 s
        GPU: 1222.29 millions/s
</pre>
</p></details>

__Вывод__: 
Вычисление в цикле с coalesced доступом к памяти (3.2.3) показало лучший результат, несмотря на атомарное прибавление к итоговой сумме. 
А рекурсивное вычисление с помощью дерева (3.2.5*) показало второй по скорости результат. 
Думаю это произошло по следующим причинам:
1. Ожидание барьеров вызывает накладные расходы
2. Для рекурсии нужно копировать результат предыдущей итерации, пусть и внутри памяти интегрированной графики
3. Интегрированная графика AMD Radeon(TM) Graphics (gfx1035) не позволяет решать задачу за честное O(N / workGroupSize) из-за малого количества варпов (6).

Интересно, что в CI способ 3.2.3 немного обогнал даже OpenMP 