### PR TITLE
Task03 Усков Евгений SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,45 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                unsigned int width, unsigned int height,
+                float fromX, float fromY,
+                float sizeX, float sizeY,
+                unsigned int iters)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    int id_x = get_global_id(0);
+    int id_y = get_global_id(1);
+
+    if (id_x >= width || id_y >= height)
+    {
+        return;
+    }
+
+    float x = fromX + (id_x + 0.5f) * sizeX / width;
+    float y = fromY + (id_y + 0.5f) * sizeY / height;
+
+    float x_0 = x;
+    float y_0 = y;
+    int iteration = 0;
+    for (; iteration < iters; iteration++) {
+        if (x * x + y * y > threshold2) {
+            break;
+        }
+        float buf_x = x;
+        float buf_y = y;
+        x = buf_x * buf_x - buf_y * buf_y + x_0;
+        y = 2 * buf_x * buf_y + y_0;
+    }
+
+    float result = iteration;
+
+    result = 1.0f * result / iters;
+    results[id_y * width + id_x] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,87 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define VALUES_PER_WORK_ITEM 32
+#define WORKGROUP_SIZE 128
+
+__kernel void globalAtomSum(__global const int *array, const unsigned int array_size, __global unsigned int *sum) {
+    unsigned int idx = get_global_id(0);
+    if (idx < array_size) {
+        atomic_add(sum, array[idx]);
+    }
+}
+
+__kernel void BatchSum(__global const int *array, const unsigned int array_size, __global unsigned int *sum) {
+    const unsigned int gid = get_global_id(0);
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORK_ITEM; ++i) {
+        unsigned int idx = gid * VALUES_PER_WORK_ITEM + i;
+        if (idx >= array_size) {
+            atomic_add(sum, res);
+            return;
+        }
+        res += array[idx];
+    }
+    atomic_add(sum, res);
+}
+
+__kernel void BatchSumCoalesed(__global const int *array, const unsigned int array_size, __global unsigned int *sum) {
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+    for (int i = 0; i < VALUES_PER_WORK_ITEM; ++i) {
+        unsigned int idx = wid * grs * VALUES_PER_WORK_ITEM + i * grs + lid;
+        if (idx >= array_size) {
+            atomic_add(sum, res);
+            return;
+        }
+        res += array[idx];
+    }
+    atomic_add(sum, res);
+}
+
+__kernel void LocalMemSUm(__global const int *array, const unsigned int array_size, __global unsigned int *sum) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buffer[WORKGROUP_SIZE];
+
+    buffer[lid] = array[gid];
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+            group_res += buffer[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+__kernel void TreeSum(__global const int *array, const unsigned int array_size, __global unsigned int *sum) {
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buffer[WORKGROUP_SIZE];
+
+    buffer[lid] = gid < array_size ? array[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int n_values = WORKGROUP_SIZE; n_values > 1; n_values /= 2) {
+        if (2 * lid < n_values) {
+            unsigned int a = buffer[lid];
+            unsigned int b = buffer[lid + n_values / 2];
+            buffer[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buffer[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,65 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f gpu_img;
+        gpu_img.resizeN(width * height);
+
+        unsigned int workGroupSize_width = 32;
+        unsigned int workGroupSize_height = 4;
+        unsigned int global_work_size_width = (width + workGroupSize_width - 1) / workGroupSize_width * workGroupSize_width;
+        unsigned int global_work_size_height = (height + workGroupSize_height - 1) / workGroupSize_height * workGroupSize_height;
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSize_width, workGroupSize_height, global_work_size_width,
+                  global_work_size_height), gpu_img, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY, iterationsLimit);
+            t.nextLap();
+        }
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        gpu_img.readN(gpu_results.ptr(), width * height);
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         unsigned int sum = 0;
         for (int i = 0; i < benchmarkingIters; ++i) {
             sum_buffer.writeN(&sum, 1);
-            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size),
+            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size / 32),
                         as_buffer, n, sum_buffer);
             t.nextLap();
         }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
         unsigned int sum = 0;
         for (int i = 0; i < benchmarkingIters; ++i) {
             sum_buffer.writeN(&sum, 1);
-            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size),
+            kernel.exec(gpu::WorkSize(workGroupSize, global_work_size / 32),
                         as_buffer, n, sum_buffer);
             t.nextLap();
         }


### PR DESCRIPTION
<details><summary>Локальный вывод SUM </summary><p>

<pre>
CPU:     0.227633+-0.000179928 s
CPU:     439.304 millions/s
CPU OMP: 0.0513157+-0.00490371 s
CPU OMP: 1948.72 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15342 Mb
  Device #1: CPU. pthread-AMD Ryzen 5 4500U with Radeon Graphics. AuthenticAMD. Total memory: 13294 Mb
Using device #0: CPU. AMD Ryzen 5 4500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15342 Mb
GPU (Atomic): 1.0951+-0.00403149 s
GPU (Atomic): 91.3161 millions/s
GPU (BatchSum): 0.052355+-7.0706e-05 s
GPU (BatchSum): 1910.04 millions/s
GPU (BatchSumCoalesed): 0.0559118+-0.000500142 s
GPU (BatchSumCoalesed): 1788.53 millions/s
GPU (LocalMemSum): 0.0245243+-0.00060958 s
GPU (LocalMemSum): 4077.58 millions/s
GPU (TreeSum): 0.0711048+-0.00172421 s
GPU (TreeSum): 1406.37 millions/s
</pre>

</p></details>


<details><summary>Локальный вывод Mandelbrot </summary><p>

<pre>
/home/evgeny/Desktop/Study/Spbu/GPGPUTasks2023/cmake-build-debug/mandelbrot 1
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 15342 Mb
  Device #1: CPU. pthread-AMD Ryzen 5 4500U with Radeon Graphics. AuthenticAMD. Total memory: 13294 Mb
Using device #1: CPU. pthread-AMD Ryzen 5 4500U with Radeon Graphics. AuthenticAMD. Total memory: 13294 Mb
CPU: 0.831775+-0.0335336 s
CPU: 12.0225 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.299893+-0.000666025 s
GPU: 33.3453 GFlops
GPU vs CPU average results difference: 1.23512%

Process finished with exit code 0
</pre>

</p></details>



<details><summary>CI SUM </summary><p>

<pre>
CPU:     0.0654775+-0.00028062 s
CPU:     1527.24 millions/s
CPU OMP: 0.0274228+-6.16317e-05 s
CPU OMP: 3646.6 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU (Atomic): 1.70989+-0.0760285 s
GPU (Atomic): 58.4832 millions/s
GPU (BatchSum): 0.105188+-0.000123342 s
GPU (BatchSum): 950.682 millions/s
GPU (BatchSumCoalesed): 0.0523975+-8.99792e-05 s
GPU (BatchSumCoalesed): 1908.49 millions/s
GPU (LocalMemSum): 0.0563865+-9.19144e-05 s
GPU (LocalMemSum): 1773.47 millions/s
GPU (TreeSum): 0.171573+-0.000609468 s
GPU (TreeSum): 582.841 millions/s
</pre>

</p></details>
<details><summary>CI Mandelbrot </summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 82[7](https://github.com/euskov17/GPGPUTasks2023/actions/runs/6285676385/job/17068305202#step:8:8)2CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum [8](https://github.com/euskov17/GPGPUTasks2023/actions/runs/6285676385/job/17068305202#step:8:9)272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6[9](https://github.com/euskov17/GPGPUTasks2023/actions/runs/6285676385/job/17068305202#step:8:10)32 Mb
CPU: 1.55622+-0.00932057 s
CPU: 6.42581 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.[11](https://github.com/euskov17/GPGPUTasks2023/actions/runs/6285676385/job/17068305202#step:8:12)4678+-0.0004735 s
GPU: 87.2007 GFlops
GPU vs CPU average results difference: 1.08872%

</pre>

</p></details>