### PR TITLE
Task03 Андрей Хорохорин SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,44 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results, unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, unsigned int smoothing)
 {
+
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+    
+    int i = get_global_id(0);
+    int j = get_global_id(1); 
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
+
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,114 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void sum_baseline(__global const unsigned int* src,
+                           __global unsigned int* dest,
+                           unsigned int n)
+{
+    const unsigned int index = get_global_id(0);
+
+    if (index >= n)
+        return;
+
+    atomic_add(dest, src[index]);
+}
+
+// keep synced with same variables in main_sum.cpp
+#define VALUES_PER_WORKITEM 64
+#define WORKGROUP_SIZE 64
+
+__kernel void sum_loop(__global const unsigned int* src,
+                       __global unsigned int* dest,
+                       unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int local_res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        unsigned int index = i + gid * VALUES_PER_WORKITEM;
+
+        if (index >= n) break;
+
+        local_res += src[index];
+    }
+
+    atomic_add(dest, local_res);
+}
+
+__kernel void sum_loop_coalesced(__global const unsigned int* src,
+                                 __global unsigned int* dest,
+                                 unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int local_res = 0;
+    const unsigned int offset = wid * grs * VALUES_PER_WORKITEM;
+
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        const unsigned int index = lid + i * grs + offset;
+
+        if (index >= n) break;
+
+        local_res += src[index];
+    }
+
+    atomic_add(dest, local_res);
+}
+
+
+__kernel void sum_local_mem(__global const unsigned int* src,
+                            __global unsigned int* dest,
+                            unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    if (gid > n) return;
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = src[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid != 0) return;
+
+    unsigned int local_res = 0;
+    for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+        local_res += buf[i];
+    }
+
+    atomic_add(dest, local_res);
+}
+
+__kernel void sum_tree(__global const unsigned int* src,
+                       __global unsigned int* dest,
+                       unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? src[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int local_res = 0;
+    for (unsigned int alive = WORKGROUP_SIZE; alive > 1; alive >>= 1) {
+        unsigned int L = lid;
+        unsigned int R = alive / 2 + lid;
+        if (R < alive) {
+            buf[L] += buf[R];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) dest[wid] = buf[0];
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,71 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        timer t;
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        gpu::gpu_mem_32f results_vram;
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и производительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = true;
+        kernel.compile(printLog);
+        results_vram.resizeN(width * height);
+
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height),
+                results_vram, width, height,
+                centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                sizeX, sizeY,
+                iterationsLimit, 1);
+            t.nextLap();
+        }
+        results_vram.readN(gpu_results.ptr(), width * height);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,7 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -14,18 +17,58 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+#define DIV_ROUND_UP(a, b) (((a) + (b) - 1) / (b))
+
+// keep synced with same variable in sum.cl
+#define VALUES_PER_WORKITEM 64
+#define WORKGROUP_SIZE 64
+
+// should executed inside context
+void run_gpu_kernel(std::vector<unsigned int> data, unsigned int expected, const char* kernelName, size_t benchmarkingIters,
+                    unsigned int workGroupSize, unsigned int globalWorkSize)
+{
+    timer t;
+
+    const unsigned int n = data.size();
+
+    gpu::gpu_mem_32u as_gpu;
+    gpu::gpu_mem_32u result_vram;
+    as_gpu.resizeN(n);
+    result_vram.resizeN(1);
+
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+    kernel.compile();
+
+
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        as_gpu.writeN(data.data(), n);
+        unsigned int result = 0;
+        result_vram.writeN(&result, 1);
+
+        kernel.exec(gpu::WorkSize(workGroupSize, globalWorkSize), as_gpu, result_vram, n);
+            
+        result_vram.readN(&result, 1);
+        EXPECT_THE_SAME(expected, result, "GPU result should be consistent!");
+
+        t.nextLap();
+    }
+
+    std::cout << "GPU(" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU(" << kernelName << "): " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+}
 
 int main(int argc, char **argv)
 {
     int benchmarkingIters = 10;
 
-    unsigned int reference_sum = 0;
+    unsigned int referenceSum = 0;
     unsigned int n = 100*1000*1000;
+    /* unsigned int n = 1*1000*1000; */
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
         as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
-        reference_sum += as[i];
+        referenceSum += as[i];
     }
 
     {
@@ -35,7 +78,7 @@ int main(int argc, char **argv)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
+            EXPECT_THE_SAME(referenceSum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -50,7 +93,7 @@ int main(int argc, char **argv)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+            EXPECT_THE_SAME(referenceSum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -58,7 +101,56 @@ int main(int argc, char **argv)
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        const unsigned int workGroupWork = WORKGROUP_SIZE * VALUES_PER_WORKITEM;
+
+        run_gpu_kernel(as, referenceSum, "sum_baseline", benchmarkingIters,
+                WORKGROUP_SIZE, DIV_ROUND_UP(n, WORKGROUP_SIZE) * WORKGROUP_SIZE);
+
+        run_gpu_kernel(as, referenceSum, "sum_loop", benchmarkingIters,
+                WORKGROUP_SIZE, DIV_ROUND_UP(n, workGroupWork) * WORKGROUP_SIZE);
+
+        run_gpu_kernel(as, referenceSum, "sum_loop_coalesced", benchmarkingIters,
+                WORKGROUP_SIZE, DIV_ROUND_UP(n, workGroupWork) * WORKGROUP_SIZE);
+
+        run_gpu_kernel(as, referenceSum, "sum_local_mem", benchmarkingIters,
+                WORKGROUP_SIZE, DIV_ROUND_UP(n, WORKGROUP_SIZE) * WORKGROUP_SIZE);
+
+        // sum_tree special call
+        {
+            timer t;
+
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u bs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_tree");
+            kernel.compile();
+
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(as.data(), n);
+
+                for (unsigned int alive = n; alive > 1; alive = DIV_ROUND_UP(alive, WORKGROUP_SIZE)) {
+                    kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, DIV_ROUND_UP(alive, WORKGROUP_SIZE) * WORKGROUP_SIZE), as_gpu, bs_gpu, alive);
+                    std::swap(as_gpu, bs_gpu);
+                }
+                    
+                unsigned int result;
+                as_gpu.readN(&result, 1);
+                EXPECT_THE_SAME(referenceSum, result, "GPU result should be consistent!");
+
+                t.nextLap();
+            }
+
+            std::cout << "GPU(sum_tree): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU(sum_tree): " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
     }
+    return 0;
 }


### PR DESCRIPTION
# Mandelbort
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15906 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15906 Mb
CPU: 0.995042+-0.0167571 s
CPU: 10.0498 GFlops
    Real iterations fraction: 56.2638%
Building kernels for Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz... 
Kernels compilation done in 0.045358 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (8)
Done.

GPU: 0.433562+-0.000723289 s
GPU: 23.0648 GFlops
    Real iterations fraction: 56.0918%
GPU vs CPU average results difference: 1.09087%
</pre>
</p></details>
<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.5557+-0.00689549 s
CPU: 6.42798 GFlops
    Real iterations fraction: 56.2638%
Building kernels for Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz... 
Kernels compilation done in 0.044772 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (16)
Done.

GPU: 0.115563+-0.000143479 s
GPU: 86.533 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%
</pre>

</p></details>


</p></details>

# Sum
<details><summary>Локальный вывод</summary><p>

<pre>
CPU:     0.0312275+-0.000195005 s
CPU:     3202.31 millions/s
CPU OMP: 0.02716+-0.000372542 s
CPU OMP: 3681.89 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15906 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-4300M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15906 Mb
GPU(sum_baseline): 2.70889+-0.0565093 s
GPU(sum_baseline): 36.9155 millions/s
GPU(sum_loop): 0.089578+-0.00194926 s
GPU(sum_loop): 1116.35 millions/s
GPU(sum_loop_coalesced): 0.110071+-0.0022132 s
GPU(sum_loop_coalesced): 908.509 millions/s
GPU(sum_local_mem): 0.132106+-0.00307966 s
GPU(sum_local_mem): 756.967 millions/s
GPU(sum_tree): 0.329182+-0.0164122 s
GPU(sum_tree): 303.783 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
CPU:     0.069726+-0.000159353 s
CPU:     1434.19 millions/s
CPU OMP: 0.0284362+-0.000127151 s
CPU OMP: 3516.65 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU(sum_baseline): 1.81997+-0.00345115 s
GPU(sum_baseline): 54.9458 millions/s
GPU(sum_loop): 0.162369+-0.000521136 s
GPU(sum_loop): 615.88 millions/s
GPU(sum_loop_coalesced): 0.115074+-0.000118392 s
GPU(sum_loop_coalesced): 869.004 millions/s
GPU(sum_local_mem): 0.154299+-0.000728911 s
GPU(sum_local_mem): 648.094 millions/s
GPU(sum_tree): 0.243063+-0.00145458 s
GPU(sum_tree): 411.416 millions/s
</pre>

</p></details>
