### PR TITLE
Task03 Александр Тульчинский SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,41 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results, unsigned int width, unsigned int height, float fromX, float fromY,
+                         float sizeX, float sizeY, unsigned int iters, int smoothing)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const unsigned int i = get_global_id(0), j = get_global_id(1);
+
+    if (i >= width || j >= height)
+        return ;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,105 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define VALUES_PER_WORKITEM 128
+#define WORKGROUP_SIZE 128
+
+__kernel void only_atomic(__global unsigned int *result,
+                     __global const unsigned int* a,
+                     unsigned int n)
+{
+    const unsigned int index = get_global_id(0);
+
+    if (index >= n)
+        return;
+
+    atomic_add(result, a[index]);
+}
+
+__kernel void cycle(__global unsigned int *result,
+                 __global const unsigned int* a,
+                 unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    unsigned int res = 0;
+
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int index = gid * VALUES_PER_WORKITEM + i;
+        if (index < n)
+            res += a[index];
+    }
+
+    atomic_add(result, res);
+}
+
+__kernel void coalesced(__global unsigned int *result,
+                 __global const unsigned int* a,
+                 unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+
+    for (int i = 0; i < VALUES_PER_WORKITEM; i++) {
+        int index = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (index < n)
+            res += a[index];
+    }
+
+    atomic_add(result, res);
+}
+
+__kernel void mem_local(__global unsigned int *result,
+                 __global const unsigned int* a,
+                 unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = a[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (int i = 0; i < WORKGROUP_SIZE; i++) {
+            group_res += buf[i];
+        }
+        atomic_add(result, group_res);
+    }
+}
+
+__kernel void tree(__global unsigned int *result,
+                 __global const unsigned int* a,
+                 unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? a[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nv = WORKGROUP_SIZE; nv > 1; nv /= 2) {
+        if (2 * lid < nv) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nv / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(result, buf[lid]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,67 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = true;
+        std::cout << "==============" << std::endl;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        timer t;
+        gpu::gpu_mem_32f gpu_result;
+        gpu_result.resizeN(width * height);
+        for (int iter = 0; iter < benchmarkingIters; iter++) {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), gpu_result, width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
+            t.nextLap();
+        }
+        gpu_result.readN(gpu_results.ptr(), width * height);
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,7 @@
+#include "libgpu/shared_device_buffer.h"
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 
 template<typename T>
@@ -59,6 +60,10 @@ int main(int argc, char **argv)
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(as.size());
+        as_gpu.writeN(as.data(), as.size());
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод mandelbrod для CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
CPU: 0.866594+-0.016542 s
CPU: 11.5394 GFlops
    Real iterations fraction: 56.2638%
==============
Building kernels for Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz... 
Kernels compilation done in 0.122255 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (16)
Done.

GPU: 0.056992+-0.0003531 s
GPU: 175.463 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%
</pre>

</p></details>

<details><summary>Локальный вывод mandelbrod для GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
CPU: 0.797146+-0.00712085 s
CPU: 12.5448 GFlops
    Real iterations fraction: 56.2638%
==============
Building kernels for NVIDIA GeForce MX230... 
Kernels compilation done in 0.030488 seconds
Device 1
	Program build log:



GPU: 0.0318983+-0.00117527 s
GPU: 313.496 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%
</pre>

</p></details>

<details><summary>Вывод GitHub CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.88082+-0.0222285 s
CPU: 5.31683 GFlops
    Real iterations fraction: 56.2638%
==============
Building kernels for Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz... 
Kernels compilation done in 0.05717 seconds
Device 1
	Program build log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <mandelbrot> was successfully vectorized (16)
Done.

GPU: 0.146617+-0.000674236 s
GPU: 68.2048 GFlops
    Real iterations fraction: 56.0919%
GPU vs CPU average results difference: 1.0902%
</pre>

</p></details>

<details><summary>Локальный вывод sum для CPU</summary><p>

<pre>
CPU:     0.302533+-0.00417741 s
CPU:     330.543 millions/s
CPU OMP: 0.0934513+-0.00203754 s
CPU OMP: 1070.08 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
only_atomic 1.68858+-0.00168929 s
only_atomic 59.2215 millions/s
cycle 0.0218967+-4.32653e-05 s
cycle 4566.91 millions/s
coalesced 0.0227025+-6.55204e-05 s
coalesced 4404.8 millions/s
mem_local 0.0223565+-0.000159561 s
mem_local 4472.97 millions/s
tree 0.0670492+-0.000642764 s
tree 1491.44 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод sum для GPU</summary><p>

<pre>
CPU:     0.286902+-0.00152974 s
CPU:     348.551 millions/s
CPU OMP: 0.0844993+-0.000329286 s
CPU OMP: 1183.44 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
only_atomic 0.0171103+-5.43865e-05 s
only_atomic 5844.42 millions/s
cycle 0.0333447+-3.65133e-05 s
cycle 2998.98 millions/s
coalesced 0.009246+-1.7195e-05 s
coalesced 10815.5 millions/s
mem_local 0.0210657+-5.1025e-05 s
mem_local 4747.06 millions/s
tree 0.0396975+-1.08743e-05 s
tree 2519.05 millions/s
</pre>

</p></details>

<details><summary>Вывод GitHub CI</summary><p>

<pre>
CPU:     0.0712605+-0.000170248 s
CPU:     1403.3 millions/s
CPU OMP: 0.0298173+-0.000181247 s
CPU OMP: 3353.75 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
only_atomic 1.9776+-0.0960797 s
only_atomic 50.5665 millions/s
cycle 0.0585413+-0.000486773 s
cycle 1708.19 millions/s
coalesced 0.0299858+-0.000544444 s
coalesced 3334.91 millions/s
mem_local 0.0675515+-8.48779e-05 s
mem_local 1480.35 millions/s
tree 0.220149+-0.00139189 s
tree 454.237 millions/s
</pre>

</p></details>

## Выводы

На серверном CPU и на локальном GPU coalesced цикл оказался самым эффективным.

На локальном CPU же обычный цикл обошел coalesced, использование локальной памяти по скорости примерно совпадает с coalesced циклом.