### PR TITLE
Task03 Шукшов Андрей ITMO

### DIFF
--- a/libs/gpu/libgpu/opencl/cl/clion_defines.cl
+++ b/libs/gpu/libgpu/opencl/cl/clion_defines.cl
@@ -46,6 +46,8 @@ void	barrier(cl_mem_fence_flags flags);
 gentypen	vload4			(size_t offset, const gentype *p);
 void		vstore4			(gentypen data, size_t offset, gentype *p);
 void		vstore4			(gentypen data, size_t offset, gentype *p);
+gentype     fma             (gentype a, gentype b, gentype c);
+gentypen    fma             (gentypen a, gentypen b, gentypen c);
 #undef gentypen
 #undef gentype
 float		vload_half		(size_t offset, const half *p);
@@ -67,7 +69,7 @@ uint	get_work_dim		();
 
 // Defined in libs/gpu/libgpu/opencl/engine.cpp:584
 // 64 for AMD, 32 for NVidia, 8 for intel GPUs, 1 for CPU
-#define WARP_SIZE 64
+#define WARP_SIZE 32
 
 #endif
 

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -12,8 +12,8 @@ __kernel void mandelbrot(__global float *out,
                          float fromX, float fromY,
                          float sizeX, float sizeY,
                          unsigned int iterationsLimit, unsigned int smoothing) {
-
-    const float threshold = 256.0f * 256.0f;
+    const float threshold = 256.0f;
+    const float threshold2 = 65536.0f;
 
     const unsigned thread_id = get_local_id(0);
     const unsigned wg_size = get_local_size(0);
@@ -34,7 +34,7 @@ __kernel void mandelbrot(__global float *out,
 
     while (thread_offset < end_offset) {
 
-        float i, j;
+        int i, j;
         float x0, y0, x, y, it;
 
 
@@ -58,7 +58,7 @@ __kernel void mandelbrot(__global float *out,
             x = fma(y, -y, fma(x, x, x0));
             y = fma(2.0f * xPrev, y, y0);
 
-            if ((fma(x, x, y * y)) > threshold) {
+            if ((fma(x, x, y * y)) > threshold2) {
                 it += iter;
                 // hack to avoid creating instructions to change exec mask
                 x = 0;

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,13 +1,118 @@
 #ifdef __CLION_IDE__
+
 #include <libgpu/opencl/cl/clion_defines.cl>
+
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+#define WAVE_SIZE 32
+__kernel void mandelbrot(__global float *out,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iterationsLimit, unsigned int smoothing) {
+
+    const float threshold = 256.0f * 256.0f;
+
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    // WORKS_SIZE per CU
+
+    const unsigned work_size = (width * height + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+
+
+    unsigned thread_offset = cu_offset + thread_id;
+    // start value for (x, y)
+
+
+    const unsigned end_offset = min(width * height, cu_offset + work_size);
+
+    while (thread_offset < end_offset) {
+
+        float i, j;
+        float x0, y0, x, y, it;
+
+
+        i = (thread_offset) % width;
+        j = (thread_offset) / width;
+
+        x0 = fromX + (i + 0.5f) * sizeX / width;
+        y0 = fromY + (j + 0.5f) * sizeY / height;
+
+        x = x0;
+        y = y0;
+        it = iterationsLimit;
+
+        float result;
+        int iter = 0;
+        for (; iter < iterationsLimit; ++iter) {
+
+
+            float xPrev = x;
+
+            x = fma(y, -y, fma(x, x, x0));
+            y = fma(2.0f * xPrev, y, y0);
+
+            if ((fma(x, x, y * y)) > threshold) {
+                it += iter;
+                // hack to avoid creating instructions to change exec mask
+                x = 0;
+                y = 0;
+                x0 = 0;
+                y0 = 0;
+            }
+
+        }
+
+        if(it - iterationsLimit > 1e-6) {
+            it = it - iterationsLimit;
+        }
+
+        result = it / iterationsLimit;
+
+        if (smoothing && (it - iterationsLimit) > 1e-6) {
+            result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+        }
+
+        out[thread_offset] = result;
+        thread_offset += wg_size;
+
+    }
+
+}
+
+__kernel void mandelbrot_naive(__global float *out, const unsigned int width, const unsigned int height,
+                               const float fromX, const float fromY, const float sizeX, const float sizeY,
+                               const unsigned int iterationsLimit, const int smoothing) {
+    const float threshold = 256.0f * 256.0f;
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iterationsLimit; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iterationsLimit) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iterationsLimit;
+    out[j * width + i] = result;
 }

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -100,15 +100,24 @@ __kernel void mandelbrot_naive(__global float *out, const unsigned int width, co
     float y = y0;
 
     int iter = 0;
+    float it = iterationsLimit;
     for (; iter < iterationsLimit; ++iter) {
         float xPrev = x;
         x = x * x - y * y + x0;
         y = 2.0f * xPrev * y + y0;
         if ((x * x + y * y) > threshold) {
-            break;
+            it += iter;
+            // hack to avoid creating instructions to change exec mask
+            x = 0;
+            y = 0;
+            x0 = 0;
+            y0 = 0;
         }
     }
-    float result = iter;
+    if(it - iterationsLimit > 1e-6) {
+        it = it - iterationsLimit;
+    }
+    float result = it;
     if (smoothing && iter != iterationsLimit) {
         result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
     }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,150 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+
+#define WAVE_SIZE 32
+__kernel void sum_atomic(__global unsigned int *res, __global const unsigned int *data, const unsigned int n) {
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    const unsigned work_size = (n + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+    unsigned thread_offset = cu_offset + thread_id;
+
+    const unsigned end_offset = min(n, cu_offset + work_size);
+
+    while (thread_offset < end_offset) {
+        int value = data[thread_offset];
+        atomic_add(res, value);
+        thread_offset += wg_size;
+    }
+}
+
+__kernel void sum_atomic_iter(__global unsigned int *res, __global const unsigned int *data, const unsigned int n) {
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    const unsigned work_size = (n + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+
+    const unsigned work_per_thread = (work_size + wg_size - 1) / wg_size;
+    unsigned thread_offset = cu_offset + thread_id * work_per_thread;
+
+    unsigned end_offset = min(n, cu_offset + work_size);
+    int sum = 0;
+    for (int i = 0; i < work_per_thread; ++i) {
+        if (thread_offset + i < end_offset) {
+            sum += data[thread_offset + i];
+        }
+    }
+
+    atomic_add(res, sum);
+}
+
+__kernel void sum_atomic_coalesce(__global unsigned int *res, __global const unsigned int *data, const unsigned int n) {
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    const unsigned work_size = (n + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+
+    unsigned thread_offset = cu_offset + thread_id;
+
+    unsigned end_offset = min(n, cu_offset + work_size);
+    int sum = 0;
+    while (thread_offset < end_offset) {
+        sum += data[thread_offset];
+        thread_offset += wg_size;
+    }
+
+    atomic_add(res, sum);
+}
+
+__kernel void sum_local(__global unsigned int *res, __global const unsigned int *data, const unsigned int n) {
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned wave_id = thread_id / WAVE_SIZE;
+    const unsigned lane_id = thread_id % WAVE_SIZE;
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    const unsigned work_size = (n + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+
+    unsigned thread_offset = cu_offset + thread_id;
+
+    __local unsigned lds_buf[256];
+    unsigned end_offset = min(n, cu_offset + work_size);
+    int sum = 0;
+
+    while (thread_offset < end_offset) {
+        sum += data[thread_offset];
+        thread_offset += wg_size;
+    }
+
+    lds_buf[thread_id] = sum;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    sum = 0;
+    if (wave_id == 0) {
+        for (int i = 0; i < 4; ++i) {
+            sum += lds_buf[i * WAVE_SIZE + lane_id];
+        }
+        // there should be a cross-lane reduction
+        atomic_add(res, sum);
+    }
+}
+
+__kernel void sum_tree(__global unsigned int *res, __global const unsigned int *data, const unsigned int n) {
+    const unsigned thread_id = get_local_id(0);
+    const unsigned wg_size = get_local_size(0);
+    const unsigned wave_id = thread_id / WAVE_SIZE;
+    const unsigned lane_id = thread_id % WAVE_SIZE;
+    const unsigned cu_id = get_group_id(0);
+    const unsigned cu_cnt = get_num_groups(0);
+
+    const unsigned work_size = (n + cu_cnt - 1) / cu_cnt;
+    const unsigned cu_offset = work_size * cu_id;
+
+    unsigned thread_offset = cu_offset + thread_id;
+
+    __local unsigned lds_buf[256];
+    unsigned end_offset = min(n, cu_offset + work_size);
+    int sum = 0;
+
+    while (thread_offset < end_offset) {
+        sum += data[thread_offset];
+        thread_offset += wg_size;
+    }
+
+    lds_buf[thread_id] = sum;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (wave_id < 4) {
+        sum += lds_buf[(wave_id + 4) * WAVE_SIZE + lane_id];
+        lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
+        barrier(CLK_LOCAL_MEM_FENCE);
+        if (wave_id < 2) {
+            sum += lds_buf[(wave_id + 2) * WAVE_SIZE + lane_id];
+            lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
+            barrier(CLK_LOCAL_MEM_FENCE);
+            if(wave_id == 0) {
+                sum += lds_buf[(wave_id + 1) * WAVE_SIZE + lane_id];
+                atomic_add(res, sum);
+            }
+        }
+
+    }
+}
+

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -132,14 +132,16 @@ __kernel void sum_tree(__global unsigned int *res, __global const unsigned int *
     barrier(CLK_LOCAL_MEM_FENCE);
 
     if (wave_id < 4) {
-        sum += lds_buf[(wave_id + 4) * WAVE_SIZE + lane_id];
-        lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
-        barrier(CLK_LOCAL_MEM_FENCE);
+        if (wg_size > 128) {
+            sum += lds_buf[(wave_id + 4) * WAVE_SIZE + lane_id];
+            lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
         if (wave_id < 2) {
             sum += lds_buf[(wave_id + 2) * WAVE_SIZE + lane_id];
             lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
             barrier(CLK_LOCAL_MEM_FENCE);
-            if(wave_id == 0) {
+            if (wave_id == 0) {
                 sum += lds_buf[(wave_id + 1) * WAVE_SIZE + lane_id];
                 atomic_add(res, sum);
             }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -131,12 +131,10 @@ __kernel void sum_tree(__global unsigned int *res, __global const unsigned int *
     lds_buf[thread_id] = sum;
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    if (wave_id < 4) {
-        if (wg_size > 128) {
-            sum += lds_buf[(wave_id + 4) * WAVE_SIZE + lane_id];
-            lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
-            barrier(CLK_LOCAL_MEM_FENCE);
-        }
+    if (wave_id < 4 && wg_size > 128) {
+        sum += lds_buf[(wave_id + 4) * WAVE_SIZE + lane_id];
+        lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
+        barrier(CLK_LOCAL_MEM_FENCE);
         if (wave_id < 2) {
             sum += lds_buf[(wave_id + 2) * WAVE_SIZE + lane_id];
             lds_buf[wave_id * WAVE_SIZE + lane_id] = sum;
@@ -145,8 +143,11 @@ __kernel void sum_tree(__global unsigned int *res, __global const unsigned int *
                 sum += lds_buf[(wave_id + 1) * WAVE_SIZE + lane_id];
                 atomic_add(res, sum);
             }
+
         }
 
+    } else {
+        atomic_add(res, sum);
     }
 }
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -98,7 +98,8 @@ __kernel void sum_local(__global unsigned int *res, __global const unsigned int 
 
     sum = 0;
     if (wave_id == 0) {
-        for (int i = 0; i < 4; ++i) {
+        #pragma unroll 4
+        for (int i = 0; i < wg_size / WAVE_SIZE; ++i) {
             sum += lds_buf[i * WAVE_SIZE + lane_id];
         }
         // there should be a cross-lane reduction

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -9,16 +9,15 @@
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
+void mandelbrotCPU(float *results,
                    unsigned int width, unsigned int height,
                    float fromX, float fromY,
                    float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+                   unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -47,13 +46,12 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     unsigned int benchmarkingIters = 10;
@@ -84,14 +82,14 @@ int main(int argc, char **argv)
                           width, height,
                           centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                           sizeX, sizeY,
-                          iterationsLimit, false);
+                          iterationsLimit, true);
             t.nextLap();
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t giga = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "CPU: " << maxApproximateFlops / giga / t.lapAvg() << " gflops" << std::endl;
 
         double realIterationsFraction = 0.0;
         for (int j = 0; j < height; ++j) {
@@ -99,7 +97,8 @@ int main(int argc, char **argv)
                 realIterationsFraction += cpu_results.ptr()[j * width + i];
             }
         }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
 
         renderToColor(cpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
@@ -107,51 +106,85 @@ int main(int argc, char **argv)
 
 
 //    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
 
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
-    // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+
+        unsigned group_size = 32;
+        // on Navi3 doesn't return the number of CUs, but the number of SAs
+        unsigned cu_count = device.compute_units * 2;
+        unsigned wave_slots_per_simd = 16;
+        gpu::gpu_mem_32f result_buffer;
+        result_buffer.resizeN(width * height);
+        {
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                // create 16 waves per CU
+                kernel.exec(gpu::WorkSize(group_size, 1,  wave_slots_per_simd * cu_count * group_size, 1),
+                            result_buffer, width, height,
+                            centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                            sizeX, sizeY,
+                            iterationsLimit, 0);
+                result_buffer.readN(gpu_results.ptr(), width * height);
+                t.nextLap();
+            }
+            size_t flopsInLoop = 10;
+            size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+            size_t giga = 1000 * 1000 * 1000;
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << maxApproximateFlops / giga / t.lapAvg() << " gflops" << std::endl;
+
+            double realIterationsFraction = 0.0;
+            for (int j = 0; j < height; ++j) {
+                for (int i = 0; i < width; ++i) {
+                    realIterationsFraction += cpu_results.ptr()[j * width + i];
+                }
+            }
+            std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                      << std::endl;
+
+            renderToColor(cpu_results.ptr(), image.ptr(), width, height);
+            image.savePNG("mandelbrot_gpu.png");
+        }
+
+        {
+            double errorAvg = 0.0;
+            for (int j = 0; j < height; ++j) {
+                for (int i = 0; i < width; ++i) {
+                    errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+                }
+            }
+            errorAvg /= width * height;
+            std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+            if (errorAvg > 0.03) {
+                throw std::runtime_error("Too high difference between CPU and GPU results!");
+            }
+        }
+    }
+
+//     Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
+//     Кликами мышки можно смещать ракурс
+//     Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
 //    bool useGPU = false;
 //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -166,10 +199,10 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
     images::Image<unsigned char> image(width, height, 3);
 
     ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-    gpu::gpu_mem_32f results_vram;
+    gpu::gpu_mem_32f result_buffer;
     if (useGPU) {
         kernel.compile();
-        results_vram.resizeN(width * height);
+        result_buffer.resizeN(width * height);
     }
 
     do {
@@ -180,11 +213,11 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
                           iterationsLimit, true);
         } else {
             kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
+                        result_buffer, width, height,
                         centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                         sizeX, sizeY,
                         iterationsLimit, 1);
-            results_vram.readN(results.ptr(), width * height);
+            result_buffer.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);
 
@@ -194,7 +227,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();
@@ -208,7 +241,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
             image = images::Image<unsigned char>(width, height, 3);
 
             if (useGPU) {
-                results_vram.resizeN(width * height);
+                result_buffer.resizeN(width * height);
             }
         }
         sizeX /= zoomingSpeed;
@@ -220,7 +253,9 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 struct vec3f {
     vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +282,9 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb,
+                   unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +293,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -125,21 +125,20 @@ int main(int argc, char **argv) {
         unsigned group_size = 32;
         // on Navi3 doesn't return the number of CUs, but the number of SAs
         unsigned cu_count = device.compute_units * 2;
-        unsigned wave_slots_per_simd = 16;
+        unsigned wave_slots_per_simd = 12;
         gpu::gpu_mem_32f result_buffer;
         result_buffer.resizeN(width * height);
         {
             timer t;
-            for (int i = 0; i < benchmarkingIters; ++i) {
-                // create 16 waves per CU
+            for (int i = 0; i < benchmarkingIters * 100; ++i) {
                 kernel.exec(gpu::WorkSize(group_size, 1,  wave_slots_per_simd * cu_count * group_size, 1),
                             result_buffer, width, height,
                             centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
                             sizeX, sizeY,
                             iterationsLimit, 0);
-                result_buffer.readN(gpu_results.ptr(), width * height);
                 t.nextLap();
             }
+            result_buffer.readN(gpu_results.ptr(), width * height);
             size_t flopsInLoop = 10;
             size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
             size_t giga = 1000 * 1000 * 1000;

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
         wg_size = 128;
         grid_size = wg_size * cu_count * wave_slots_per_simd;
         sum_gpu_bench("sum_local", gpu_data, reference_sum, n, wg_size, grid_size);
-        wg_size = 256;
+        wg_size = 128;
         grid_size = wg_size * cu_count * wave_slots_per_simd;
         sum_gpu_bench("sum_tree", gpu_data, reference_sum, n, wg_size, grid_size);
     }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,14 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include <libutils/timer.h>
 
+#include "cl/sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -14,17 +17,39 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+void sum_gpu_bench(const std::string &kernel_name, const gpu::gpu_mem_32u &gpu_data,
+                   unsigned int reference_sum, unsigned int n, unsigned wg_size, unsigned grid_size,
+                   int benchmark_iters = 10) {
+    ocl::Kernel sum_gpu(sum_kernel, sum_kernel_length, kernel_name);
+    sum_gpu.compile();
+    timer t;
+    for (int iter = 0; iter < benchmark_iters; ++iter) {
+        unsigned int sum = 0;
+        gpu::gpu_mem_32u gpu_sum;
+        gpu_sum.resizeN(1);
+        gpu_sum.writeN(&sum, 1);
 
-int main(int argc, char **argv)
-{
+        sum_gpu.exec(gpu::WorkSize(wg_size, grid_size),
+                     gpu_sum, gpu_data, n);
+
+        gpu_sum.readN(&sum, 1);
+        EXPECT_THE_SAME(reference_sum, sum, kernel_name + " result should be consistent!");
+        t.nextLap();
+    }
+    std::cout << kernel_name << ":     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << kernel_name << ":     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+}
+
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
         as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
+//        as[i] = (unsigned int)1;
         reference_sum += as[i];
     }
 
@@ -39,14 +64,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+:sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +79,35 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
-    {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    { ;
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        // 4 x wave32 on Navi3
+
+        unsigned wg_size = 32;
+        // on Navi3 doesn't return the number of CUs, but the number of SAs
+        unsigned cu_count = device.compute_units * 2;
+        unsigned wave_slots_per_simd = 16;
+
+        unsigned grid_size = wg_size * cu_count * wave_slots_per_simd;
+        gpu::gpu_mem_32u gpu_data;
+        gpu_data.resizeN(n);
+        gpu_data.writeN(as.data(), n);
+        sum_gpu_bench("sum_atomic", gpu_data, reference_sum, n, wg_size, grid_size);
+        sum_gpu_bench("sum_atomic_iter", gpu_data, reference_sum, n, wg_size, grid_size);
+        sum_gpu_bench("sum_atomic_coalesce", gpu_data, reference_sum, n, wg_size, grid_size);
+
+        wg_size = 128;
+        grid_size = wg_size * cu_count * wave_slots_per_simd;
+        sum_gpu_bench("sum_local", gpu_data, reference_sum, n, wg_size, grid_size);
+        wg_size = 256;
+        grid_size = wg_size * cu_count * wave_slots_per_simd;
+        sum_gpu_bench("sum_tree", gpu_data, reference_sum, n, wg_size, grid_size);
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод mandelbrot:</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1036). Free memory: 24497/24566 Mb
  Device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Using device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
CPU: 0.1365+-0.00951753 s
CPU: 73.2601 gflops
    Real iterations fraction: 56.09%
GPU: 0.001+-1.09865e-10 s
GPU: 10000 gflops
    Real iterations fraction: 56.09%
GPU vs CPU average results difference: 1.17447%
</pre>

</p></details>

<details><summary>Вывод Github CI mandelbrot:</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.96827+-0.0046509 s
CPU: 5.0806 gflops
    Real iterations fraction: 56.09%
GPU: 0.387879+-0.000476792 s
GPU: 25.7812 gflops
    Real iterations fraction: 56.09%
GPU vs CPU average results difference: 1.17447%
</pre>

</p></details>

<details><summary>Локальный вывод sum:</summary><p>

<pre>
CPU:     0.123+-0.00057735 s
CPU:     813.008 millions/s
CPU OMP: 0.0095+-0.0005 s
CPU OMP: 10526.3 millions/s
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1036). Free memory: 24497/24566 Mb
  Device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Using device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
sum_atomic:     0.0385+-0.0005 s
sum_atomic:     2597.4 millions/s
sum_atomic_iter:     0.002+-0 s
sum_atomic_iter:     50000 millions/s
sum_atomic_coalesce:     0.001+-0 s
sum_atomic_coalesce:     100000 millions/s
sum_local:     0.0005+-0.0005 s
sum_local:     200000 millions/s
sum_tree:     0.000666667+-0.000471405 s
sum_tree:     150000 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI sum:</summary><p>

<pre>
CPU:     0.0773157+-0.000180165 s
CPU:     1293.4 millions/s
CPU OMP: 0.0323535+-0.000287872 s
CPU OMP: 3090.86 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
sum_atomic:     2.02023+-0.00518811 s
sum_atomic:     49.4994 millions/s
sum_atomic_iter:     0.036043+-4.57857e-05 s
sum_atomic_iter:     2774.46 millions/s
sum_atomic_coalesce:     0.0274785+-0.000108275 s
sum_atomic_coalesce:     3639.21 millions/s
sum_local:     0.030136+-0.000211416 s
sum_local:     3318.29 millions/s
sum_tree:     0.0300992+-0.000115274 s
sum_tree:     3322.35 millions/s
</pre>

</p></details>

## Выводы
### Задача 2
Пришлось лезть в дизасм, чтобы понять почему наивная версия едет быстрее, оказалось, что компилятор не может нормально перемешать скалярные и векторные инструкции, чтобы нормально загрузить `v-pipe` и `s-pipe`. В итоге решил не мучаться и просто забить на каждом CU все waveslot'ы, ибо больше волн - больше вероятность того, что прокнет `v-pipe` и `s-pipe`  за один такт.

Также хакнул `break` в цикле, чтобы он не трогал лишний раз `exec` маску, где-то 5% процентов это выиграло, что приятно
### Задача 3
Тяжело писать нормальный `reduction` без интринсиков или inline assembly, так как на уровне волны можно по-человечески сложить через `swizzle`, а не сидеть полу или еще более мертвой волне на LDSе  

