### PR TITLE
Task03 Иван Васильев SPbU

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,42 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* results,
+                         unsigned int width, unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, unsigned int smoothing
+                         )
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    size_t i = get_global_id(0);
+    size_t j = get_global_id(1);
+    if ((i >= width) || (j >= height)) {
+        return;
+    }
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,124 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+#define VALUES_PER_WORKITEM 8
+#define WORKGROUP_SIZE 128
+
+__kernel void sum_baseline(__global const unsigned int* arr,
+                           __global unsigned int* sum,
+                           unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    if (gid >= n) {
+        return;
+    }
+    atomic_add(sum, arr[gid]);
+}
+
+__kernel void sum_looped(__global const unsigned int* arr,
+                           __global unsigned int* sum,
+                           unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = gid * VALUES_PER_WORKITEM + i;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+    atomic_add(sum, res);
+}
+
+__kernel void sum_looped_coalesced(__global const unsigned int* arr,
+                         __global unsigned int* sum,
+                         unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+    atomic_add(sum, res);
+}
+
+__kernel void sum_with_local(__global const unsigned int* arr,
+                                   __global unsigned int* sum,
+                                   unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = gid < n ? arr[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid > 0) {
+        return;
+    }
+    unsigned int res = 0;
+    for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+        res += buf[i];
+    }
+    atomic_add(sum, res);
+}
+
+__kernel void sum_tree(__global const unsigned int* arr,
+                             __global unsigned int* sum,
+                             unsigned int n)
+{
+    const unsigned int wid = get_group_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = gid < n ? arr[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues/2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}
+
+__kernel void sum_tree2(__global const unsigned int* arr,
+                       __global unsigned int* sum,
+                       unsigned int n)
+{
+    const unsigned int wid = get_group_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int gid = get_global_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+    buf[lid] = gid < n ? arr[gid] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues/2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        sum[wid] = buf[0];
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -90,8 +90,8 @@ int main(int argc, char **argv)
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
         size_t gflops = 1000*1000*1000;
-        std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "CPU:                                    " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "CPU:                                    " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
         double realIterationsFraction = 0.0;
         for (int j = 0; j < height; ++j) {
@@ -107,45 +107,80 @@ int main(int argc, char **argv)
 
 
 //    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f gpu_res_buffer;
+        gpu_res_buffer.resizeN(width * height);
+        unsigned int work_group_width = 8;
+        unsigned int work_group_height = 8;
+        unsigned int global_work_width = (width + work_group_width - 1) / work_group_width * work_group_width;
+        unsigned int global_work_height = (height + work_group_height - 1) / work_group_height * work_group_height;
+
+        float sizeY = sizeX * height / width;
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(work_group_width, work_group_height, global_work_width, global_work_height),
+                        gpu_res_buffer,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, 0);
+            t.nextLap();
+        }
+        gpu_res_buffer.readN(gpu_results.ptr(), width * height);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000*1000*1000;
+        std::cout << "GPU (without VRAM<->RAM transfer time): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU (without VRAM<->RAM transfer time): " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += cpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -193,7 +193,7 @@ int main(int argc, char **argv)
                     throw std::runtime_error("No actions made");
                 }
                 unsigned int sum = 0;
-                std::vector<unsigned int> sumv(n, 0);
+                std::vector<unsigned int> sumv(n1, 0);
                 tmp_gpu.readN(sumv.data(), n1);
                 for (unsigned int i = 0; i < n1; ++i) {
                     sum += sumv[i];

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,10 @@
 #include <libutils/misc.h>
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
@@ -13,6 +17,42 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
+
+void printStats(timer t, unsigned int n, std::string method) {
+    std::cout << method << std::endl;
+    std::cout << "  " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "  " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+}
+
+void runKernel(std::string kernel_name,
+               std::string method_name,
+               unsigned int n,
+               gpu::gpu_mem_32u* as_gpu,
+               unsigned int real_sum,
+               unsigned int work_group_size = 128,
+               unsigned int global_work_size = 0,
+               int benchmarkingIters = 10,
+               unsigned int sum_buffer_size = 1) {
+    ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+
+    if (global_work_size == 0) {
+        global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
+    }
+    gpu::gpu_mem_32u sum_gpu;
+    sum_gpu.resizeN(sum_buffer_size);
+    std::vector<unsigned int> zeroes(sum_buffer_size, 0);
+    unsigned int sum;
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        sum_gpu.writeN(zeroes.data(), sum_buffer_size);
+        kernel.exec(gpu::WorkSize(work_group_size, global_work_size),
+                    *as_gpu, sum_gpu, n);
+        sum_gpu.readN(&sum, 1);
+        EXPECT_THE_SAME(real_sum, sum, method_name + " result should be consistent!");
+        t.nextLap();
+    }
+    printStats(t, n, method_name);
+}
 
 
 int main(int argc, char **argv)
@@ -38,8 +78,7 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        printStats(t, n, "CPU");
     }
 
     {
@@ -53,12 +92,116 @@ int main(int argc, char **argv)
             EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
-        std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        printStats(t, n, "CPU OMP");
     }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        as_gpu.writeN(as.data(), n);
+        {
+            runKernel("sum_baseline",
+                      "GPU atomic add",
+                      n,
+                      &as_gpu,
+                      reference_sum
+            );
+        }
+
+        {
+            unsigned int values_per_workitem = 8;
+            unsigned int work_group_size = 128;
+            unsigned int global_work_size = (n + values_per_workitem) / values_per_workitem;
+            global_work_size = (global_work_size + work_group_size - 1) / work_group_size * work_group_size;
+            runKernel("sum_looped",
+                      "GPU loop",
+                      n,
+                      &as_gpu,
+                      reference_sum,
+                      work_group_size,
+                      global_work_size
+            );
+            runKernel("sum_looped_coalesced",
+                      "GPU coalesced loop",
+                      n,
+                      &as_gpu,
+                      reference_sum,
+                      work_group_size,
+                      global_work_size
+            );
+        }
+
+        {
+            runKernel("sum_with_local",
+                      "GPU local memory buffer",
+                      n,
+                      &as_gpu,
+                      reference_sum,
+                      128
+            );
+        }
+
+        {
+            runKernel("sum_tree",
+                      "GPU tree",
+                      n,
+                      &as_gpu,
+                      reference_sum
+            );
+        }
+
+        {
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_tree2");
+            unsigned int work_group_size = 128;
+            gpu::gpu_mem_32u sum_gpu;
+            gpu::gpu_mem_32u tmp_gpu;
+            sum_gpu.resizeN(n);
+            tmp_gpu.resizeN(n);
+            std::vector<unsigned int> zeroes(n, 0);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int n1 = n;
+                unsigned int c = 0;
+                while (n1 > 1) {
+                    unsigned int global_work_size = (n1 + work_group_size - 1) / work_group_size * work_group_size;
+                    if (c == 0) {
+                        kernel.exec(gpu::WorkSize(work_group_size, global_work_size),
+                                    as_gpu,
+                                    tmp_gpu,
+                                    n1);
+                    }
+                    else {
+                        kernel.exec(gpu::WorkSize(work_group_size, global_work_size),
+                                    tmp_gpu,
+                                    sum_gpu,
+                                    n1);
+                        std::swap(tmp_gpu, sum_gpu);
+                    }
+                    n1 = global_work_size / work_group_size;
+                    c++;
+                    if (c == 5) { // chance to stop earlier
+                        break;
+                    }
+                }
+                if (c == 0) {
+                    throw std::runtime_error("No actions made");
+                }
+                unsigned int sum = 0;
+                std::vector<unsigned int> sumv(n, 0);
+                tmp_gpu.readN(sumv.data(), n1);
+                for (unsigned int i = 0; i < n1; ++i) {
+                    sum += sumv[i];
+                }
+                EXPECT_THE_SAME(reference_sum, sum, "GPU multiple trees result should be consistent!");
+                t.nextLap();
+            }
+            printStats(t, n, "GPU multiple trees");
+        }
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод mandelbrot</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 630. Total memory: 6478 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
CPU:                                    0.573333+-0.0124454 s
CPU:                                    17.4419 GFlops
    Real iterations fraction: 56.2638%
GPU (without VRAM<->RAM transfer time): 0.003+-4.1159e-11 s
GPU (without VRAM<->RAM transfer time): 3333.33 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

<details><summary>Вывод Github CI mandelbrot</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU:                                    1.54835+-0.000725591 s
CPU:                                    6.45848 GFlops
    Real iterations fraction: 56.2638%
GPU (without VRAM<->RAM transfer time): 0.107042+-0.000171817 s
GPU (without VRAM<->RAM transfer time): 93.4216 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>



<details><summary>Локальный вывод sum</summary><p>

<pre>
CPU
  0.322167+-0.00146249 s
  310.398 millions/s
CPU OMP
  0.0916667+-0.0020548 s
  1090.91 millions/s
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 630. Total memory: 6478 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
GPU atomic add
  0.003+-4.1159e-11 s
  33333.3 millions/s
GPU loop
  0.002+-0 s
  50000 millions/s
GPU coalesced loop
  0.00166667+-0.000471405 s
  60000 millions/s
GPU local memory buffer
  0.00366667+-0.000471405 s
  27272.7 millions/s
GPU tree
  0.006+-8.23181e-11 s
  16666.7 millions/s
GPU multiple trees
  0.147333+-0.00188562 s
  678.733 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI sum</summary><p>

<pre>
CPU
  0.0734068+-7.4127e-05 s
  1362.27 millions/s
CPU OMP
  0.0322252+-0.000402452 s
  3103.16 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU atomic add
  1.62804+-0.0114259 s
  61.4235 millions/s
GPU loop
  0.262504+-0.000361356 s
  380.946 millions/s
GPU coalesced loop
  0.195099+-0.000519139 s
  512.561 millions/s
GPU local memory buffer
  0.0642718+-0.000119339 s
  1555.89 millions/s
GPU tree
  0.168819+-0.000483176 s
  592.352 millions/s
GPU multiple trees
  0.289272+-0.000486834 s
  345.695 millions/s
</pre>

</p></details>

### 3.2.6
Создание цикла для каждого юнита при адекватных нагрузках работало лучше, как мы и обсуждали, так как, несмотря на увеличение операций, становилось меньше `atomic_add`'ов. Если ставить совсем маленький цикл (в частности, 1), то выходит почти (или буквально) ухудшенная версия первого кернела. При больших циклах второй подход начинает работать хуже (судя по всему, дело в обращениям к глобальной памяти). Подход с coalesced доступом в цикле работает стабильно лучше предыдущего (что понятно), но при очень большом числе операций в цикле начинает работать медленнее. У меня до ~10_000 значений на воркайтем все работало как и при  условных 8 значениях, но при увеличении до ~100_000 всё сильно падало. Как написано [тут](https://www.techpowerup.com/gpu-specs/geforce-gtx-1660-ti.c3364), у меня 1536 cores, при n = 100 * 1000 * 1000 нет шансов, что все всё время будут делать что-то полезное при 100 * 1000 значениях на воркайтем. Результат по времени суммирования с локальной памятью и главным потоком получился не очень, видимо, скорость чтения из GPU RAM у меня достаточна высока (288.0 GB/s), чтобы ради всего одного использования копировать данные в локальную память, буду знать. Интересно, что на Github CI такой подход был хорош, видимо, чтение из RAM там настолько не быстрое, что выгоднее его провести так. К сожалению, подход с деревом вышел не очень хорошим, хуже первого. Тут сразу можно было предположить, что подход с несколькими запусками кернела с деревом выйдет ещё хуже, но я решил посмотреть, сильно ли. Сильно. Однако в случае Github CI все лучше относительно базового метода. Вот тут сложно понять причины (драйвера такие, или устройство, что `atomic_add` в разной степени "плох"), но можно принять факт.