### PR TITLE
Task03 Юлиана Шахвалиева HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,49 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float *results,
+                         unsigned int width,
+                         unsigned int height,
+                         float fromX, float fromY,
+                         float sizeX, float sizeY,
+                         unsigned int iters, int smoothing)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    if (j >= height || i >= width)
+        return;
+
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }
+

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,109 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+
+__kernel void sum1_baseline_atomic_add(__global const unsigned int *arr,
+                                      __global unsigned int *sum,
+                                      unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n) {
+        return;
+    }
+
+    atomic_add(sum, arr[gid]);
+}
+
+
+__kernel void sum2_with_cycle(__global const unsigned int *arr,
+                             __global unsigned int *sum,
+                             unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+
+    int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int index = gid * VALUES_PER_WORKITEM + i;
+        if (index < n) {
+            res += arr[index];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+__kernel void sum3_with_cycle_coalesced(__global const unsigned int *arr,
+                                       __global unsigned int *sum,
+                                       unsigned int n)
+{
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+    const unsigned int grs = get_local_size(0);
+
+    int res = 0;
+    for (int i = 0; i < VALUES_PER_WORKITEM; ++i) {
+        int idx = wid * grs * VALUES_PER_WORKITEM + i * grs + lid;
+        if (idx < n) {
+            res += arr[idx];
+        }
+    }
+
+    atomic_add(sum, res);
+}
+
+
+__kernel void sum4_local_mem_and_main_thread(__global const unsigned int *arr,
+                                        __global unsigned int *sum,
+                                        unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0) {
+        unsigned int group_res = 0;
+        for (unsigned int i = 0; i < WORKGROUP_SIZE; ++i) {
+            group_res += buf[i];
+        }
+        atomic_add(sum, group_res);
+    }
+}
+
+
+__kernel void sum5_with_tree(__global const unsigned int *arr,
+                             __global unsigned int *sum,
+                             unsigned int n)
+{
+    const unsigned int gid = get_global_id(0);
+    const unsigned int lid = get_local_id(0);
+    const unsigned int wid = get_group_id(0);
+
+    __local unsigned int buf[WORKGROUP_SIZE];
+
+    buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int nValues = WORKGROUP_SIZE; nValues > 1; nValues /= 2) {
+        if (2 * lid < nValues) {
+            unsigned int a = buf[lid];
+            unsigned int b = buf[lid + nValues / 2];
+            buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0) {
+        atomic_add(sum, buf[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -17,7 +17,7 @@ void mandelbrotCPU(float* results,
 {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
+
     #pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
@@ -106,44 +106,85 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
 
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
-    // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+        float sizeY = sizeX * height / width;
+
+        unsigned int groupSizeX = 16;
+        unsigned int workSizeX = (width + groupSizeX - 1) / groupSizeX * groupSizeX;
+
+        unsigned int groupSizeY = 16;
+        unsigned int workSizeY = (height + groupSizeY - 1) / groupSizeY * groupSizeY;
+        auto workSize = gpu::WorkSize(groupSizeX, groupSizeY, workSizeX, workSizeY);
+
+        gpu::gpu_mem_32f temp_result;
+        temp_result.resizeN(width * height);
+
+        {
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                kernel.exec(workSize, temp_result, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                            sizeX, sizeY, iterationsLimit, 0);
+                t.nextLap();
+            }
+            size_t flopsInLoop = 10;
+            size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+            size_t gflops = 1000 * 1000 * 1000;
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+            temp_result.readN(gpu_results.ptr(), width * height);
+
+            double realIterationsFraction = 0.0;
+            for (int j = 0; j < height; ++j) {
+                for (int i = 0; i < width; ++i) {
+                    realIterationsFraction += cpu_results.ptr()[j * width + i];
+                }
+            }
+            std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                      << std::endl;
+
+            renderToColor(cpu_results.ptr(), image.ptr(), width, height);
+            image.savePNG("mandelbrot_gpu.png");
+        }
+    }
+
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
+
+//     Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
+//     Кликами мышки можно смещать ракурс
+//     Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
 //    bool useGPU = false;
 //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,6 +1,17 @@
+#include "cl/sum_cl.h"
+#include "libgpu/context.h"
+#include "libgpu/shared_device_buffer.h"
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+#define WORKGROUP_SIZE 64
+#define VALUES_PER_WORKITEM 64
+
+const int benchmarkingIters = 10;
+unsigned int reference_sum = 0;
+const unsigned int n = 100*1000*1000;
+const unsigned int zero[] = {0};
+char defines[1000];
 
 
 template<typename T>
@@ -14,13 +25,41 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+void measure_time_gpu(gpu::gpu_mem_32u as_gpu, std::string method_name, unsigned int size)
+{
+
+    gpu::gpu_mem_32u result_gpu;
+    result_gpu.resizeN(1);
+
+    ocl::Kernel kernel(sum_kernel,
+                       sum_kernel_length,
+                       method_name,
+                       defines);
+
+    bool printLog = false;
+    kernel.compile(printLog);
+
+    unsigned int workSizeX = (size + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE * WORKGROUP_SIZE;
+    auto workSize = gpu::WorkSize(WORKGROUP_SIZE, workSizeX);
+
+    timer t;
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        result_gpu.writeN(zero, 1);
+        kernel.exec(workSize,as_gpu, result_gpu, n);
+
+        unsigned int sum = 0;
+        result_gpu.readN(&sum, 1);
+
+        EXPECT_THE_SAME(reference_sum, sum, "GPU " + method_name + " result should be consistent!");
+        t.nextLap();
+    }
+    std::cout << "GPU " + method_name + ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "GPU " + method_name + ": " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
+}
+
 
 int main(int argc, char **argv)
 {
-    int benchmarkingIters = 10;
-
-    unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,8 +78,10 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
     }
+            unsigned int global_work_size = (n + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE * WORKGROUP_SIZE;
+            timer t;
 
     {
         timer t;
@@ -54,11 +95,29 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl << std::endl;
     }
 
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Context context;
+         context.init(device.device_id_opencl);
+         context.activate();
+
+         gpu::gpu_mem_32u as_gpu;
+         as_gpu.resizeN(n);
+         as_gpu.writeN(as.data(), n);
+
+         sprintf(defines, "-D VALUES_PER_WORKITEM=%d -D WORKGROUP_SIZE=%d", VALUES_PER_WORKITEM, WORKGROUP_SIZE);
+
+
+         measure_time_gpu(as_gpu, "sum1_baseline_atomic_add", n);
+         auto temp = (n + VALUES_PER_WORKITEM - 1) / VALUES_PER_WORKITEM;
+         measure_time_gpu(as_gpu, "sum2_with_cycle", temp);
+         measure_time_gpu(as_gpu, "sum3_with_cycle_coalesced", temp);
+         measure_time_gpu(as_gpu, "sum4_local_mem_and_main_thread", n);
+         measure_time_gpu(as_gpu, "sum5_with_tree", n);
+
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод sum</summary><p>

<pre>
CPU:     0.261253+-0.00137017 s
CPU:     382.771 millions/s

CPU OMP: 0.0832528+-0.00376301 s
CPU OMP: 1201.16 millions/s

OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz. Intel(R) Corporation. Total memory: 15710 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1050. Total memory: 4040 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1050. Total memory: 4040 Mb
GPU sum1_baseline_atomic_add: 0.00842133+-1.19536e-05 s
GPU sum1_baseline_atomic_add: 11874.6 millions/s

GPU sum2_with_cycle: 0.0183665+-0.000700892 s
GPU sum2_with_cycle: 5444.7 millions/s

GPU sum3_with_cycle_coalesced: 0.00391333+-6.54896e-06 s
GPU sum3_with_cycle_coalesced: 25553.7 millions/s

GPU sum4_local_mem_and_main_thread: 0.0102308+-4.7052e-06 s
GPU sum4_local_mem_and_main_thread: 9774.37 millions/s

GPU sum5_with_tree: 0.0142205+-0.000457022 s
GPU sum5_with_tree: 7032.1 millions/s


Process finished with exit code 0
</pre>

</p></details>

<details><summary>Локальный вывод mandelbrot</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-7300HQ CPU @ 2.50GHz. Intel(R) Corporation. Total memory: 15710 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1050. Total memory: 4040 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1050. Total memory: 4040 Mb
CPU: 1.24077+-0.0312487 s
CPU: 8.05954 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0139722+-4.37851e-05 s
GPU: 715.709 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI sum</summary><p>

<pre>
CPU:     0.064586+-0.000309703 s
CPU:     1548.32 millions/s

CPU OMP: 0.0272323+-0.00010938 s
CPU OMP: 3672.11 millions/s

OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU sum1_baseline_atomic_add: 1.66992+-0.00862323 s
GPU sum1_baseline_atomic_add: 59.8833 millions/s

GPU sum2_with_cycle: 0.0828658+-3.58907e-05 s
GPU sum2_with_cycle: 1206.77 millions/s

GPU sum3_with_cycle_coalesced: 0.0362995+-7.97679e-05 s
GPU sum3_with_cycle_coalesced: 2754.86 millions/s

GPU sum4_local_mem_and_main_thread: 0.0792885+-9.32787e-05 s
GPU sum4_local_mem_and_main_thread: 1261.22 millions/s

GPU sum5_with_tree: 0.198291+-0.000301444 s
GPU sum5_with_tree: 504.31 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI mandelbrot</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
CPU: 1.55937+-0.00598649 s
CPU: 6.41286 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.111667+-0.000253143 s
GPU: 89.5517 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0.942446%
</pre>

</p></details>

Cамым быстрым методом на обоих платформах оказался метод суммирования с циклом и coalesced доступом (3.2.3). При чем отрыв от ближайших соперников был значительным в обоих случаях. Наблюдается интересная картина с бейзлайновым методом с атомарным добавлением (3.2.1): кажется, что этот метод самый простой, без какой бы то ни было оптимизации, тем не менее он занимает второе место по скорости в локальном выводе. Тем не менее на Github CI описываемый метод ожидаемо занимает последнюю позицию. Похожая ситуация и с суммированием с циклом (3.2.2): локально этот способ показал наихудший результат, а на Github CI он занял в второе место. 

В общем и целом, можно сделать вывод о том, что скорость сильно зависит не только от способа вычислений, но и от железа их производящего.
