### PR TITLE
Task04 Скальт Альберт SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,94 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+__kernel void baseline(__global const float *a, __global const float *b, __global float *c, unsigned N, unsigned M,
+                       unsigned K) {
+    const int i = get_global_id(1);
+    const int j = get_global_id(0);
+
+    float sum = 0.0;
+    for (int k = 0; k < M; ++k) {
+        sum += a[i * M + k] * b[k * K + j];
+    }
+
+    c[i * K + j] = sum;
+}
+
+#define TILE_SIZE 16
+
+__kernel void local_mem(__global const float *a, __global const float *b, __global float *c, unsigned N, unsigned M,
+                        unsigned K) {
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    const int i = get_global_id(1);
+    const int j = get_global_id(0);
+
+    const int li = get_local_id(1);
+    const int lj = get_local_id(0);
+
+    const int gi = get_group_id(1);
+    const int gj = get_group_id(0);
+
+    float sum = 0.0;
+    for (int block = 0; block * TILE_SIZE < M; ++block) {
+        tileA[li][lj] = a[(gi * TILE_SIZE + li) * M + (block * TILE_SIZE + lj)];
+        tileB[li][lj] = b[(block * TILE_SIZE + li) * M + (gj * TILE_SIZE + lj)];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[li][k] * tileB[k][lj];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    c[i * K + j] = sum;
+}
+
+__kernel void local_mem_more_work(__global const float *a, __global const float *b, __global float *c, unsigned N,
+                                  unsigned M, unsigned K) {
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    // Always 0.
+    const int li = get_local_id(1);
+    // [0..TILE_SIZE - 1].
+    const int lj = get_local_id(0);
+
+    const int gi = get_group_id(1);
+    const int gj = get_group_id(0);
+
+    // Каждый поток считает свой столбец.
+    float sum[TILE_SIZE];
+    for (int i = 0; i < TILE_SIZE; ++i)
+        sum[i] = 0.0;
+
+    for (int block = 0; block * TILE_SIZE < M; ++block) {
+        for (int row = 0; row < TILE_SIZE; ++row) {
+            tileA[row][lj] = a[(gi * TILE_SIZE + row) * M + (block * TILE_SIZE + lj)];
+            tileB[row][lj] = b[(block * TILE_SIZE + row) * M + (gj * TILE_SIZE + lj)];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int rowInB = 0; rowInB < TILE_SIZE; ++rowInB) {
+            float coef = tileB[rowInB][lj];
+            for (int rowInA = 0; rowInA < TILE_SIZE; ++rowInA) {
+                sum[rowInA] += tileA[rowInA][rowInB] * coef;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    // Синхронно пишем в ответ по строкам, каждый пишет в одну и ту же строчку.
+    for (int row = 0; row < TILE_SIZE; ++row) {
+        c[(gi*TILE_SIZE+row)*K+(gj*TILE_SIZE+lj)] = sum[row];
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,30 @@
-__kernel void matrix_transpose(...)
-{
-    // TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose(__global const float *a, __global float *res, unsigned m, unsigned k) {
+    const int i = get_global_id(1);
+    const int j = get_global_id(0);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    const int li = get_local_id(1);
+    const int lj = get_local_id(0);
+
+    // Считываем в столбец.
+    tile[lj][li] = a[i * k + j];
+
+    // Дожидаемся остальных.
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int gi = get_group_id(1);
+    const int gj = get_group_id(0);
+
+    // Записываем элемент строки в нужную позицию.
+    res[gj * TILE_SIZE * m + gi * TILE_SIZE + li * m + lj] = tile[li][lj];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -1,35 +1,36 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_multiplication_cl.h"
 
-#include <vector>
+#include <cassert>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
+    int benchmarkingIters = 10;// TODO пока тестируетесь удобно выставить единицу
     unsigned int M = 1024;
     unsigned int K = 1024;
     unsigned int N = 1024;
-    const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
+    const size_t gflops =
+            ((size_t) M * K * N * 2) / (1000 * 1000 * 1000);// умножить на два, т.к. операция сложения и умножения
 
-    std::vector<float> as(M*K, 0);
-    std::vector<float> bs(K*N, 0);
-    std::vector<float> cs(M*N, 0);
+    std::vector<float> as(M * K, 0);
+    std::vector<float> bs(K * N, 0);
+    std::vector<float> cs(M * N, 0);
 
-    FastRandom r(M+K+N);
+    FastRandom r(M + K + N);
     for (unsigned int i = 0; i < as.size(); ++i) {
         as[i] = r.nextf();
     }
@@ -58,34 +59,62 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
+
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
+    as_gpu.resizeN(M * K);
+    bs_gpu.resizeN(K * N);
+    cs_gpu.resizeN(M * N);
 
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
+    as_gpu.writeN(as.data(), M * K);
+    bs_gpu.writeN(bs.data(), K * N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
+    auto check_diff = [&N](const std::vector<float> &a, const std::vector<float> &b) {
+        float diff_sum = 0;
+        for (int i = 0; i < a.size(); ++i) {
+            if (a[i] != 0.0 || b[i] != 0.0)
+                diff_sum += fabs(a[i] - b[i]) / std::max(fabs(a[i]), fabs(b[i]));
+        }
+        double diff_avg = diff_sum / a.size();
+        assert(diff_avg < 0.01);
+    };
 
-    {
+    for (const auto &kernel_name : std::vector<std::string>{"baseline", "local_mem"}) {
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, kernel_name);
+        matrix_multiplication_kernel.compile();
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+            unsigned int work_group_size = 16;
+            auto sz = gpu::WorkSize(work_group_size, work_group_size, M, M);
+            matrix_multiplication_kernel.exec(sz, as_gpu, bs_gpu, cs_gpu, M, K, N);
 
             t.nextLap();
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "GPU[" << kernel_name << "]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU[" << kernel_name << "]: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        cs_gpu.readN(cs.data(), M * N);
+        check_diff(cs, cs_cpu_reference);
     }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+    {
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "local_mem_more_work");
+        matrix_multiplication_kernel.compile();
+
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int work_group_size = 16;
+            auto sz = gpu::WorkSize(work_group_size, 1, M, M / work_group_size);
+            matrix_multiplication_kernel.exec(sz, as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+            t.nextLap();
+        }
+        std::cout << "GPU[local_mem_more_work]: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU[local_mem_more_work]: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        cs_gpu.readN(cs.data(), M * N);
+        check_diff(cs, cs_cpu_reference);
+    }
 
     // Проверяем корректность результатов
     double diff_sum = 0;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
+
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -45,15 +45,17 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 16;
+            // В данной задачи M делится на work_group_size, поэтому запишем по-простому.
+            unsigned int global_work_size = M;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+
+            auto sz = gpu::WorkSize(work_group_size, work_group_size, global_work_size, global_work_size);
+            matrix_transpose_kernel.exec(sz, as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +76,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
### Транспонирование
#### Локально
```
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Data generated for M=1024, K=1024
GPU: 9.81667e-05+-7.31247e-06 s
GPU: 10681.6 millions/s
```
#### CI
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 83[7](https://github.com/GPGPUCourse/GPGPUTasks2023/pull/172/checks#step:7:8)0C CPU @ 2.[8](https://github.com/GPGPUCourse/GPGPUTasks2023/pull/172/checks#step:7:9)0GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024
GPU: 0.001367+-0.000137431 s
GPU: 767.064 millions/s
```

### Перемножение
#### Локально
```
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.54181+-0.0274041 s
CPU: 0.305726 GFlops
GPU[baseline]: 0.0191493+-0.000103786 s
GPU[baseline]: 104.442 GFlops
GPU[local_mem]: 0.0117587+-8.89282e-05 s
GPU[local_mem]: 170.087 GFlops
GPU[local_mem_more_work]: 0.00694467+-5.00189e-05 s
GPU[local_mem_more_work]: 287.991 GFlops
Average difference: 0.000149043%
```

#### CI
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.81932+-0.00221452 s
CPU: 0.523653 GFlops
GPU[baseline]: 0.100367+-0.00120585 s
GPU[baseline]: 19.9269 GFlops
GPU[local_mem]: 0.136076+-0.000663577 s
GPU[local_mem]: 14.6977 GFlops
GPU[local_mem_more_work]: 0.121351+-0.000170043 s
GPU[local_mem_more_work]: 16.4811 GFlops
Average difference: 0.000149043%
```

Лучшей оказалась третья реализация. Это означает, что несмотря на то, что при переходе от второй к третьей мы уменьшили параллелизацию (теперь каждый поток делает в TILE_SIZE больше последовательной работы), нас сильно ускорило уменьшение подгрузок данных из локальной памяти.