### PR TITLE
Task04 Игорь Логинов SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,160 @@
-__kernel void matrix_multiplication(...)
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define GROUP_SIZE 16
+#define THREAD_WORK 8
+#define matrix(as, i, j, n, m) as[(i) * (m) + (j)]
+#define matrixSafeGet(as, i, j, n, m) ((i) < (n) && (j) < (m) ? as[(i) * (m) + (j)] : 0.0f)
+
+__kernel void matrix_multiplication_more_work_per_thread(__global const float * as,
+                                                         __global const float * bs,
+                                                         __global float * cs,
+                                                         const unsigned int m,
+                                                         const unsigned int k,
+                                                         const unsigned int n)
 {
-    // TODO
+    unsigned int gi = get_group_id(1);
+    unsigned int gj = get_group_id(0);
+    unsigned int li = get_local_id(1);
+    unsigned int lj = get_local_id(0);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[GROUP_SIZE][GROUP_SIZE * THREAD_WORK];
+
+    float sum[THREAD_WORK];
+    for (int t = 0; t < THREAD_WORK; t++) sum[t] = 0.0f;
+
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[li][lj] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        for (int s = 0; s < THREAD_WORK; s++)
+        {
+            bs_local[li][lj * THREAD_WORK + s] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, k, n);
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int tt = 0; tt < GROUP_SIZE; tt++)
+        {
+            float tmp = as_local[li][tt];
+            for (int s = 0; s < THREAD_WORK; s++)
+            {
+                sum[s] += tmp * bs_local[tt][lj * THREAD_WORK + s];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int s = 0; s < THREAD_WORK; s++)
+    {
+        if (gi * GROUP_SIZE + li < m && gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s < n)
+        {
+            matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, m, n) = sum[s];
+        }
+    }
+}
+
+__kernel void matrix_multiplication_local_mem_coalesced(__global const float * as,
+                                                        __global const float * bs,
+                                                        __global float * cs,
+                                                        const unsigned int m,
+                                                        const unsigned int k,
+                                                        const unsigned int n)
+{
+    unsigned int gi = get_group_id(1);
+    unsigned int gj = get_group_id(0);
+    unsigned int li = get_local_id(1);
+    unsigned int lj = get_local_id(0);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[GROUP_SIZE][GROUP_SIZE];
+    float sum = 0;
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[li][lj] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        bs_local[lj][li] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE + lj, k, n);
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int tt = 0; tt < GROUP_SIZE; tt++)
+        {
+            sum += as_local[li][tt] * bs_local[lj][tt];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (gi * GROUP_SIZE + li >= m || gj * GROUP_SIZE + lj >= n) return;
+    matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE + lj, m, n) = sum;
+}
+
+__kernel void matrix_multiplication_local_mem_not_coalesced(__global const float * as,
+                                                            __global const float * bs,
+                                                            __global float * cs,
+                                                            const unsigned int m,
+                                                            const unsigned int k,
+                                                            const unsigned int n)
+{
+    unsigned int gi = get_group_id(0);
+    unsigned int gj = get_group_id(1);
+    unsigned int li = get_local_id(0);
+    unsigned int lj = get_local_id(1);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[GROUP_SIZE][GROUP_SIZE];
+    float sum = 0;
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[li][lj] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        bs_local[li][lj] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE + lj, k, n);
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int tt = 0; tt < GROUP_SIZE; tt++)
+        {
+            sum += as_local[li][tt] * bs_local[tt][lj];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (gi * GROUP_SIZE + li >= m || gj * GROUP_SIZE + lj >= n) return;
+    matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE + lj, m, n) = sum;
+}
+
+__kernel void matrix_multiplication_naive(__global const float * as,
+                                          __global const float * bs,
+                                          __global float * cs,
+                                          const unsigned int m,
+                                          const unsigned int k,
+                                          const unsigned int n)
+{
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= m || j >= n) return;
+
+    float sum = 0;
+    for (unsigned int t = 0; t < k; t++)
+    {
+        sum += matrix(as, i, t, m, k) * matrix(bs, t, j, k, n);
+    }
+    matrix(cs, i, j, m, n) = sum;
+}
+
+__kernel void matrix_multiplication_naive0(__global const float * as,
+                                           __global const float * bs,
+                                           __global float * cs,
+                                           const unsigned int m,
+                                           const unsigned int k,
+                                           const unsigned int n)
+{
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    if (i >= m || j >= n) return;
+
+    matrix(cs, i, j, m, n) = 0;
+    for (unsigned int t = 0; t < k; t++)
+    {
+        matrix(cs, i, j, m, n) += matrix(as, i, t, m, k) * matrix(bs, t, j, k, n);
+    }
 }

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -9,6 +9,99 @@
 #define matrix(as, i, j, n, m) as[(i) * (m) + (j)]
 #define matrixSafeGet(as, i, j, n, m) ((i) < (n) && (j) < (m) ? as[(i) * (m) + (j)] : 0.0f)
 
+__kernel void matrix_multiplication_more_work_per_thread3(__global const float * as,
+                                                          __global const float * bs,
+                                                          __global float * cs,
+                                                          const unsigned int m,
+                                                          const unsigned int k,
+                                                          const unsigned int n)
+{
+    unsigned int gi = get_group_id(1);
+    unsigned int gj = get_group_id(0);
+    unsigned int li = get_local_id(1);
+    unsigned int lj = get_local_id(0);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[GROUP_SIZE][THREAD_WORK][GROUP_SIZE];
+
+    float sum[THREAD_WORK];
+    for (int t = 0; t < THREAD_WORK; t++) sum[t] = 0.0f;
+
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[lj][li] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        for (int s = 0; s < THREAD_WORK; s++)
+        {
+            bs_local[li][s][lj] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, k, n);
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int tt = 0; tt < GROUP_SIZE; tt++)
+        {
+            float tmp = as_local[tt][li];
+            for (int s = 0; s < THREAD_WORK; s++)
+            {
+                sum[s] += tmp * bs_local[tt][s][lj];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int s = 0; s < THREAD_WORK; s++)
+    {
+        if (gi * GROUP_SIZE + li < m && gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s < n)
+        {
+            matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, m, n) = sum[s];
+        }
+    }
+}
+
+__kernel void matrix_multiplication_more_work_per_thread2(__global const float * as,
+                                                         __global const float * bs,
+                                                         __global float * cs,
+                                                         const unsigned int m,
+                                                         const unsigned int k,
+                                                         const unsigned int n)
+{
+    unsigned int gi = get_group_id(1);
+    unsigned int gj = get_group_id(0);
+    unsigned int li = get_local_id(1);
+    unsigned int lj = get_local_id(0);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[THREAD_WORK][GROUP_SIZE][GROUP_SIZE];
+
+    float sum[THREAD_WORK];
+    for (int t = 0; t < THREAD_WORK; t++) sum[t] = 0.0f;
+
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[li][lj] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        for (int s = 0; s < THREAD_WORK; s++)
+        {
+            bs_local[s][li][lj] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, k, n);
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int s = 0; s < THREAD_WORK; s++)
+        {
+            for (int tt = 0; tt < GROUP_SIZE; tt++)
+            {
+                sum[s] += as_local[li][tt] * bs_local[s][tt][lj];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int s = 0; s < THREAD_WORK; s++)
+    {
+        if (gi * GROUP_SIZE + li < m && gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s < n)
+        {
+            matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, m, n) = sum[s];
+        }
+    }
+}
+
 __kernel void matrix_multiplication_more_work_per_thread(__global const float * as,
                                                          __global const float * bs,
                                                          __global float * cs,
@@ -54,6 +147,38 @@ __kernel void matrix_multiplication_more_work_per_thread(__global const float * 
             matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE * THREAD_WORK + lj * THREAD_WORK + s, m, n) = sum[s];
         }
     }
+}
+
+__kernel void matrix_multiplication_local_mem_coalesced2(__global const float * as,
+                                                        __global const float * bs,
+                                                        __global float * cs,
+                                                        const unsigned int m,
+                                                        const unsigned int k,
+                                                        const unsigned int n)
+{
+    unsigned int gi = get_group_id(1);
+    unsigned int gj = get_group_id(0);
+    unsigned int li = get_local_id(1);
+    unsigned int lj = get_local_id(0);
+
+    __local float as_local[GROUP_SIZE][GROUP_SIZE];
+    __local float bs_local[GROUP_SIZE][GROUP_SIZE];
+    float sum = 0;
+    for (int t = 0; t < k; t += GROUP_SIZE)
+    {
+        as_local[lj][li] = matrixSafeGet(as, gi * GROUP_SIZE + li, t + lj, m, k);
+        bs_local[li][lj] = matrixSafeGet(bs, t + li, gj * GROUP_SIZE + lj, k, n);
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int tt = 0; tt < GROUP_SIZE; tt++)
+        {
+            sum += as_local[tt][li] * bs_local[tt][lj];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (gi * GROUP_SIZE + li >= m || gj * GROUP_SIZE + lj >= n) return;
+    matrix(cs, gi * GROUP_SIZE + li, gj * GROUP_SIZE + lj, m, n) = sum;
 }
 
 __kernel void matrix_multiplication_local_mem_coalesced(__global const float * as,

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,74 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define GROUP_SIZE 16
+
+__kernel void matrix_transpose(__global const float * as,
+                               __global float * as_t,
+                               const unsigned int m,
+                               const unsigned int k)
 {
-    // TODO
+    int li = get_local_id(1);
+    int lj = get_local_id(0);
+    int gi = get_group_id(1);
+    int gj = get_group_id(0);
+
+    __local float tmp[GROUP_SIZE][GROUP_SIZE];
+    int i = gi * GROUP_SIZE + li;
+    int j = gj * GROUP_SIZE + lj;
+    if (i < m && j < k)
+    {
+        tmp[lj][li] = as[i * k + j];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    i = gj * GROUP_SIZE + li;
+    j = gi * GROUP_SIZE + lj;
+    if (i < k && j < m)
+    {
+        as_t[i * m + j] = tmp[li][lj];
+    }
+}
+
+__kernel void matrix_transpose_not_coalesced(__global const float * as,
+                                             __global float * as_t,
+                                             const unsigned int m,
+                                             const unsigned int k)
+{
+    int li = get_local_id(0);
+    int lj = get_local_id(1);
+    int gi = get_group_id(0);
+    int gj = get_group_id(1);
+
+    __local float tmp[GROUP_SIZE][GROUP_SIZE];
+    int i = gi * GROUP_SIZE + li;
+    int j = gj * GROUP_SIZE + lj;
+    if (i < m && j < k)
+    {
+        tmp[lj][li] = as[i * k + j];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    i = gj * GROUP_SIZE + li;
+    j = gi * GROUP_SIZE + lj;
+    if (i < k && j < m)
+    {
+        as_t[i * m + j] = tmp[li][lj];
+    }
+}
+
+__kernel void matrix_transpose_naive(__global const float * as,
+                                     __global float * as_t,
+                                     const unsigned int m,
+                                     const unsigned int k)
+{
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    if (i < m && j < k)
+    {
+        as_t[j * m + i] = as[i * k + j];
+    }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 1; // TODO пока тестируетесь удобно выставить единицу
+    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
     bool skipCPUBenchmarking = true;
     unsigned int M = 1024;
     unsigned int K = 1025;

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -19,8 +19,8 @@ int main(int argc, char **argv)
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
-    bool skipCPUBenchmarking = false;
+    int benchmarkingIters = 1; // TODO пока тестируетесь удобно выставить единицу
+    bool skipCPUBenchmarking = true;
     unsigned int M = 1024;
     unsigned int K = 1025;
     unsigned int N = 1023;
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
         {
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                unsigned int work_group_size = 16;
+                unsigned int work_group_size = 8;
                 unsigned int work_per_thread = 8;
                 unsigned int global_work_sizeX = (M + work_group_size - 1) / work_group_size * work_group_size;
                 unsigned int global_work_sizeY = (N + work_group_size - 1) / work_group_size * work_group_size;

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
-    bool skipCPUBenchmarking = false;
+    bool skipCPUBenchmarking = true;
     unsigned int M = 1024;
     unsigned int K = 1025;
     unsigned int N = 1023;
@@ -75,7 +75,10 @@ int main(int argc, char **argv)
                 "matrix_multiplication_naive",
                 "matrix_multiplication_local_mem_not_coalesced",
                 "matrix_multiplication_local_mem_coalesced",
-                "matrix_multiplication_more_work_per_thread"
+                "matrix_multiplication_more_work_per_thread",
+                "matrix_multiplication_local_mem_coalesced2",
+                "matrix_multiplication_more_work_per_thread2",
+                "matrix_multiplication_more_work_per_thread3"
         };
         std::string kernel_name = kernels[kernel_name_id];
         ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
@@ -90,9 +93,9 @@ int main(int argc, char **argv)
                 unsigned int global_work_sizeX = (M + work_group_size - 1) / work_group_size * work_group_size;
                 unsigned int global_work_sizeY = (N + work_group_size - 1) / work_group_size * work_group_size;
 
-                if (kernel_name == kernels[3])
+                if (kernel_name_id >= 3)
                     std::swap(global_work_sizeX, global_work_sizeY);
-                if (kernel_name == kernels[4])
+                if (kernel_name_id == 4 || kernel_name_id == 6 || kernel_name_id == 7)
                     global_work_sizeX = (N + work_per_thread * work_group_size - 1) / (work_per_thread * work_group_size) * work_group_size;
 
                 matrix_multiplication_kernel.exec(
@@ -133,6 +136,9 @@ int main(int argc, char **argv)
     benchmarkKernel(2);
     benchmarkKernel(3);
     benchmarkKernel(4);
+    benchmarkKernel(5);
+    benchmarkKernel(6);
+    benchmarkKernel(7);
 
     return 0;
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -20,9 +20,10 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
+    bool skipCPUBenchmarking = true;
     unsigned int M = 1024;
-    unsigned int K = 1024;
-    unsigned int N = 1024;
+    unsigned int K = 1025;
+    unsigned int N = 1023;
     const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
 
     std::vector<float> as(M*K, 0);
@@ -40,7 +41,7 @@ int main(int argc, char **argv)
 
     {
         timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        for (int iter = 0; iter < benchmarkingIters && (!skipCPUBenchmarking || iter < 1); ++iter) {
             for (int j = 0; j < M; ++j) {
                 for (int i = 0; i < N; ++i) {
                     float sum = 0.0f;
@@ -54,56 +55,84 @@ int main(int argc, char **argv)
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << std::endl;
     }
 
-    const std::vector<float> cs_cpu_reference = cs;
-
-    /*
-    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
-
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
-
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
-
+    auto benchmarkKernel = [&](int kernel_name_id)
     {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+        const std::vector<float> cs_cpu_reference = cs;
 
-            t.nextLap();
+        gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
+        as_gpu.resizeN(M * K);
+        bs_gpu.resizeN(K * N);
+        cs_gpu.resizeN(M * N);
+
+        as_gpu.writeN(as.data(), M * K);
+        bs_gpu.writeN(bs.data(), K * N);
+
+        std::vector<std::string> kernels = {
+                "matrix_multiplication_naive0",
+                "matrix_multiplication_naive",
+                "matrix_multiplication_local_mem_not_coalesced",
+                "matrix_multiplication_local_mem_coalesced",
+                "matrix_multiplication_more_work_per_thread"
+        };
+        std::string kernel_name = kernels[kernel_name_id];
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                 kernel_name);
+        matrix_multiplication_kernel.compile();
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                unsigned int work_group_size = 16;
+                unsigned int work_per_thread = 8;
+                unsigned int global_work_sizeX = (M + work_group_size - 1) / work_group_size * work_group_size;
+                unsigned int global_work_sizeY = (N + work_group_size - 1) / work_group_size * work_group_size;
+
+                if (kernel_name == kernels[3])
+                    std::swap(global_work_sizeX, global_work_sizeY);
+                if (kernel_name == kernels[4])
+                    global_work_sizeX = (N + work_per_thread * work_group_size - 1) / (work_per_thread * work_group_size) * work_group_size;
+
+                matrix_multiplication_kernel.exec(
+                        gpu::WorkSize(work_group_size, work_group_size, global_work_sizeX, global_work_sizeY),
+                        as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+                t.nextLap();
+            }
+            std::cout << "Kernel: " << kernels[kernel_name_id] << std::endl;
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+        cs_gpu.readN(cs.data(), M * N);
 
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        // Проверяем корректность результатов
+        double diff_sum = 0;
+        for (int i = 0; i < M * N; ++i) {
+            double a = cs[i];
+            double b = cs_cpu_reference[i];
+            if (a != 0.0 || b != 0.0) {
+                double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+                diff_sum += diff;
+            }
         }
-    }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
-    }
+        double diff_avg = diff_sum / (M * N);
+        std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+        if (diff_avg > 0.01) {
+            std::cerr << "Too big difference!" << std::endl;
+            exit(1);
+        }
+        std::cout << std::endl;
+    };
+
+    benchmarkKernel(0);
+    benchmarkKernel(1);
+    benchmarkKernel(2);
+    benchmarkKernel(3);
+    benchmarkKernel(4);
 
     return 0;
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -20,7 +20,7 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
-    bool skipCPUBenchmarking = true;
+    bool skipCPUBenchmarking = false;
     unsigned int M = 1024;
     unsigned int K = 1025;
     unsigned int N = 1023;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -20,8 +20,8 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10;
-    unsigned int M = 1024;
-    unsigned int K = 1024;
+    unsigned int M = 10241;
+    unsigned int K = 5008;
 
     std::vector<float> as(M*K, 0);
     std::vector<float> as_t(M*K, 0);
@@ -32,28 +32,37 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
 
     as_gpu.writeN(as.data(), M*K);
 
-    ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose");
-    matrix_transpose_kernel.compile();
+    std::vector<std::string> kernels = {
+            "matrix_transpose",
+            "matrix_transpose_not_coalesced",
+            "matrix_transpose_naive"
+    };
+    std::string kernel_name = kernels[0];
+    ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, kernel_name);
+    matrix_transpose_kernel.compile(false);
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 16;
+            unsigned int global_work_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+            unsigned int global_work_size_y = (K + work_group_size - 1) / work_group_size * work_group_size;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+
+            if (kernel_name != kernels[1])
+                std::swap(global_work_size_x, global_work_size_y);
+            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, global_work_size_x, global_work_size_y),
+                                         as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +83,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
Транспонирование матрицы:

<details><summary>Локальный вывод (CPU)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Using device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
Data generated for M=10241, K=5008
GPU: 0.045+-6.58545e-10 s
GPU: 1139.71 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод (GPU)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Using device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Data generated for M=10241, K=5008
GPU: 0.0365+-0.0005 s
GPU: 1405.12 millions/s
</pre>

</p></details>

<details><summary>GitHub CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=10241, K=5008
GPU: 0.198362+-0.00113175 s
GPU: 258.552 millions/s
</pre>

</p></details>

Умножение матриц:

<details><summary>Локальный вывод (CPU)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Using device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
Data generated for M=1024, K=1025, N=1023
CPU: 7.05467+-0.0102089 s
CPU: 0.2835 GFlops

Kernel: matrix_multiplication_naive0
GPU: 0.2345+-0.00197906 s
GPU: 8.52878 GFlops
Average difference: 0.00019131%

Kernel: matrix_multiplication_naive
GPU: 0.108+-0.0011547 s
GPU: 18.5185 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_not_coalesced
GPU: 0.129667+-0.000471405 s
GPU: 15.4242 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_coalesced
GPU: 0.136833+-0.000687184 s
GPU: 14.6163 GFlops
Average difference: 0%

Kernel: matrix_multiplication_more_work_per_thread
GPU: 0.1185+-0.0005 s
GPU: 16.8776 GFlops
Average difference: 0%
</pre>

</p></details>

<details><summary>Локальный вывод (GPU)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 3 4300G with Radeon Graphics. Intel(R) Corporation. Total memory: 15748 Mb
  Device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Using device #1: GPU. AMD Radeon(TM) Graphics (gfx90c). Free memory: 6145/6225 Mb
Data generated for M=1024, K=1025, N=1023
CPU: 7.013+-0.026064 s
CPU: 0.285185 GFlops

Kernel: matrix_multiplication_naive0
GPU: 0.194667+-0.00110554 s
GPU: 10.274 GFlops
Average difference: 0%

Kernel: matrix_multiplication_naive
GPU: 0.0986667+-0.000471405 s
GPU: 20.2703 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_not_coalesced
GPU: 0.0475+-0.0005 s
GPU: 42.1053 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_coalesced
GPU: 0.0416667+-0.000471405 s
GPU: 48 GFlops
Average difference: 0%

Kernel: matrix_multiplication_more_work_per_thread
GPU: 0.0203333+-0.000471405 s
GPU: 98.3607 GFlops
Average difference: 0%
</pre>

</p></details>

<details><summary>GitHub CI</summary><p>

<pre>
OpenCL devices:
   Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1025, N=1023
CPU: 1.71667+-0.00379032 s
CPU: 1.16505 GFlops

Kernel: matrix_multiplication_naive0
GPU: 1.97466+-0.00102471 s
GPU: 1.01283 GFlops
Average difference: 0.000164951%

Kernel: matrix_multiplication_naive
GPU: 0.432469+-0.000916951 s
GPU: 4.62461 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_not_coalesced
GPU: 0.907605+-0.0021133 s
GPU: 2.2036 GFlops
Average difference: 0%

Kernel: matrix_multiplication_local_mem_coalesced
GPU: 0.85367+-0.00411647 s
GPU: 2.34283 GFlops
Average difference: 0%

Kernel: matrix_multiplication_more_work_per_thread
GPU: 0.839042+-0.00240253 s
GPU: 2.38367 GFlops
Average difference: 0%
</pre>

</p></details>