### PR TITLE
Task04 Шушаков Даниил ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,87 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+__kernel void matrix_multiplication_naive(__global const float *as, __global const float *bs, __global float *cs,
+                                          unsigned int M, unsigned int K, unsigned int N) {
+    int i = get_global_id(1), j = get_global_id(0);
+    if (i >= M || j >= N)
+        return;
+    float sum = 0;
+    for (int k = 0; k < K; k++)
+        sum += as[i * K + k] * bs[k * N + j];
+    cs[i * N + j] = sum;
+}
+
+#ifndef TILE_SIZE
+    #define TILE_SIZE 16
+#endif
+
+__kernel void matrix_multiplication_local_mem(__global const float *as, __global const float *bs, __global float *cs,
+                                              unsigned int M, unsigned int K, unsigned int N) {
+    int i = get_global_id(1), j = get_global_id(0);
+    int local_i = get_local_id(1), local_j = get_local_id(0);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE], tile_b[TILE_SIZE][TILE_SIZE];
+    float sum = 0;
+    for (int tile_idx = 0; tile_idx < K; tile_idx += TILE_SIZE) {
+        if (tile_idx + local_j < K && i < M)
+            tile_a[local_i][local_j] = as[i * K + (tile_idx + local_j)];// coalesed read as
+        if (tile_idx + local_i < K && j < N)
+            tile_b[local_i][local_j] = bs[(tile_idx + local_i) * N + j];// coalesed read bs
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (i < M && j < N) {
+            for (int k = 0; k < min(TILE_SIZE, (int) (K - tile_idx)); k++) {
+                sum += tile_a[local_i][k] * tile_b[k][local_j];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (i < M && j < N) {
+        cs[i * N + j] = sum;
+    }
+}
+
+
+#ifndef WORK_PER_ITEM
+    #define WORK_PER_ITEM 4
+#endif
+
+__kernel void matrix_multiplication_local_mem_more_work(__global const float *as, __global const float *bs,
+                                                        __global float *cs, unsigned int M, unsigned int K,
+                                                        unsigned int N) {
+    // assume TILE_SIZE % WORK_PER_ITEM == 0
+    const int ROW_TILE_SIZE = TILE_SIZE / WORK_PER_ITEM;
+    int local_i = get_local_id(1), local_j = get_local_id(0);
+    int i = get_group_id(1) * TILE_SIZE + local_i, j = get_global_id(0);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE], tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sums[WORK_PER_ITEM];
+    for (int i = 0; i < WORK_PER_ITEM; i++)
+        sums[i] = 0.f;
+
+    for (int tile_idx = 0; tile_idx < K; tile_idx += TILE_SIZE) {
+        for (int w = 0; w < TILE_SIZE; w += ROW_TILE_SIZE) {
+            if (tile_idx + local_j < K && (i + w) < M)
+                tile_a[local_i + w][local_j] = as[(i + w) * K + (tile_idx + local_j)];// coalesed read as
+            if ((tile_idx + local_i + w) < K && j < N)
+                tile_b[local_i + w][local_j] = bs[(tile_idx + local_i + w) * N + j];// coalesed read bs
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+
+        for (int k = 0; k < min(TILE_SIZE, (int) (K - tile_idx)); k++) {
+            float tile_b_value = tile_b[k][local_j];
+            for (int w = 0; w < WORK_PER_ITEM; w++) {
+                if (i + w * ROW_TILE_SIZE < M && j < N) {
+                    sums[w] += tile_a[local_i + w * ROW_TILE_SIZE][k] * tile_b_value;
+                }
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0; w < WORK_PER_ITEM; w++) {
+        if (i + w * ROW_TILE_SIZE < M && j < N) {
+            cs[(i + w * ROW_TILE_SIZE) * N + j] = sums[w];
+        }
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,49 @@
-__kernel void matrix_transpose(...)
-{
-    // TODO
+#ifndef LOCAL_SIZE
+    #define LOCAL_SIZE 16
+#endif
+
+__kernel void matrix_transpose(__global const float *as, __global float *as_tr, unsigned int M, unsigned int K) {
+    unsigned int local_j = get_local_id(0), local_i = get_local_id(1);
+    unsigned int j = get_global_id(0), i = get_global_id(1);
+    unsigned int start_j = j - local_j, start_i = i - local_i;
+
+    __local float buffer[LOCAL_SIZE][LOCAL_SIZE + 1];// fix bank conflict
+
+    if (j < K && i < M)
+        buffer[local_i][local_j] = as[i * K + j];// coalesed read
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int dest_i = start_j + local_i;
+    unsigned int dest_j = start_i + local_j;
+
+    if (dest_j < K && dest_i < M) {
+        as_tr[dest_i * M + dest_j] = buffer[local_j][local_i];// coalesed write
+    }
+}
+
+
+__kernel void matrix_transpose_bad_banks(__global const float *as, __global float *as_tr, unsigned int M,
+                                         unsigned int K) {
+    unsigned int local_j = get_local_id(0), local_i = get_local_id(1);
+    unsigned int j = get_global_id(0), i = get_global_id(1);
+    unsigned int start_j = j - local_j, start_i = i - local_i;
+
+    __local float buffer[LOCAL_SIZE][LOCAL_SIZE];// no fix bank conflict :(
+    if (j < K && i < M)
+        buffer[local_i][local_j] = as[i * K + j];// coalesed read
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    unsigned int dest_i = start_j + local_i;
+    unsigned int dest_j = start_i + local_j;
+    if (dest_j < K && dest_i < M)
+        as_tr[dest_i * M + dest_j] = buffer[local_j][local_i];// coalesed write
+}
+
+
+__kernel void matrix_transpose_naive(__global const float *as, __global float *as_tr, unsigned int M, unsigned int K) {
+    unsigned int j = get_global_id(0), i = get_global_id(1);
+    if (j < K && i < M)
+        as_tr[j * M + i] = as[i * K + j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -1,91 +1,61 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_multiplication_cl.h"
 
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
+
+int benchmarkingIters = 1;// TODO пока тестируетесь удобно выставить единицу
+unsigned int M = 1024;
+unsigned int K = 1024;
+unsigned int N = 1024;
+
+const size_t gflops =
+        ((size_t) M * K * N * 2) / (1000 * 1000 * 1000);// умножить на два, т.к. операция сложения и умножения
 
 
-int main(int argc, char **argv)
-{
-    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
-
-    gpu::Context context;
-    context.init(device.device_id_opencl);
-    context.activate();
-
-    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
-    unsigned int M = 1024;
-    unsigned int K = 1024;
-    unsigned int N = 1024;
-    const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
-
-    std::vector<float> as(M*K, 0);
-    std::vector<float> bs(K*N, 0);
-    std::vector<float> cs(M*N, 0);
-
-    FastRandom r(M+K+N);
-    for (unsigned int i = 0; i < as.size(); ++i) {
-        as[i] = r.nextf();
-    }
-    for (unsigned int i = 0; i < bs.size(); ++i) {
-        bs[i] = r.nextf();
-    }
-    std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
-
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            for (int j = 0; j < M; ++j) {
-                for (int i = 0; i < N; ++i) {
-                    float sum = 0.0f;
-                    for (int k = 0; k < K; ++k) {
-                        sum += as.data()[j * K + k] * bs.data()[k * N + i];
-                    }
-                    cs.data()[j * N + i] = sum;
+std::vector<float> cpu_compute(std::vector<float> const &as, std::vector<float> const &bs) {
+    timer t;
+    std::vector<float> cs(M * N, 0);
+    for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        for (int j = 0; j < M; ++j) {
+            for (int i = 0; i < N; ++i) {
+                float sum = 0.0f;
+                for (int k = 0; k < K; ++k) {
+                    sum += as.data()[j * K + k] * bs.data()[k * N + i];
                 }
+                cs.data()[j * N + i] = sum;
             }
-            t.nextLap();
         }
-        std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        t.nextLap();
     }
+    std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+    std::cout << "CPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+    return cs;
+}
 
-    const std::vector<float> cs_cpu_reference = cs;
-
-    /*
-    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
-
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
-
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
-
+void bench_and_test(ocl::Kernel kernel, gpu::WorkSize workSize, gpu::gpu_mem_32f as_gpu, gpu::gpu_mem_32f bs_gpu,
+                    gpu::gpu_mem_32f cs_gpu, std::vector<float> const &cs_cpu_reference, std::string test_name) {
+    std::cout << "Test " << test_name << ":\n";
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
 
+            kernel.exec(workSize, as_gpu, bs_gpu, cs_gpu, M, K, N);
             t.nextLap();
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "\tGPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "\tGPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
     }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+    std::vector<float> cs = cs_cpu_reference;
+    cs_gpu.readN(cs.data(), M * N);
+
 
     // Проверяем корректность результатов
     double diff_sum = 0;
@@ -99,10 +69,79 @@ int main(int argc, char **argv)
     }
 
     double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    std::cout << "\tAverage difference: " << diff_avg * 100.0 << "%" << std::endl;
     if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+        std::cerr << "\tToo big difference!" << std::endl;
+        return;
+    }
+    std::cout << std::endl;
+}
+
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    std::vector<float> as(M * K, 0);
+    std::vector<float> bs(K * N, 0);
+
+    FastRandom r(M + K + N);
+    for (unsigned int i = 0; i < as.size(); ++i) {
+        as[i] = r.nextf();
+    }
+    for (unsigned int i = 0; i < bs.size(); ++i) {
+        bs[i] = r.nextf();
+    }
+
+    std::cout << "Data generated for M=" << M << ", K=" << K << ", N=" << N << std::endl;
+
+    const std::vector<float> cs_cpu_reference = cpu_compute(as, bs);
+
+    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
+    as_gpu.resizeN(M * K);
+    bs_gpu.resizeN(K * N);
+    cs_gpu.resizeN(M * N);
+
+    as_gpu.writeN(as.data(), M * K);
+    bs_gpu.writeN(bs.data(), K * N);
+
+    {
+        for (int work_group_size : {8, 16}) {
+            ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                     "matrix_multiplication_naive");
+            matrix_multiplication_kernel.compile();
+            bench_and_test(matrix_multiplication_kernel, gpu::WorkSize(work_group_size, work_group_size, N, M), as_gpu,
+                           bs_gpu, cs_gpu, cs_cpu_reference, "Naive " + std::to_string(work_group_size));
+        }
+    }
+
+    {
+        for (int work_group_size : {8, 16}) {
+            ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                     "matrix_multiplication_local_mem",
+                                                     "-DTILE_SIZE=" + std::to_string(work_group_size));
+            matrix_multiplication_kernel.compile();
+            bench_and_test(matrix_multiplication_kernel, gpu::WorkSize(work_group_size, work_group_size, N, M), as_gpu,
+                           bs_gpu, cs_gpu, cs_cpu_reference, "Local Mem " + std::to_string(work_group_size));
+        }
+    }
+
+    {
+        for (int work_group_size : {8, 16})
+            for (int work_per_item = 4; work_per_item <= work_group_size; work_per_item *= 2) {
+                std::string defines = "-DTILE_SIZE=" + std::to_string(work_group_size) +
+                                      " -DWORK_PER_ITEM=" + std::to_string(work_per_item);
+                ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                         "matrix_multiplication_local_mem_more_work", defines);
+                matrix_multiplication_kernel.compile();
+                bench_and_test(matrix_multiplication_kernel,
+                               gpu::WorkSize(work_group_size, work_group_size / work_per_item,
+                                             (N + work_per_item - 1) / work_per_item, M),
+                               as_gpu, bs_gpu, cs_gpu, cs_cpu_reference,
+                               "More WPI " + std::to_string(work_group_size) + ", " + std::to_string(work_per_item));
+            }
     }
 
     return 0;

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -10,7 +10,7 @@
 #include <stdexcept>
 #include <vector>
 
-int benchmarkingIters = 1;// TODO пока тестируетесь удобно выставить единицу
+int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
 unsigned int M = 1024;
 unsigned int K = 1024;
 unsigned int N = 1024;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -1,80 +1,139 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_transpose_cl.h"
 
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 
-int main(int argc, char **argv)
-{
-    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
-
-    gpu::Context context;
-    context.init(device.device_id_opencl);
-    context.activate();
-
-    int benchmarkingIters = 10;
-    unsigned int M = 1024;
-    unsigned int K = 1024;
-
-    std::vector<float> as(M*K, 0);
-    std::vector<float> as_t(M*K, 0);
-
-    FastRandom r(M+K);
-    for (unsigned int i = 0; i < as.size(); ++i) {
-        as[i] = r.nextf();
-    }
-    std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
-
-    /*
-    gpu::gpu_mem_32f as_gpu, as_t_gpu;
-    as_gpu.resizeN(M*K);
-    as_t_gpu.resizeN(K*M);
-
-    as_gpu.writeN(as.data(), M*K);
-
-    ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose");
-    matrix_transpose_kernel.compile();
-
+void bench_and_check(int benchmarkingIters, uint K, uint M, uint work_group_size, ocl::Kernel kernel,
+                     gpu::gpu_mem_32f as_gpu, gpu::gpu_mem_32f as_t_gpu, std::vector<float> const &as,
+                     std::string kernel_name) {
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int global_work_size_x = K;
+            unsigned int global_work_size_y = M;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            kernel.exec(gpu::WorkSize(work_group_size, work_group_size, global_work_size_x, global_work_size_y), as_gpu,
+                        as_t_gpu, M, K);
 
             t.nextLap();
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << M*K/1000.0/1000.0 / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU (" << kernel_name << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU (" << kernel_name << "): " << M * K / 1000.0 / 1000.0 / t.lapAvg() << " millions/s"
+                  << std::endl;
     }
 
-    as_t_gpu.readN(as_t.data(), M*K);
+    std::vector<float> as_t(M * K, 0);
+    as_t_gpu.readN(as_t.data(), M * K);
 
+   
     // Проверяем корректность результатов
     for (int j = 0; j < M; ++j) {
         for (int i = 0; i < K; ++i) {
             float a = as[j * K + i];
             float b = as_t[i * M + j];
             if (a != b) {
-                std::cerr << "Not the same!" << std::endl;
-                return 1;
+                std::cerr << kernel_name << ": Not the same!" << std::endl;
+                return;
             }
         }
     }
-    */
+}
+
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
+    int benchmarkingIters = 40;
+    unsigned int M = 1024;
+    unsigned int K = 1024;
+
+    std::vector<float> as(M * K, 0);
+
+    FastRandom r(M + K);
+    for (float &a : as) {
+        a = r.nextf();
+    }
+    std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
+
+
+    gpu::gpu_mem_32f as_gpu, as_t_gpu;
+    as_gpu.resizeN(M * K);
+    as_t_gpu.resizeN(K * M);
+
+    as_gpu.writeN(as.data(), M * K);
+
+
+    {
+        int grs = 16;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "normal " + std::to_string(grs));
+    }
+
+
+    {
+        int grs = 16;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose_bad_banks",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "bad_banks " + std::to_string(grs));
+    }
+
+
+    {
+        int grs = 16;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose_naive",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "naive " + std::to_string(grs));
+    }
+
+    {
+        int grs = 8;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "normal " + std::to_string(grs));
+    }
+
+    {
+        int grs = 8;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose_bad_banks",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "bad_banks " + std::to_string(grs));
+    }
+
+    {
+        int grs = 8;
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose_naive",
+                                            "-DLOCAL_SIZE=" + std::to_string(grs));
+        matrix_transpose_kernel.compile();
+        bench_and_check(benchmarkingIters, K, M, grs, matrix_transpose_kernel, as_gpu, as_t_gpu, as,
+                        "naive " + std::to_string(grs));
+    }
+
 
     return 0;
 }


### PR DESCRIPTION
## Транспонирование матрицы
<details><summary>Локальный вывод</summary>
<p>

```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15359 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 486/512 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
Data generated for M=1024, K=1024
GPU (normal 16): 8.22083e-05+-5.24388e-06 s
GPU (normal 16): 12755.1 millions/s
GPU (bad_banks 16): 9.4875e-05+-1.48078e-06 s
GPU (bad_banks 16): 11052.2 millions/s
GPU (naive 16): 0.000106042+-6.10953e-07 s
GPU (naive 16): 9888.34 millions/s
GPU (normal 8): 8.30833e-05+-6.40095e-07 s
GPU (normal 8): 12620.8 millions/s
GPU (bad_banks 8): 8.06667e-05+-4.71405e-07 s
GPU (bad_banks 8): 12998.9 millions/s
GPU (naive 8): 7.925e-05+-9.68246e-07 s
GPU (naive 8): 13231.2 millions/s
```

</p>
</details> 

Как можно заметить, при workgroup size равным 16, версия с coalesed доступом и без bank conflicts выигрывает перед версией с bank conflicts и наивной версией без локальной памяти. Но с workgroup size равным 8 ситуация ровно наоборот :thinking:

<details><summary>Вывод CI</summary>
<p>

```
 OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024
GPU (normal 16): 0.00224508+-4.17761e-05 s
GPU (normal 16): 467.054 millions/s
GPU (bad_banks 16): 0.00238817+-0.000203222 s
GPU (bad_banks 16): 439.072 millions/s
GPU (naive 16): 0.00276563+-0.000121904 s
GPU (naive 16): 379.146 millions/s
GPU (normal 8): 0.00587246+-0.000654563 s
GPU (normal 8): 178.558 millions/s
GPU (bad_banks 8): 0.00319754+-7.88696e-05 s
GPU (bad_banks 8): 327.932 millions/s
GPU (naive 8): 0.00157067+-3.81168e-05 s
GPU (naive 8): 667.599 millions/s
```
</p>
</details> 

На процессоре CI ситуация похожая, только у наивной версии с размером 8 более заметное преимущество.

## Умножение матриц

<details><summary>Локальный вывод</summary>
<p>

```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15359 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 486/512 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 13.582+-0.052216 s
CPU: 0.147254 GFlops
Test Naive 8:
        GPU: 0.0178862+-0.000274415 s
        GPU: 111.818 GFlops
        Average difference: 0.000149043%

Test Naive 16:
        GPU: 0.00973067+-0.000319038 s
        GPU: 205.536 GFlops
        Average difference: 0.000149043%

Test Local Mem 8:
        GPU: 0.010903+-0.000252771 s
        GPU: 183.436 GFlops
        Average difference: 0.000149043%

Test Local Mem 16:
        GPU: 0.00751383+-0.000147385 s
        GPU: 266.176 GFlops
        Average difference: 0.000149043%

Test More WPI 8, 4:
        GPU: 0.0125078+-0.00021983 s
        GPU: 159.9 GFlops
        Average difference: 0.000149043%

Test More WPI 8, 8:
        GPU: 0.0217502+-0.00016345 s
        GPU: 91.9533 GFlops
        Average difference: 0.000149043%

Test More WPI 16, 4:
        GPU: 0.004683+-0.00017898 s
        GPU: 427.077 GFlops
        Average difference: 0.000149043%

Test More WPI 16, 8:
        GPU: 0.00453133+-9.16964e-05 s
        GPU: 441.371 GFlops
        Average difference: 0.000149043%

Test More WPI 16, 16:
        GPU: 0.00839933+-0.000158216 s
        GPU: 238.114 GFlops
        Average difference: 0.000149043%
```

Лучшие результаты

```
Test Naive 16:
        GPU: 0.00973067+-0.000319038 s
        GPU: 205.536 GFlops
        Average difference: 0.000149043%

Test Local Mem 16:
        GPU: 0.00751383+-0.000147385 s
        GPU: 266.176 GFlops
        Average difference: 0.000149043%

Test More WPI 16, 8:
        GPU: 0.00453133+-9.16964e-05 s
        GPU: 441.371 GFlops
        Average difference: 0.000149043%
```
</p>
</details> 

Во всех реализациях наилучшее время с workgroup size равным 16. А в третьей реализации лучший размер WORK_PER_ITEM = 8. Уменьшение количества обращение сначала к глобальной памяти, а затем к локальной, ускоряет алгоритм.

<details><summary>Вывод CI</summary>
<p>

```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 2.99319+-0.0209854 s
CPU: 0.668184 GFlops
Test Naive 8:
	GPU: 0.202039+-0.00342093 s
	GPU: 9.89905 GFlops
	Average difference: 0.000149043%

Test Naive 16:
	GPU: 0.199993+-0.00319281 s
	GPU: 10.0004 GFlops
	Average difference: 0.000149043%

Test Local Mem 8:
	GPU: 0.351593+-0.0031655 s
	GPU: 5.68839 GFlops
	Average difference: 0.000149043%

Test Local Mem 16:
	GPU: 0.230392+-0.00314917 s
	GPU: 8.68087 GFlops
	Average difference: 0.000149043%

Test More WPI 8, 4:
	GPU: 0.431206+-0.00124138 s
	GPU: 4.63815 GFlops
	Average difference: 0.000149043%

Test More WPI 8, 8:
	GPU: 0.292917+-0.00418074 s
	GPU: 6.82786 GFlops
	Average difference: 0.000149043%

Test More WPI 16, 4:
	GPU: 0.234822+-0.00147273 s
	GPU: 8.5171 GFlops
	Average difference: 0.000149043%

Test More WPI 16, 8:
	GPU: 0.161887+-0.00123551 s
	GPU: 12.3543 GFlops
	Average difference: 0.000149043%

Test More WPI 16, 16:
	GPU: 0.16062+-0.00164542 s
	GPU: 12.4518 GFlops
	Average difference: 0.000149043%
```

Лучшие результаты:
```
Test Naive 16:
	GPU: 0.199993+-0.00319281 s
	GPU: 10.0004 GFlops
	Average difference: 0.000149043%

Test Local Mem 16:
	GPU: 0.230392+-0.00314917 s
	GPU: 8.68087 GFlops
	Average difference: 0.000149043%

Test More WPI 16, 16:
	GPU: 0.16062+-0.00164542 s
	GPU: 12.4518 GFlops
	Average difference: 0.000149043%
```

</p>
</details> 

На процессоре же лучше, когда каждый поток считает больше значений в резльтирующей матрице. А версия с локальной памятью работает медленее наивной версии, с чем я уже сталкивался ранее. И, кажется, тут дается объяснение этому: [ссылка](https://www.intel.com/content/www/us/en/docs/opencl-sdk/developer-guide-processor-graphics/2019-4/local-memory-usage.html)