### PR TITLE
Task04 Николай Стойко ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -78,8 +78,8 @@ __kernel void matrix_multiplication_more_work_per_thread(__global const float *a
             int a_index = (j + w) * K + col;
             int b_index = i + N * row;
 
-            tileA[wj][local_i] = col < K && j + w < M ? as[a_index] : 0.0;
-            tileB[wj][local_i] = i < N && row < K ? bs[b_index] : 0.0;
+            tileA[wj][local_i] = a_index < K * M ? as[a_index] : 0.0;
+            tileB[wj][local_i] = b_index < N * K ? bs[b_index] : 0.0;
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -16,9 +16,8 @@ __kernel void matrix_multiplication_naive(__global const float *as, __global con
         }
     }
 
-    unsigned int c_index = j * N + i;
     if (i < N && j < M) {
-        cs[c_index] = sum;
+        cs[j * N + i] = sum;
     }
 }
 
@@ -34,9 +33,9 @@ __kernel void matrix_multiplication_local(__global const float *as, __global con
 
     float sum = 0.0f;
 
-    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
-        int a_index = j * K + (tileK * TILE_SIZE + local_i);
-        int b_index = i + N * (tileK * TILE_SIZE + local_j);
+    for (int tileK = 0; tileK < K; tileK += TILE_SIZE) {
+        int a_index = j * K + (tileK + local_i);
+        int b_index = i + N * (tileK + local_j);
 
         tileA[local_j][local_i] = a_index < M * K ? as[a_index] : 0;
         tileB[local_j][local_i] = b_index < K * N ? bs[b_index] : 0;
@@ -52,5 +51,52 @@ __kernel void matrix_multiplication_local(__global const float *as, __global con
 
     if (i < N && j < M) {
         cs[j * N + i] = sum;
+    }
+}
+
+#define THREAD_WORK 4
+__kernel void matrix_multiplication_more_work_per_thread(__global const float *as, __global const float *bs, __global float *cs,
+                                                         const unsigned int M, const unsigned int K, const unsigned int N)
+{
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int i = get_global_id(0);
+    int j = get_group_id(1) * TILE_SIZE + local_j;
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[THREAD_WORK] = {};
+
+    const int RTS = TILE_SIZE / THREAD_WORK;
+
+    for (int tileK = 0; tileK < K; tileK += TILE_SIZE) {
+        int col = tileK + local_i;
+        int row = tileK + local_j;
+
+        for (int w = 0, wj = local_j; w < TILE_SIZE; w += RTS, wj += RTS, row += RTS) {
+            int a_index = (j + w) * K + col;
+            int b_index = i + N * row;
+
+            tileA[wj][local_i] = col < K && j + w < M ? as[a_index] : 0.0;
+            tileB[wj][local_i] = i < N && row < K ? bs[b_index] : 0.0;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            float buf = tileB[k][local_i];
+            for (int w = 0, ws = local_j; w < THREAD_WORK; ++w, ws += RTS) {
+                sum[w] += tileA[ws][k] * buf;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int w = 0, ws = j; w < THREAD_WORK; ++w, ws += RTS) {
+        if (i < N && ws < M) {
+            cs[i + N * ws] = sum[w];
+        }
     }
 }

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,56 @@
-__kernel void matrix_multiplication(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#define TILE_SIZE 16
+
+__kernel void matrix_multiplication_naive(__global const float *as, __global const float *bs, __global float *cs, const unsigned int M, const unsigned int K, const unsigned int N)
 {
-    // TODO
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; ++k) {
+        if (i < N && j < M) {
+            sum += as[j * K + k] * bs[k * N + i];
+        }
+    }
+
+    unsigned int c_index = j * N + i;
+    if (i < N && j < M) {
+        cs[c_index] = sum;
+    }
+}
+
+__kernel void matrix_multiplication_local(__global const float *as, __global const float *bs, __global float *cs, const unsigned int M, const unsigned int K, const unsigned int N)
+{
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; ++tileK) {
+        int a_index = j * K + (tileK * TILE_SIZE + local_i);
+        int b_index = i + N * (tileK * TILE_SIZE + local_j);
+
+        tileA[local_j][local_i] = a_index < M * K ? as[a_index] : 0;
+        tileB[local_j][local_i] = b_index < K * N ? bs[b_index] : 0;
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (i < N && j < M) {
+        cs[j * N + i] = sum;
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,21 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose(__global const float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][(local_i + local_j) % TILE_SIZE] = a[j * k + i]; // To solve bank conflict
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[i * m + j] = tile[local_j][(local_i + local_j) % TILE_SIZE];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -10,6 +10,51 @@
 #include <iostream>
 #include <stdexcept>
 
+int checkMultiplication(const gpu::gpu_mem_32f& as_gpu, const gpu::gpu_mem_32f& bs_gpu, unsigned int N, unsigned int K, unsigned int M,
+                        const std::vector<float>& cs_cpu_reference,
+                        const std::string& kernelName,
+                        gpu::WorkSize workSize,
+                        int benchmarkingIters = 10) {
+    const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
+    std::vector<float> cs(M*N, 0);
+    gpu::gpu_mem_32f cs_gpu;
+    cs_gpu.resizeN(M*N);
+
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, kernelName);
+    matrix_multiplication_kernel.compile();
+
+    {
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            matrix_multiplication_kernel.exec(workSize, as_gpu, bs_gpu, cs_gpu, M, K, N);
+            t.nextLap();
+        }
+        std::cout << "GPU: " << kernelName << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << kernelName << ": " << gflops / t.lapAvg() << " GFlops" << std::endl;
+    }
+
+    cs_gpu.readN(cs.data(), M*N);
+
+    // Проверяем корректность результатов
+    double diff_sum = 0;
+    for (int i = 0; i < M * N; ++i) {
+        double a = cs[i];
+        double b = cs_cpu_reference[i];
+        if (a != 0.0 || b != 0.0) {
+            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+            diff_sum += diff;
+        }
+    }
+
+    double diff_avg = diff_sum / (M * N);
+    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    if (diff_avg > 0.01) {
+        std::cerr << "Too big difference!" << std::endl;
+        return 1;
+    }
+
+    return 0;
+}
 
 int main(int argc, char **argv)
 {
@@ -58,51 +103,34 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
-    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
+    gpu::gpu_mem_32f as_gpu, bs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
 
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
+    unsigned int groupSize = 16;
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+    unsigned int workSizeX = (N + groupSize - 1) / groupSize * groupSize;
+    unsigned int workSizeY = (M + groupSize - 1) / groupSize * groupSize;
 
-            t.nextLap();
-        }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+    // 4.2.0 Реализуйте наивное умножение матриц через глобальную память
+    if (int ret = checkMultiplication(as_gpu, bs_gpu, N, K, M,
+                                  cs_cpu_reference,
+                                  "matrix_multiplication_naive",
+                                  gpu::WorkSize(groupSize, groupSize, workSizeX, workSizeY),
+                                  benchmarkingIters)) {
+        return ret;
     }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
-
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
-        }
-    }
-
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+    // 4.2.1 Реализуйте умножение матриц через локальную память. (на лекции это вплоть до "Умножение матриц 2: локальная память")
+    if (int ret = checkMultiplication(as_gpu, bs_gpu, N, K, M,
+                                  cs_cpu_reference,
+                                  "matrix_multiplication_local",
+                                  gpu::WorkSize(groupSize, groupSize, workSizeX, workSizeY),
+                                  benchmarkingIters)) {
+        return ret;
     }
 
     return 0;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -45,15 +44,14 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 16;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, K, M),
+                                         as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +72,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
### Задание 4.1. Транспонирование матрицы

<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Data generated for M=1024, K=1024
GPU: 0.000666667+-0.000471405 s
GPU: 1572.86 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
        Data generated for M=1024, K=1024
GPU: 0.0032695+-5.4613e-05 s
GPU: 320.714 millions/s
</pre>
</p></details>


### Задание 4.2. Умножение матриц
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 8.9875+-0.349438 s
CPU: 0.222531 GFlops
GPU: matrix_multiplication_naive: 0.0255+-0.0005 s
GPU: matrix_multiplication_naive: 78.4314 GFlops
        Average difference: 0.000303504%
GPU: matrix_multiplication_local: 0.0085+-0.0005 s
GPU: matrix_multiplication_local: 235.294 GFlops
        Average difference: 0.000303504%
GPU: matrix_multiplication_more_work_per_thread: 0.0065+-0.0005 s
GPU: matrix_multiplication_more_work_per_thread: 307.692 GFlops
        Average difference: 0.000303504%
</pre>
</p></details>


<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.76737+-0.0011816 s
CPU: 0.530874 GFlops
GPU: matrix_multiplication_naive: 0.0822983+-0.00345596 s
GPU: matrix_multiplication_naive: 24.3018 GFlops
    Average difference: 0.000149043%
GPU: matrix_multiplication_local: 0.0422865+-0.000507676 s
GPU: matrix_multiplication_local: 47.2964 GFlops
    Average difference: 0.000149043%
GPU: matrix_multiplication_more_work_per_thread: 0.0399977+-0.000136121 s
GPU: matrix_multiplication_more_work_per_thread: 50.0029 GFlops
    Average difference: 0.000149043%
</pre>
</p></details>

Не совсем честно просто вычислять на CPU умножение матриц c размером кратным 4K, не транспонируя. 
Происходит конфликт кешей CPU, когда лучше их не использовать. 
К примеру вычисления 1025 X 1025 X 1025 не будет пытаться подгружать странице в кеш целиком, и будет работать в 6 раз быстрее.
```
Data generated for M=1025, K=1025, N=1025
CPU: 1.696+-0.0108474 s
CPU: 1.17925 GFlops
```

__Вывод__: 
Видно, что использование локальной памяти значительно увеличивает производительность.
А если выполнять больше работы на поток, то можно получить еще больший прирост скорости.