### PR TITLE
Task0 Шукшов Андрей ITMO

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,16 +68,26 @@ int main() {
         // TODO 1.2
         // Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
         std::vector<unsigned char> platformName(platformNameSize, 0);
-        // clGetPlatformInfo(...);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
         // Запросите и напечатайте так же в консоль вендора данной платформы
 
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+
+        std::vector<unsigned char> platformVendor(platformVendorSize, 0);
+        OCL_SAFE_CALL(
+                clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "Vendor: " << platformVendor.data() << std::endl;
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
-
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        std::cout << "    Number of platform devices: " << devicesCount << std::endl;
+        std::vector<cl_device_id> devices(devicesCount, 0);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), nullptr));
         for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
             // TODO 2.2
             // Запросите и напечатайте в консоль:
@@ -85,6 +95,41 @@ int main() {
             // - Тип устройства (видеокарта/процессор/что-то странное)
             // - Размер памяти устройства в мегабайтах
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+
+            std::cout << "    Device #" << (deviceIndex + 1) << "/" << devicesCount << std::endl;
+            auto device = devices[deviceIndex];
+
+            size_t deviceNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, 0, nullptr, &deviceNameSize));
+            std::vector<unsigned char> deviceName(deviceNameSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, deviceNameSize, deviceName.data(), nullptr));
+            std::cout << "Name: " << deviceName.data() << std::endl;
+
+            cl_device_type deviceType;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(cl_device_type), &deviceType, nullptr));
+            std::cout << "Type: " << deviceType << std::endl;
+
+            cl_ulong deviceMemSize = 0;
+            OCL_SAFE_CALL(
+                    clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(deviceMemSize), &deviceMemSize, nullptr));
+            std::cout << "Global memory size: " << double(deviceMemSize) / 10e5 << std::endl;
+
+            cl_ulong deviceLDSSize = 0;
+            OCL_SAFE_CALL(
+                    clGetDeviceInfo(device, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(deviceLDSSize), &deviceLDSSize, nullptr));
+            std::cout << "Local memory size: " << double(deviceLDSSize) / 1e5 << std::endl;
+
+            cl_uint deviceCUs = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_MAX_COMPUTE_UNITS, sizeof(deviceCUs), &deviceCUs, nullptr));
+            std::cout << "Number of CUs: " << deviceCUs << std::endl;
+
+            cl_ulong deviceExtensionsSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr, &deviceExtensionsSize));
+            std::vector<unsigned char> deviceExtensions(deviceExtensionsSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, deviceExtensionsSize, deviceExtensions.data(),
+                                          nullptr));
+
+            std::cout << "Extensions: " << deviceExtensions.data() << std::endl;
         }
     }
 


### PR DESCRIPTION
<details><summary>Локальный вывод:</summary><p>

<pre>
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: AMD Accelerated Parallel Processing
Vendor: Advanced Micro Devices, Inc.
    Number of platform devices: 2
    Device #1/2
Name: gfx1100
Type: 4
Global memory size: 25753
Local memory size: 0.65536
Number of CUs: 48
Extensions: cl_khr_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_at
omics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes
 cl_khr_byte_addressable_store cl_khr_fp16 cl_khr_gl_sharing cl_amd_device_attribute_query cl_amd_media_ops cl_amd_media
_ops2 cl_khr_d3d10_sharing cl_khr_d3d11_sharing cl_khr_dx9_media_sharing cl_khr_image2d_from_buffer cl_khr_subgroups cl_
khr_gl_event cl_khr_depth_images cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_amd_liquid_flash cl_amd_copy_buffer_p
2p cl_amd_planar_yuv
    Device #2/2
Name: gfx1036
Type: 4
Global memory size: 25759.3
Local memory size: 0.65536
Number of CUs: 1
Extensions: cl_khr_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_at
omics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes
 cl_khr_byte_addressable_store cl_khr_fp16 cl_khr_gl_sharing cl_amd_device_attribute_query cl_amd_media_ops cl_amd_media
_ops2 cl_khr_d3d10_sharing cl_khr_d3d11_sharing cl_khr_dx9_media_sharing cl_khr_image2d_from_buffer cl_khr_subgroups cl_
khr_gl_event cl_khr_depth_images cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_amd_liquid_flash cl_amd_copy_buffer_p
2p cl_amd_planar_yuv
</pre>

</p></details>
<details><summary>Вывод Github CI:</summary><p>

<pre>
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) CPU Runtime for OpenCL(TM) Applications
Vendor: Intel(R) Corporation
    Number of platform devices: 1
    Device #1/1
Name: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
Type: 2
Global memory size: 7268.78
Local memory size: 0.32768
Number of CUs: 2
Extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_fp64 cl_khr_image2d_from_buffer cl_intel_vec_len_hint 

</pre>

</p></details>
