### PR TITLE
Task04 Иван Васильев SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,112 @@
-__kernel void matrix_multiplication(...)
+#ifdef __CLION_IDE__
+#include "clion_defines.cl"
+#endif
+#line 5
+
+__kernel void matrix_multiplication_base(__global const float* as,
+                                    __global const float* bs,
+                                    __global float* cs,
+                                    unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    if ((j < M) && (i < N)){
+        float sum = 0;
+        for (int k=0; k < K; ++k) {
+            sum += as[j * K + k] * bs[k * N + i];
+        }
+        cs[j * N + i] = sum;
+    }
+}
+
+#define TILE_SIZE 16
+__kernel void matrix_multiplication_local_mem(__global const float* as,
+                                      __global const float* bs,
+                                      __global float* cs,
+                                      unsigned int M, unsigned int K, unsigned int N)
+{
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    __local float tileA[TILE_SIZE * TILE_SIZE];
+    __local float tileB[TILE_SIZE * TILE_SIZE];
+    float sum = 0.0f;
+
+    for (int tileK=0; tileK * TILE_SIZE < K; ++tileK) {
+        int ax = TILE_SIZE * tileK + local_i;
+        if ((j < M) && (ax < K)) {
+            tileA[local_j * TILE_SIZE + local_i] = as[j * K + ax];
+        } else {
+            tileA[local_j * TILE_SIZE + local_i] = 0;
+        }
+        int by = TILE_SIZE * tileK + local_j;
+        if ((by < K) && (i < N)) {
+            tileB[local_j * TILE_SIZE + local_i] = bs[by * N + i];
+        } else {
+            tileB[local_j * TILE_SIZE + local_i] = 0;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k=0; k < TILE_SIZE; ++k) {
+            sum += tileA[local_j * TILE_SIZE + k] * tileB[k * TILE_SIZE + local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if ((j < M) && (i < N)){
+        cs[j * N + i] = sum;
+    }
+}
+
+#define VALUES_PER_WORK_ITEM 8
+__kernel void matrix_multiplication_busy(__global const float* as,
+                                              __global const float* bs,
+                                              __global float* cs,
+                                              unsigned int M, unsigned int K, unsigned int N)
+{
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    __local float tileA[TILE_SIZE * TILE_SIZE * VALUES_PER_WORK_ITEM];
+    __local float tileB[TILE_SIZE * TILE_SIZE];
+    float sum[VALUES_PER_WORK_ITEM];
+    for (int w=0; w<VALUES_PER_WORK_ITEM; ++w) {
+        sum[w] = 0;
+    }
+
+    for (int tileK=0; tileK * TILE_SIZE < K; ++tileK) {
+        for (int w=0; w<VALUES_PER_WORK_ITEM; ++w) {
+            int ax = TILE_SIZE * tileK + local_i;
+            int ay = j * VALUES_PER_WORK_ITEM + w;
+            int local_ay = (local_j * VALUES_PER_WORK_ITEM + w);
+            if ((ay < M) && (ax < K)) {
+                tileA[local_ay * TILE_SIZE + local_i] = as[ay * K + ax];
+            } else {
+                tileA[local_ay * TILE_SIZE + local_i] = 0;
+            }
+        }
+        int by = TILE_SIZE * tileK + local_j;
+        if ((by < K) && (i < N)) {
+            tileB[local_j * TILE_SIZE + local_i] = bs[by * N + i];
+        } else {
+            tileB[local_j * TILE_SIZE + local_i] = 0;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k=0; k < TILE_SIZE; ++k) {
+            float tmp = tileB[k * TILE_SIZE + local_i];
+            for (int w=0; w<VALUES_PER_WORK_ITEM; ++w) {
+                sum[w] += tileA[(local_j * VALUES_PER_WORK_ITEM + w) * TILE_SIZE + k] * tmp;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    for (int w=0; w<VALUES_PER_WORK_ITEM; ++w) {
+        int dst_y = j * VALUES_PER_WORK_ITEM + w;
+        if ((dst_y < M) && (i < N)) {
+            cs[dst_y * N + i] = sum[w];
+        }
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,29 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+    #include "clion_defines.cl"
+#endif
+#line 5
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose(__global const float* as,
+                               __global float* as_t,
+                               unsigned int M, unsigned int K)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+    int local_ij = (local_i + local_j) % TILE_SIZE;
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    if ((i < K) && (j < M)) {
+        tile[local_j][local_ij] = as[j * K + i];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int dst_x = j - local_j + local_i;
+    int dst_y = i - local_i + local_j;
+    if ((dst_x < M) && (dst_y < K)) {
+        as_t[dst_y * M + dst_x] = tile[local_i][local_ij];
+    }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -6,9 +6,59 @@
 
 #include "cl/matrix_multiplication_cl.h"
 
+#include <utility>
 #include <vector>
 #include <iostream>
 #include <stdexcept>
+
+
+int test_kernel(std::string kernel_name, gpu::WorkSize work_size,
+                const gpu::gpu_mem_32f& as_gpu,
+                const gpu::gpu_mem_32f& bs_gpu,
+                const gpu::gpu_mem_32f& cs_gpu,
+                unsigned int M, unsigned int K, unsigned int N,
+                std::vector<float> cs,
+                std::vector<float> cs_cpu_reference,
+                int benchmarkingIters) {
+    std::cout << kernel_name << " kernel test:" << std::endl;
+    const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000);
+
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, std::move(kernel_name));
+    matrix_multiplication_kernel.compile();
+
+    {
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            matrix_multiplication_kernel.exec(work_size, as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+            t.nextLap();
+        }
+        std::cout << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << gflops / t.lapAvg() << " GFlops" << std::endl;
+    }
+
+    cs_gpu.readN(cs.data(), M*N);
+
+    // Проверяем корректность результатов
+    double diff_sum = 0;
+    for (int i = 0; i < M * N; ++i) {
+        double a = cs[i];
+        double b = cs_cpu_reference[i];
+        if (a != 0.0 || b != 0.0) {
+            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+            diff_sum += diff;
+        }
+    }
+
+    double diff_avg = diff_sum / (M * N);
+    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    if (diff_avg > 0.01) {
+        std::cerr << "Too big difference!" << std::endl;
+        return 1;
+    }
+    std::cout << std::endl;
+    return 0;
+}
 
 
 int main(int argc, char **argv)
@@ -52,13 +102,14 @@ int main(int argc, char **argv)
             }
             t.nextLap();
         }
-        std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "CPU test:" << std::endl;
+        std::cout << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << std::endl;
     }
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
@@ -67,43 +118,67 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
+    {
+        unsigned int work_group_size = 16;
+        unsigned int global_work_size_x = (N + work_group_size - 1) / work_group_size * work_group_size;
+        unsigned int global_work_size_y = (M + work_group_size - 1) / work_group_size * work_group_size;
+        gpu::WorkSize work_size = gpu::WorkSize(work_group_size, work_group_size, global_work_size_x, global_work_size_y);
+        int test_result = test_kernel(
+            "matrix_multiplication_base",
+            work_size,
+            as_gpu,
+            bs_gpu,
+            cs_gpu,
+            M, K, N,
+            cs, cs_cpu_reference,
+            benchmarkingIters * 10
+        );
+        if (test_result != 0) {
+            return 1;
+        }
+    }
 
     {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
-
-            t.nextLap();
-        }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
-
-    cs_gpu.readN(cs.data(), M*N);
-    */
-
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        unsigned int tile_size = 16;
+        unsigned int global_work_size_x = (N + tile_size - 1) / tile_size * tile_size;
+        unsigned int global_work_size_y = (M + tile_size - 1) / tile_size * tile_size;
+        gpu::WorkSize work_size = gpu::WorkSize(tile_size, tile_size, global_work_size_x, global_work_size_y);
+        int test_result = test_kernel(
+                "matrix_multiplication_local_mem",
+                work_size,
+                as_gpu,
+                bs_gpu,
+                cs_gpu,
+                M, K, N,
+                cs, cs_cpu_reference,
+                benchmarkingIters
+        );
+        if (test_result != 0) {
+            return 1;
         }
     }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+    {
+        unsigned int tile_size = 16;
+        unsigned int values_per_work_item = 8;
+        unsigned int global_work_size_x = (N + tile_size - 1) / tile_size * tile_size;
+        unsigned int global_work_size_y = ((M + values_per_work_item - 1) / values_per_work_item + tile_size - 1) / tile_size * tile_size;
+        gpu::WorkSize work_size = gpu::WorkSize(tile_size, tile_size, global_work_size_x, global_work_size_y);
+        int test_result = test_kernel(
+                "matrix_multiplication_busy",
+                work_size,
+                as_gpu,
+                bs_gpu,
+                cs_gpu,
+                M, K, N,
+                cs, cs_cpu_reference,
+                benchmarkingIters
+        );
+        if (test_result != 0) {
+            return 1;
+        }
     }
+
 
     return 0;
 }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -20,8 +20,8 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10;
-    unsigned int M = 1024;
-    unsigned int K = 1024;
+    unsigned int M = 4009;
+    unsigned int K = 2023;
 
     std::vector<float> as(M*K, 0);
     std::vector<float> as_t(M*K, 0);
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
+
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -46,14 +46,15 @@ int main(int argc, char **argv)
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int tile_size = 16;
+            unsigned int global_work_size_x = (K + tile_size - 1) / tile_size * tile_size;
+            unsigned int global_work_size_y = (M + tile_size - 1) / tile_size * tile_size;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(tile_size, tile_size, global_work_size_x, global_work_size_y), as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +75,7 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
+
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод transpose</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 630. Total memory: 6478 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Data generated for M=4009, K=2023
GPU: 0.000333333+-0.000471405 s
GPU: 24330.6 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI transpose</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=4009, K=2023
GPU: 0.037116+-0.00569872 s
GPU: 218.51 millions/s
</pre>

</p></details>



<details><summary>Локальный вывод multiplication ugly MKN</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 630. Total memory: 6478 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Data generated for M=1124, K=1224, N=1324
CPU test:
1.999+-0.0113578 s
1.50075 GFlops

matrix_multiplication_base kernel test:
0.00886667+-0.000339935 s
338.346 GFlops
Average difference: 0.000226467%

matrix_multiplication_local_mem kernel test:
0.00716667+-0.000372678 s
418.605 GFlops
Average difference: 0.000226467%

matrix_multiplication_busy kernel test:
0.00683333+-0.000372678 s
439.024 GFlops
Average difference: 0.000226467%
</pre>

</p></details>

<details><summary>Локальный вывод multiplication MKN=1024</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) UHD Graphics 630. Total memory: 6478 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1660 Ti. Total memory: 6143 Mb
Data generated for M=1024, K=1024, N=1024
CPU test:
1.571+-0.02284 s
1.27307 GFlops

matrix_multiplication_base kernel test:
0.00601667+-0.000288194 s
332.41 GFlops
Average difference: 0.000196008%

matrix_multiplication_local_mem kernel test:
0.004+-0 s
500 GFlops
Average difference: 0.000196008%

matrix_multiplication_busy kernel test:
0.004+-0 s
500 GFlops
Average difference: 0.000196008%
</pre>

</p></details>

<details><summary>Вывод Github CI multiplication</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU test:
3.39176+-0.075348 s
0.589665 GFlops

matrix_multiplication_base kernel test:
0.0768188+-0.000749127 s
26.0353 GFlops
Average difference: 0.000149043%

matrix_multiplication_local_mem kernel test:
0.126048+-0.00109594 s
15.867 GFlops
Average difference: 0.000149043%

matrix_multiplication_busy kernel test:
0.0754062+-0.000474513 s
26.523 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

### 4.3
Реализации показывают себя относительно по-разному на разных девайсах и даже при разных сопоставимых размерах. Первая реализация показывает сравнительно большее отклонение, поэтому я запускал больше итераций. Локально каждая следующая реализация давала заметный прогресс, однако при "красивых" M=K=N=1024 время было одинаковое и круглое стабильно во 2 и третей реализациях, но при других размерах третья реализация имела ненулевое преимущество. Такая картина у меня на другом девайсе и при M=N=K=1024. В случае GitHub CI вторая реализация уступила первой, которая едва оказалась хуже последней.  Хочется отметить, что на GPU в любом случае оптимизации дают прирост, но он в общем не получился огромным. Возможно, если не так яростно проверять выход за размеры матрицы, а заполнять их нулями в плюсовом коде до кратных тому, чему надо, то выйдет лучше. 

