### PR TITLE
Task04 Александр Тульчинский SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,86 @@
-__kernel void matrix_multiplication(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+#define TILE_SIZE 16
+#define WORK_PER_THREAD 16
+
+__kernel void matrix_multiplication_naive(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    float sum = 0.0f;
+    for (int k = 0; k < K; k++) {
+        sum += a[j * K + k] * b[k * N + i];
+    }
+    c[j * N + i] = sum;
+}
+
+__kernel void matrix_multiplication_local(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
+{
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    int group_i = get_group_id(0);
+    int group_j = get_group_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (int tileK = 0; tileK * TILE_SIZE < K; tileK++) {
+        tileA[local_j][local_i] = a[(group_j * TILE_SIZE + local_j) * K + tileK * TILE_SIZE + local_i];
+        tileB[local_j][local_i] = b[(tileK * TILE_SIZE + local_j) * K + group_i * TILE_SIZE + local_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[j * N + i] = sum;
+}
+
+__kernel void matrix_multiplication_local_work(__global float *a, __global float *b, __global float *c, unsigned int M, unsigned int K, unsigned int N)
+{
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    int group_i = get_group_id(0);
+    int group_j = get_group_id(1);
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum[TILE_SIZE];
+    for (int k = 0; k < TILE_SIZE; k++)
+        sum[k] = 0.0f;
+
+    for (int tileK = 0; tileK * TILE_SIZE < K; tileK++) {
+        for (int k = 0; k < TILE_SIZE; k++) {
+            tileA[k][local_i] = a[(group_j * TILE_SIZE + k) * K + tileK * TILE_SIZE + local_i];
+            tileB[k][local_i] = b[(tileK * TILE_SIZE + k) * N + group_i * TILE_SIZE + local_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; k++) {
+            float tmp = tileB[k][local_i];
+            for (int w = 0; w < TILE_SIZE; w++) {
+                sum[w] += tmp * tileA[w][k];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (int k = 0; k < TILE_SIZE; k++)
+        c[(group_j * TILE_SIZE + k) * N + group_i * TILE_SIZE + local_i] = sum[k];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,27 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose(__global float *a, __global float *at, unsigned int m, unsigned int k)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][local_i] = a[j * k + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int group_i = get_group_id(0);
+    int group_j = get_group_id(1);
+
+    at[group_i * m * TILE_SIZE + group_j * TILE_SIZE + local_j * m + local_i] = tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -58,7 +58,6 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
@@ -67,42 +66,54 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
+    const std::vector<std::string> names = {"matrix_multiplication_naive", "matrix_multiplication_local", "matrix_multiplication_local_work"};
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+    for (const auto& name : names) {
 
-            t.nextLap();
+        std::cout << "============ " << name << " ============" << std::endl;
+
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                 name);
+        matrix_multiplication_kernel.compile();
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                // TODO
+                unsigned int work_group_size = 16;
+                unsigned int global_work_size = M;
+                gpu::WorkSize size = gpu::WorkSize(work_group_size, work_group_size, global_work_size, global_work_size);
+                if (name == names[2]) {
+                    size = gpu::WorkSize(work_group_size, 1, global_work_size, global_work_size / work_group_size);
+                }
+                matrix_multiplication_kernel.exec(size, as_gpu, bs_gpu,
+                                                  cs_gpu, M, K, N);
+
+                t.nextLap();
+            }
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+        cs_gpu.readN(cs.data(), M * N);
 
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        // Проверяем корректность результатов
+        double diff_sum = 0;
+        for (int i = 0; i < M * N; ++i) {
+            double a = cs[i];
+            double b = cs_cpu_reference[i];
+            if (a != 0.0 || b != 0.0) {
+                double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+                diff_sum += diff;
+            }
         }
-    }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+        double diff_avg = diff_sum / (M * N);
+        std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+        if (diff_avg > 0.01) {
+            std::cerr << "Too big difference!" << std::endl;
+            return 1;
+        }
     }
 
     return 0;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -46,14 +45,15 @@ int main(int argc, char **argv)
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 16;
+            unsigned int global_work_size = M;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            gpu::WorkSize size = gpu::WorkSize(work_group_size, work_group_size, global_work_size, global_work_size);
+            matrix_transpose_kernel.exec(size, as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +74,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод transpose для CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
Data generated for M=1024, K=1024
GPU: 0.000978667+-9.77372e-05 s
GPU: 1071.43 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод transpose для GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Data generated for M=1024, K=1024
GPU: 0.000276833+-2.03443e-06 s
GPU: 3787.75 millions/s
</pre>

</p></details>

<details><summary>Вывод GitHub CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024
GPU: 0.00135167+-0.000187397 s
GPU: 775.765 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод multiply для CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 15.6941+-0.413812 s
CPU: 0.127437 GFlops
============ matrix_multiplication_naive ============
GPU: 0.0387767+-0.000258177 s
GPU: 51.5774 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local ============
GPU: 0.0576715+-0.000716148 s
GPU: 34.6792 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local_work ============
GPU: 0.0505713+-0.000465209 s
GPU: 39.5481 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Локальный вывод multiply для GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 11.5329+-0.0644261 s
CPU: 0.173418 GFlops
============ matrix_multiplication_naive ============
GPU: 0.0507243+-0.000327238 s
GPU: 39.4288 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local ============
GPU: 0.0199415+-1.14127e-05 s
GPU: 100.293 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local_work ============
GPU: 0.0176692+-1.96674e-05 s
GPU: 113.192 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Вывод GitHub CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.47379+-0.00178088 s
CPU: 0.575739 GFlops
============ matrix_multiplication_naive ============
GPU: 0.0819568+-0.000578162 s
GPU: 24.4031 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local ============
GPU: 0.154796+-0.000570338 s
GPU: 12.9202 GFlops
Average difference: 0.000149043%
============ matrix_multiplication_local_work ============
GPU: 0.109464+-0.000987077 s
GPU: 18.2708 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

## Выводы

`Too big workgroup size for this kernel: 1024!` -- ошибка падала на GPU,  поэтому использовал `work_group_size = 16 * 16`.

Третий алгоритм лучший по времени. Это значит, что мы много времени тратим на обращение к памяти (пусть даже и локальной), раз уменьшение загрузок из нее нас так ускорило.