### PR TITLE
Task04 Igor Korkin SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,80 @@
-__kernel void matrix_multiplication(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define TILE_SIZE 32
+
+__kernel void matrix_multiplication_naive(__global const float* as, __global const float* bs, __global float* cs,
+                                    unsigned int M, unsigned int K, unsigned int N) // Ha-ha, MKN.
 {
-    // TODO
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    float sum = 0.f;
+    for (int k = 0; k < K; ++k) {
+        sum += as[j * K + k] * bs[k * N + i];
+    }
+    cs[j * N + i] = sum;
+}
+
+__kernel void matrix_multiplication_local_memory(__global const float* as, __global const float* bs, __global float* cs,
+                                          unsigned int M, unsigned int K, unsigned int N) // Ha-ha, MKN.
+{
+    const unsigned int lid_i = get_local_id(0);
+    const unsigned int lid_j = get_local_id(1);
+    const unsigned int gid_i = get_global_id(0);
+    const unsigned int gid_j = get_global_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.f;
+    for (int k_tile = 0; k_tile * TILE_SIZE < K; ++k_tile) {
+        tile_a[lid_j][lid_i] = as[gid_j * K + k_tile * TILE_SIZE + lid_i];
+        tile_b[lid_j][lid_i] = bs[(k_tile * TILE_SIZE + lid_j) * N + gid_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k)
+            sum += tile_a[lid_j][k] * tile_b[k][lid_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    cs[gid_j * N + gid_i] = sum;
+}
+
+#define THREAD_WORK 8
+#define GAP (TILE_SIZE / THREAD_WORK)
+
+__kernel void matrix_multiplication_MWPT(__global const float* as, __global const float* bs, __global float* cs,
+                                                 unsigned int M, unsigned int K, unsigned int N) // Ha-ha, MKN.
+{
+    const unsigned int lid_i = get_local_id(0);
+    const unsigned int lid_j = get_local_id(1);
+    const unsigned int gid_i = get_global_id(0);
+    const unsigned int gid_j = get_global_id(1);
+
+    __local float tile_a[TILE_SIZE][TILE_SIZE];
+    __local float tile_b[TILE_SIZE][TILE_SIZE];
+
+    float sum[THREAD_WORK] = {};
+
+    for (int k_tile = 0; k_tile * TILE_SIZE < K; ++k_tile) {
+        for (int t = 0; t < THREAD_WORK; ++t) {
+            tile_a[lid_j + t * GAP][lid_i] = as[(gid_j + t * GAP) * K + k_tile * TILE_SIZE + lid_i];
+            tile_b[lid_j + t * GAP][lid_i] = bs[(k_tile * TILE_SIZE + lid_j + t * GAP) * N + gid_i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE; ++k)
+            for (int t = 0; t < THREAD_WORK; ++t)
+                sum[t] += tile_a[lid_j + t * GAP][k] * tile_b[k][lid_i];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    for (int t = 0; t < THREAD_WORK; ++t)
+        cs[(gid_j + t * GAP) * N + gid_i] = sum[t];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -14,9 +14,12 @@ __kernel void matrix_transpose(__global const float* as, __global float* as_t, u
     const unsigned int gid_j = get_global_id(1);
 
     __local float tile[TILE_SIZE][TILE_SIZE];
-    tile[lid_i][lid_j] = as[gid_j * K + gid_i];
+    tile[lid_j][lid_i] = as[gid_j * K + gid_i];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    as_t[gid_i * M + gid_j] = tile[lid_i][lid_j];
+    const unsigned int wid_i = get_group_id(0);
+    const unsigned int wid_j = get_group_id(1);
+
+    as_t[(wid_i * TILE_SIZE + lid_j) * M + (wid_j * TILE_SIZE) + lid_i] = tile[lid_i][lid_j];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,22 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define TILE_SIZE 32
+
+__kernel void matrix_transpose(__global const float* as, __global float* as_t, unsigned int M, unsigned int K)
 {
-    // TODO
+    const unsigned int lid_i = get_local_id(0);
+    const unsigned int lid_j = get_local_id(1);
+    const unsigned int gid_i = get_global_id(0);
+    const unsigned int gid_j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    tile[lid_i][lid_j] = as[gid_j * K + gid_i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    as_t[gid_i * M + gid_j] = tile[lid_i][lid_j];
 }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -46,14 +45,15 @@ int main(int argc, char **argv)
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 32;
+            unsigned int global_work_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+            unsigned int global_work_size_y = (K + work_group_size - 1) / work_group_size * work_group_size;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, global_work_size_x, global_work_size_y), as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +74,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
Я постарался, у меня не получилось. Видимо, главным вопросом в этом семестре будет то, научусь ли я сдавать работы вовремя, а не ночью после дедлайна. А то мне очень стыдно за всё это, хоть и мои вылеты из жизни далеко не всегда мною контролируются.

Кстати, случайная музыкальная рекомендация: Dead Girls by Penelope Scott. Слушал её буквально всё время, которое делал домашку, занятная песня.

Задание 4.1. Транспонирование матрицы
--

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15741 Mb
Using device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15741 Mb
Data generated for M=1024, K=1024
GPU: 0.00183333+-0.000372678 s
GPU: 571.951 millions/s

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024
GPU: 0.00166283+-0.000156726 s
GPU: 630.596 millions/s
</pre>

</p></details>

Задание 4.2. Умножение матриц
--

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15741 Mb
Using device #0: CPU. AMD Ryzen 5 4600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15741 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 6.77883+-0.0598482 s
CPU: 0.295036 GFlops
GPU naive: 0.1045+-0.00214087 s
GPU naive: 19.1388 GFlops
Average difference: 0.000196008%
GPU local memory: 0.028+-0.00251661 s
GPU local memory: 71.4286 GFlops
Average difference: 0.000196008%
GPU MWPT: 0.023+-0.00152753 s
GPU MWPT: 86.9565 GFlops
Average difference: 0.000196008%

Process finished with exit code 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.90706+-0.000217753 s
CPU: 0.511894 GFlops
GPU naive: 0.0911763+-0.000225932 s
GPU naive: 21.9355 GFlops
Average difference: 0.000149043%
GPU local memory: 0.0852822+-0.000149478 s
GPU local memory: 23.4516 GFlops
Average difference: 0.000149043%
GPU MWPT: 0.0776933+-0.000459432 s
GPU MWPT: 25.7422 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

**4.2.3.**

Не совсем про производительность, но сначала меня удивило, что во всех трёх вариантов вышел одинаковый average difference, но потом до меня дошло, что выполнялись одни и те же операции сложения и умножения на одном и том же устройстве, так что равенство этих значений имеет место быть.

А теперь про производительность: на моём компьютере, как и предполагалось, наивный алгоритм работает медленнее, чем алгоритм с локальной памятью, а последний работает медленнее, чем алгоритм с перезагрузом потока. Но при этом, если поставить `#define THREAD_WORK 32`, то тогда алгоритм с перезагрузом потока начинает работать медленнее (возможно, потому, что теперь всю математику делает всего один поток).

Шутка же произошла с Github CI, ибо у меня почему-то все три скорости примерно равны. Я посмотрел в выводы других учащихся, и у всех (из тех, что я посмотрел) алгоритмы с локальной памятью работают дольше, чем наивный. Я не знаю, какую чёрную магию я применил, что два последних алгоритма ускорились на локальной машине и не замедлились тут, но я просто приму это, как данность.