### PR TITLE
Task05 Стойко Николай ITMO

### DIFF
--- a/src/cl/merge.cl
+++ b/src/cl/merge.cl
@@ -1,1 +1,50 @@
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#include <float.h>
+#endif
 
+__kernel void merge(__global const float *as,
+                        __global float *bs,
+                        const unsigned int n,
+                        const unsigned int width) {
+    int globalId = get_global_id(0);
+    int groupId = globalId / width;
+
+    int leftA = groupId * width;
+    int rightA = leftA + width;
+    int localId = globalId - leftA;
+
+    bool isRight = groupId % 2;
+
+    int otherL = isRight ? leftA - width : rightA;
+    int otherR = isRight ? leftA : rightA + width;
+    int start = isRight ? leftA - width : leftA;
+
+    int l = otherL - 1, r = otherR, m = 0;
+
+    bool isLeft = !isRight;
+    float v = globalId < n ? as[globalId] : FLT_MAX;
+    float base = FLT_MIN;
+
+    while (r - l > 1) {
+        m = (l + r) / 2;
+        base = as[m];
+
+        if (m >= otherR){
+            base = FLT_MAX;
+        } else if (m < otherL) {
+            base = FLT_MIN;
+        }
+
+        if (v < base || isLeft && v <= base)
+            r = m;
+        else
+            l = m;
+    }
+
+    unsigned int index = start + localId + r - otherL;
+
+    if (globalId < n && index < n){
+        bs[index] = v;
+    }
+}

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -50,9 +50,10 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
-    gpu::gpu_mem_32f as_gpu;
+
+    gpu::gpu_mem_32f as_gpu, bs_gpu;
     as_gpu.resizeN(n);
+    bs_gpu.resizeN(n);
     {
         ocl::Kernel merge(merge_kernel, merge_kernel_length, "merge");
         merge.compile();
@@ -62,7 +63,11 @@ int main(int argc, char **argv) {
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфера данных
             unsigned int workGroupSize = 128;
             unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            merge.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            for (unsigned int w = 1; w < n; w <<= 1) {
+                merge.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                               as_gpu, bs_gpu, n, w);
+                as_gpu.swap(bs_gpu);
+            }
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -73,6 +78,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
### **Задание 5.1.** Базовое, за него можно получить 10/10 баллов.

<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Data generated for n=33554432!
CPU: 12.285+-0 s
CPU: 2.6862 millions/s
GPU: 0.296+-0 s
GPU: 111.486 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.59384+-0.000699435 s
CPU: 9.18237 millions/s
GPU: 8.00671+-0.0281291 s
GPU: 4.12154 millions/s
</pre>
</p></details>


Видимо, в CI std::sort (quick-sort + merge-sort) оказался быстрее чем merge-sort из-за асимптотики.