### PR TITLE
Task04 Константин Гамора ITMO

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,5 +33,5 @@ jobs:
       run: ./matrix_transpose
 
     - name: matrix_multiplication
-      working-directory: ${{github.workspace}}/build
-      run: ./matrix_multiplication
+      working-directory: ${{github.workspace}}
+      run: ./run.sh

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+./build/matrix_multiplication "matrix_multiplication_naive"
+./build/matrix_multiplication "matrix_multiplication_local_memory"
+./build/matrix_multiplication "matrix_multiplication_more_work_per_thread"

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -27,16 +27,17 @@ __kernel void matrix_multiplication_local_memory(__global const float *lmat, __g
     const int fcol = get_global_id(0);
     const int frow = get_global_id(1);
 
-    int local_row = get_local_id(0);
     int local_col = get_local_id(0);
+    int local_row = get_local_id(1);
 
     __local float ltile[TILE_SIZE][TILE_SIZE];
     __local float rtile[TILE_SIZE][TILE_SIZE];
 
     float sum = 0.0f;
     for (int tileK = 0; tileK * TILE_SIZE < ncommon; tileK++) {
-        ltile[local_row][local_col] = lmat[(frow * ncommon) + ((tileK * TILE_SIZE) + local_col)];
-        rtile[local_row][local_col] = rmat[(((tileK * TILE_SIZE) + local_row) * rncol) + fcol];
+        int kstart = tileK * TILE_SIZE;
+        ltile[local_row][local_col] = lmat[(frow * ncommon) + (kstart + local_col)];
+        rtile[local_row][local_col] = rmat[((kstart + local_row) * rncol) + fcol];
 
         barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -43,9 +43,58 @@ __kernel void matrix_multiplication_local_memory(__global const float *lmat, __g
 
         for (int k = 0; k < TILE_SIZE; k++)
             sum += ltile[local_row][k] * rtile[k][local_col];
-        
+
         barrier(CLK_LOCAL_MEM_FENCE);
     }
 
     fmat[(frow * rncol) + fcol] = sum;
+}
+
+#define WORK_PER_THREAD 4
+#define RTS (TILE_SIZE / WORK_PER_THREAD)
+__kernel void matrix_multiplication_more_work_per_thread(__global const float *lmat, __global const float *rmat,
+                                                         __global float *fmat, const unsigned int lnrow,
+                                                         const unsigned int ncommon, const unsigned int rncol) {
+    unsigned int local_col = get_local_id(0);
+    unsigned int local_row = get_local_id(1);
+
+    unsigned int fcol = get_global_id(0);
+    unsigned int frow = get_group_id(1) * TILE_SIZE + local_row;
+
+    __local float ltile[TILE_SIZE][TILE_SIZE];
+    __local float rtile[TILE_SIZE][TILE_SIZE];
+
+    float sum[WORK_PER_THREAD];
+    for (unsigned int i = 0; i < WORK_PER_THREAD; i++) {
+        sum[i] = 0.0f;
+    }
+
+    for (unsigned int kstart = 0; kstart < ncommon; kstart+=TILE_SIZE) {
+
+        for (unsigned int i = 0; i < WORK_PER_THREAD; i++) {
+            unsigned int frow_actual = frow + i * RTS;
+            ltile[local_row + i * RTS][local_col] =
+                    (fcol < rncol && frow_actual < lnrow) ? lmat[frow_actual * ncommon + kstart + local_col] : 0;
+            rtile[local_row + i * RTS][local_col] =
+                    (fcol < rncol && frow_actual < lnrow) ? rmat[(kstart + local_row + i * RTS) * rncol + fcol] : 0;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned int k = 0; k < TILE_SIZE; k++) {
+            float tmp = rtile[k][local_col];
+            for (unsigned int i = 0; i < WORK_PER_THREAD; i++) {
+                sum[i] += ltile[local_row + i * RTS][k] * tmp;
+            }
+        }
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (unsigned int i = 0; i < WORK_PER_THREAD; i++) {
+        unsigned int frown = frow + i * RTS;
+        if (fcol < rncol && frown < lnrow) {
+            fmat[frown * rncol + fcol] = sum[i];
+        }
+    }
 }

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -40,7 +40,7 @@ __kernel void matrix_multiplication_local_memory(__global const float *lmat, __g
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
-        for (int k = 0; k < TILE_SIZE;)
+        for (int k = 0; k < TILE_SIZE; k++)
             sum += ltile[local_row][k] * rtile[k][local_col];
         
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,50 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+__kernel void matrix_multiplication_naive(__global const float *lmat, __global const float *rmat, __global float *fmat,
+                                          const unsigned int lnrow, const unsigned int ncommon,
+                                          const unsigned int rncol) {
+    const int fcol = get_global_id(0);
+    const int frow = get_global_id(1);
+
+    float fval = 0.0f;
+
+    int lrow = frow;
+    int rcol = fcol;
+    int lncol = ncommon;
+    int rnrow = ncommon;
+
+    for (unsigned int i = 0; i < ncommon; i++) {
+        int lcol = i;
+        int rrow = i;
+        fval += lmat[(lrow * lncol) + lcol] * rmat[(rrow * rncol) + rcol];
+    }
+
+    fmat[(frow * rncol) + fcol] = fval;
+}
+
+#define TILE_SIZE 16
+__kernel void matrix_multiplication_local_memory(__global const float *lmat, __global const float *rmat,
+                                                 __global float *fmat, const unsigned int lnrow,
+                                                 const unsigned int ncommon, const unsigned int rncol) {
+    const int fcol = get_global_id(0);
+    const int frow = get_global_id(1);
+
+    int local_row = get_local_id(0);
+    int local_col = get_local_id(0);
+
+    __local float ltile[TILE_SIZE][TILE_SIZE];
+    __local float rtile[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (int tileK = 0; tileK * TILE_SIZE < ncommon; tileK++) {
+        ltile[local_row][local_col] = lmat[(frow * ncommon) + ((tileK * TILE_SIZE) + local_col)];
+        rtile[local_row][local_col] = rmat[(((tileK * TILE_SIZE) + local_row) * rncol) + fcol];
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (int k = 0; k < TILE_SIZE;)
+            sum += ltile[local_row][k] * rtile[k][local_col];
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    fmat[(frow * rncol) + fcol] = sum;
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,20 @@
-__kernel void matrix_transpose(...)
-{
-    // TODO
+#define TILE_SIZE 16
+__kernel void matrix_transpose(__global const float *mat, __global float *mat_tr, int nrow, int ncol) {
+    const int local_col = get_local_id(0);
+    const int local_row = get_local_id(1);
+
+    const int col = get_global_id(0);
+    const int row = get_global_id(1);
+
+    __local float local_mat[TILE_SIZE][TILE_SIZE];
+
+    const int ind = (row * ncol) + col;
+
+    local_mat[local_row][local_col] = mat[ind];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int ind_tr = (col * nrow) + row;
+
+    mat_tr[ind_tr] = local_mat[local_row][local_col];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -23,7 +23,15 @@ __kernel void matrix_transpose(__global const float *mat, __global float *mat_tr
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    const int ind_tr = (col * nrow) + row;
+    const int local_ind_tr = (local_col * local_ncol) + local_row;
+    
+    const int tile_col_tr = local_ind_tr % TILE_COLS;
+    const int tile_row_tr = local_ind_tr / TILE_COLS;
 
-    mat_tr[ind_tr] = local_mat[tile_row][tile_col];
+    const int base_col = get_group_id(1) * local_nrow;
+    const int base_row = get_group_id(0) * local_ncol;
+
+    const int ind_tr = ((base_row + local_row) * ncol) + (base_col + local_col);
+
+    mat_tr[ind_tr] = local_mat[tile_row_tr][tile_col_tr];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,20 +1,29 @@
-#define TILE_SIZE 16
+#define TILE_ROWS 16
+#define TILE_COLS (TILE_ROWS + 1)
 __kernel void matrix_transpose(__global const float *mat, __global float *mat_tr, int nrow, int ncol) {
     const int local_col = get_local_id(0);
     const int local_row = get_local_id(1);
 
+    const int local_ncol = get_local_size(0);
+    const int local_nrow = get_local_size(1);
+
+    const int local_ind = (local_row * local_ncol) + local_col;
+
     const int col = get_global_id(0);
     const int row = get_global_id(1);
 
-    __local float local_mat[TILE_SIZE][TILE_SIZE];
+    __local float local_mat[TILE_ROWS][TILE_COLS];
+
+    const int tile_col = local_ind % TILE_COLS;
+    const int tile_row = local_ind / TILE_COLS;
 
     const int ind = (row * ncol) + col;
 
-    local_mat[local_row][local_col] = mat[ind];
+    local_mat[tile_row][tile_col] = mat[ind];
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
     const int ind_tr = (col * nrow) + row;
 
-    mat_tr[ind_tr] = local_mat[local_row][local_col];
+    mat_tr[ind_tr] = local_mat[tile_row][tile_col];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
+    int benchmarkingIters = 1; // TODO пока тестируетесь удобно выставить единицу
     unsigned int M = 1024;
     unsigned int K = 1024;
     unsigned int N = 1024;
@@ -58,7 +58,6 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
@@ -67,7 +66,7 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_local_memory");
     matrix_multiplication_kernel.compile();
 
     {
@@ -75,8 +74,8 @@ int main(int argc, char **argv)
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
             unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+            unsigned int global_work_size = M * N;
+            matrix_multiplication_kernel.exec(gpu::WorkSize(16, 16, M, N), as_gpu, bs_gpu, cs_gpu, M, K, N);
 
             t.nextLap();
         }
@@ -85,7 +84,6 @@ int main(int argc, char **argv)
     }
 
     cs_gpu.readN(cs.data(), M*N);
-    */
 
     // Проверяем корректность результатов
     double diff_sum = 0;

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -11,6 +11,7 @@
 #include <stdexcept>
 
 
+#define WORK_PER_THREAD 8
 int main(int argc, char **argv)
 {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
@@ -66,7 +67,7 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_local_memory");
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_more_work_per_thread");
     matrix_multiplication_kernel.compile();
 
     {
@@ -75,7 +76,7 @@ int main(int argc, char **argv)
             // TODO
             unsigned int work_group_size = 128;
             unsigned int global_work_size = M * N;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(16, 16, M, N), as_gpu, bs_gpu, cs_gpu, M, K, N);
+            matrix_multiplication_kernel.exec(gpu::WorkSize(16, 4, M, N / 4), as_gpu, bs_gpu, cs_gpu, M, K, N);
 
             t.nextLap();
         }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 1; // TODO пока тестируетесь удобно выставить единицу
+    int benchmarkingIters = 10; // TODO пока тестируетесь удобно выставить единицу
     unsigned int M = 1024;
     unsigned int K = 1024;
     unsigned int N = 1024;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -1,18 +1,17 @@
-#include <libutils/misc.h>
-#include <libutils/timer.h>
-#include <libutils/fast_random.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/matrix_transpose_cl.h"
 
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <vector>
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
@@ -23,21 +22,21 @@ int main(int argc, char **argv)
     unsigned int M = 1024;
     unsigned int K = 1024;
 
-    std::vector<float> as(M*K, 0);
-    std::vector<float> as_t(M*K, 0);
+    std::vector<float> as(M * K, 0);
+    std::vector<float> as_t(M * K, 0);
 
-    FastRandom r(M+K);
+    FastRandom r(M + K);
     for (unsigned int i = 0; i < as.size(); ++i) {
         as[i] = r.nextf();
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
-    gpu::gpu_mem_32f as_gpu, as_t_gpu;
-    as_gpu.resizeN(M*K);
-    as_t_gpu.resizeN(K*M);
 
-    as_gpu.writeN(as.data(), M*K);
+    gpu::gpu_mem_32f as_gpu, as_t_gpu;
+    as_gpu.resizeN(M * K);
+    as_t_gpu.resizeN(K * M);
+
+    as_gpu.writeN(as.data(), M * K);
 
     ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose");
     matrix_transpose_kernel.compile();
@@ -47,21 +46,21 @@ int main(int argc, char **argv)
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
             unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int global_work_size = M * K;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(16, 16, M, K), as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << M*K/1000.0/1000.0 / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << M * K / 1000.0 / 1000.0 / t.lapAvg() << " millions/s" << std::endl;
     }
 
-    as_t_gpu.readN(as_t.data(), M*K);
+    as_t_gpu.readN(as_t.data(), M * K);
 
     // Проверяем корректность результатов
     for (int j = 0; j < M; ++j) {
@@ -74,7 +73,7 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
+
 
     return 0;
 }


### PR DESCRIPTION
Транспонирование матрицы

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./matrix_transpose 
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for M=1024, K=1024
GPU: 0.00304983+-0.000261792 s
GPU: 343.814 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./matrix_transpose
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024
GPU: 0.00228717+-0.000118644 s
GPU: 458.461 millions/s
</pre>

</p></details>

Умножение матриц

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./run.sh 
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 22.0311+-0 s
CPU: 0.0907808 GFlops
GPU: 0.279081+-0 s
GPU: 7.16638 GFlops
Average difference: 0.000149043%
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 22.1109+-0 s
CPU: 0.090453 GFlops
GPU: 0.129855+-0 s
GPU: 15.4018 GFlops
Average difference: 0.000149043%
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 22.4639+-0 s
CPU: 0.0890318 GFlops
GPU: 0.081969+-0 s
GPU: 24.3995 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./run.sh
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.8809+-0.00292847 s
CPU: 0.515344 GFlops
GPU: 0.094074+-0.0011863 s
GPU: 21.2599 GFlops
Average difference: 0.000149043%
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.6776+-0.00250698 s
CPU: 0.543832 GFlops
GPU: 0.183364+-0.000689689 s
GPU: 10.9073 GFlops
Average difference: 0.000149043%
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.90788+-0.00664371 s
CPU: 0.511787 GFlops
GPU: 0.103563+-0.000958598 s
GPU: 19.3119 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

Сравнение результатов

| GFlops                 | Локальный запуск | GH Actions |
|------------------------|------------------|------------|
| Наивно                 | 7.16638          | 21.2599    |
| Локальная память       | 15.4018          | 10.9073    |
| Больше работы на поток | 24.3995          | 19.3119    |

> UPD: извините, что так `сильно` вылез за дедлайн. Просрочка была бы не настолько сильной, если бы меня не съел `more_work_per_tread`