### PR TITLE
Task05 Антон Суркис ITMO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 add_subdirectory(libs)
 
@@ -20,6 +20,5 @@ endif()
 # Она считывает все байты из файла src/cl/aplusb.cl (т.е. весь исходный код кернела) и преобразует их в массив байтов в файле src/cl/aplusb_cl.h aplusb_kernel
 # Обратите внимание что это происходит на этапе компиляции, кроме того необходимо чтобы файл src/cl/aplusb_cl.h был перечислен среди исходников для компиляции при вызове add_executable
 
-convertIntoHeader(src/cl/merge.cl src/cl/merge_cl.h merge_kernel)
-add_executable(merge src/main_merge.cpp src/cl/merge_cl.h)
+add_executable(merge src/main_merge.cpp)
 target_link_libraries(merge libclew libgpu libutils)

--- a/src/cl/clion_defines.cl
+++ b/src/cl/clion_defines.cl
@@ -72,4 +72,7 @@ void atomic_add(...);
 // 64 for AMD, 32 for NVidia, 8 for intel GPUs, 1 for CPU
 #define WARP_SIZE 64
 
+#define WORK_GROUP_SIZE 64
+using uint = unsigned int;
+
 #endif // pragma once

--- a/src/cl/merge.cl
+++ b/src/cl/merge.cl
@@ -1,8 +1,8 @@
-uint binsearch_lt(
-    float x,
-    __global const float* arr,
-    uint len
-) {
+#ifdef __CLION_IDE__
+    #include "clion_defines.cl"
+#endif
+
+uint simple_binsearch_lt(float x, const float *arr, uint len) {
     if (arr[0] >= x) {
         return 0;
     }
@@ -19,11 +19,7 @@ uint binsearch_lt(
     return r;
 }
 
-uint binsearch_le(
-    float x,
-    __global const float* arr,
-    uint len
-) {
+uint simple_binsearch_le(float x, const float *arr, uint len) {
     if (arr[0] > x) {
         return 0;
     }
@@ -40,34 +36,64 @@ uint binsearch_le(
     return r;
 }
 
-__kernel void merge(
-    __global const float* src,
-    __global float* dst,
-    uint len,
-    uint sorted_block_len
-) {
-    uint src_flat_id = get_global_id(0);
+void simple_merge_pass(const float *src, float *dst, uint len, uint sorted_block_len, uint src_flat_id) {
     if (src_flat_id >= len) {
         return;
     }
 
     uint own_block = src_flat_id / sorted_block_len;
-    uint sib_block = own_block ^ 1; // *sib*ling
+    uint sib_block = own_block ^ 1;// *sib*ling
 
     uint own_block_start = own_block * sorted_block_len;
     uint sib_block_start = sib_block * sorted_block_len;
 
-    uint own_block_end = min(len, own_block_start + sorted_block_len);
+    //uint own_block_end = min(len, own_block_start + sorted_block_len);
     uint sib_block_end = min(len, sib_block_start + sorted_block_len);
+    uint sib_block_len = sib_block_end - sib_block_start;
+    const float *sib_block_src = src + sib_block_start;
 
     uint dst_flat_id = src_flat_id - own_block % 2 * sorted_block_len;
     float x = src[src_flat_id];
     bool is_left = own_block % 2 == 0;
     if (is_left) {
-        dst_flat_id += binsearch_lt(x, src + sib_block_start, sib_block_end - sib_block_start);
+        dst_flat_id += simple_binsearch_lt(x, sib_block_src, sib_block_len);
     } else {
-        dst_flat_id += binsearch_le(x, src + sib_block_start, sib_block_end - sib_block_start);
+        dst_flat_id += simple_binsearch_le(x, sib_block_src, sib_block_len);
     }
 
     dst[dst_flat_id] = x;
+}
+
+__kernel void simple_merge_phase_local(__global const float *src, __global float *dst, uint len) {
+    __local float buf1[WORK_GROUP_SIZE];
+    __local float buf2[WORK_GROUP_SIZE];
+
+    uint global_id = get_global_id(0);
+    uint local_id = get_local_id(0);
+    uint local_start = global_id - local_id;
+    uint local_len = min(len - local_start, (uint) WORK_GROUP_SIZE);
+
+    buf1[local_id] = global_id < len ? src[global_id] : 0.0;
+    buf2[local_id] = 0.0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+    float *local_src = buf1;
+    float *local_dst = buf2;
+
+    for (uint sorted_size = 1; sorted_size < local_len; sorted_size *= 2) {
+        simple_merge_pass(local_src, local_dst, local_len, sorted_size, local_id);
+        barrier(CLK_LOCAL_MEM_FENCE);
+        float *tmp = local_src;
+        local_src = local_dst;
+        local_dst = tmp;
+    }
+
+    if (global_id < len) {
+        dst[global_id] = local_src[local_id];
+    }
+}
+
+__kernel void simple_merge_phase_global(__global const float *src, __global float *dst, uint len,
+                                        uint sorted_block_len) {
+    uint src_flat_id = get_global_id(0);
+    simple_merge_pass(src, dst, len, sorted_block_len, src_flat_id);
 }

--- a/src/cl/merge.cl
+++ b/src/cl/merge.cl
@@ -1,1 +1,73 @@
+uint binsearch_lt(
+    float x,
+    __global const float* arr,
+    uint len
+) {
+    if (arr[0] >= x) {
+        return 0;
+    }
+    uint l = 0;
+    uint r = len;
+    while (l + 1 < r) {
+        uint m = l + (r - l) / 2;
+        if (arr[m] < x) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    return r;
+}
 
+uint binsearch_le(
+    float x,
+    __global const float* arr,
+    uint len
+) {
+    if (arr[0] > x) {
+        return 0;
+    }
+    uint l = 0;
+    uint r = len;
+    while (l + 1 < r) {
+        uint m = l + (r - l) / 2;
+        if (arr[m] <= x) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    return r;
+}
+
+__kernel void merge(
+    __global const float* src,
+    __global float* dst,
+    uint len,
+    uint sorted_block_len
+) {
+    uint src_flat_id = get_global_id(0);
+    if (src_flat_id >= len) {
+        return;
+    }
+
+    uint own_block = src_flat_id / sorted_block_len;
+    uint sib_block = own_block ^ 1; // *sib*ling
+
+    uint own_block_start = own_block * sorted_block_len;
+    uint sib_block_start = sib_block * sorted_block_len;
+
+    uint own_block_end = min(len, own_block_start + sorted_block_len);
+    uint sib_block_end = min(len, sib_block_start + sorted_block_len);
+
+    uint dst_flat_id = src_flat_id - own_block % 2 * sorted_block_len;
+    float x = src[src_flat_id];
+    bool is_left = own_block % 2 == 0;
+    if (is_left) {
+        dst_flat_id += binsearch_lt(x, src + sib_block_start, sib_block_end - sib_block_start);
+    } else {
+        dst_flat_id += binsearch_le(x, src + sib_block_start, sib_block_end - sib_block_start);
+    }
+
+    dst[dst_flat_id] = x;
+}

--- a/src/cl/merge_diag.cl
+++ b/src/cl/merge_diag.cl
@@ -1,0 +1,21 @@
+#ifdef __CLION_IDE__
+    #include "clion_defines.cl"
+#endif
+
+__kernel void calc_idx(__global const float *arr, __global uint *idx_a, __global uint *idx_b, uint len,
+                       uint sorted_block_len) {
+    // Here work groups don't correspond to phase 2
+    uint gid = get_global_id(0);
+    uint dst_block_len = 2 * sorted_block_len;
+    uint dst_id = WORK_GROUP_SIZE * gid;
+    uint diag = dst_id % dst_block_len;
+    uint dst_block = dst_id / dst_block_len;
+    uint dst_block_start = dst_block * dst_block_len;
+}
+
+__kernel void merge(__global const float *src, __global float *dst, __global const uint *idx_a,
+                    __global const uint *idx_b, uint len, uint sorted_len) {
+    __local float local_src_a[WORK_GROUP_SIZE];
+    __local float local_src_b[WORK_GROUP_SIZE];
+    __local float local_dst[WORK_GROUP_SIZE];
+}

--- a/src/cl/merge_simple.cl
+++ b/src/cl/merge_simple.cl
@@ -36,7 +36,7 @@ uint binsearch_le(float x, __global const float *arr, uint len) {
     return r;
 }
 
-__kernel void kmain(__global const float *src, __global float *dst, uint len, uint sorted_block_len) {
+__kernel void merge(__global const float *src, __global float *dst, uint len, uint sorted_block_len) {
     uint src_id = get_global_id(0);
     if (src_id >= len) {
         return;

--- a/src/cl/merge_simple.cl
+++ b/src/cl/merge_simple.cl
@@ -1,0 +1,66 @@
+#ifdef __CLION_IDE__
+    #include "clion_defines.cl"
+#endif
+
+uint binsearch_lt(float x, __global const float *arr, uint len) {
+    if (arr[0] >= x) {
+        return 0;
+    }
+    uint l = 0;
+    uint r = len;
+    while (l + 1 < r) {
+        uint m = l + (r - l) / 2;
+        if (arr[m] < x) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    return r;
+}
+
+uint binsearch_le(float x, __global const float *arr, uint len) {
+    if (arr[0] > x) {
+        return 0;
+    }
+    uint l = 0;
+    uint r = len;
+    while (l + 1 < r) {
+        uint m = l + (r - l) / 2;
+        if (arr[m] <= x) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    return r;
+}
+
+__kernel void kmain(__global const float *src, __global float *dst, uint len, uint sorted_block_len) {
+    uint src_id = get_global_id(0);
+    if (src_id >= len) {
+        return;
+    }
+
+    uint own_block = src_id / sorted_block_len;
+    uint sib_block = own_block ^ 1;// *sib*ling
+
+    uint own_block_start = own_block * sorted_block_len;
+    uint sib_block_start = sib_block * sorted_block_len;
+
+    //uint own_block_end = min(len, own_block_start + sorted_block_len);
+    uint sib_block_end = min(len, sib_block_start + sorted_block_len);
+    uint sib_block_len = sib_block_end - sib_block_start;
+    __global const float *sib_block_src = src + sib_block_start;
+
+    uint dst_id = src_id - own_block % 2 * sorted_block_len;
+    float x = src[src_id];
+    bool is_left = own_block % 2 == 0;
+    if (is_left) {
+        dst_id += binsearch_lt(x, sib_block_src, sib_block_len);
+    } else {
+        dst_id += binsearch_le(x, sib_block_src, sib_block_len);
+    }
+
+    dst[dst_id] = x;
+}

--- a/src/cl/merge_simple_local.cl
+++ b/src/cl/merge_simple_local.cl
@@ -66,7 +66,7 @@ void merge_pass(__local const float *src, __local float *dst, uint len, uint sor
     dst[dst_id] = x;
 }
 
-__kernel void kmain(__global const float *src, __global float *dst, uint len) {
+__kernel void merge(__global const float *src, __global float *dst, uint len) {
     __local float buf1[WORK_GROUP_SIZE];
     __local float buf2[WORK_GROUP_SIZE];
 

--- a/src/cl/merge_simple_local.cl
+++ b/src/cl/merge_simple_local.cl
@@ -2,7 +2,9 @@
     #include "clion_defines.cl"
 #endif
 
-uint simple_binsearch_lt(float x, const float *arr, uint len) {
+// The code is almost identical to normal merge pass, but the pointer types are in different space
+
+uint binsearch_lt(float x, __local const float *arr, uint len) {
     if (arr[0] >= x) {
         return 0;
     }
@@ -19,7 +21,7 @@ uint simple_binsearch_lt(float x, const float *arr, uint len) {
     return r;
 }
 
-uint simple_binsearch_le(float x, const float *arr, uint len) {
+uint binsearch_le(float x, __local const float *arr, uint len) {
     if (arr[0] > x) {
         return 0;
     }
@@ -36,12 +38,12 @@ uint simple_binsearch_le(float x, const float *arr, uint len) {
     return r;
 }
 
-void simple_merge_pass(const float *src, float *dst, uint len, uint sorted_block_len, uint src_flat_id) {
-    if (src_flat_id >= len) {
+void merge_pass(__local const float *src, __local float *dst, uint len, uint sorted_block_len, uint src_id) {
+    if (src_id >= len) {
         return;
     }
 
-    uint own_block = src_flat_id / sorted_block_len;
+    uint own_block = src_id / sorted_block_len;
     uint sib_block = own_block ^ 1;// *sib*ling
 
     uint own_block_start = own_block * sorted_block_len;
@@ -50,21 +52,21 @@ void simple_merge_pass(const float *src, float *dst, uint len, uint sorted_block
     //uint own_block_end = min(len, own_block_start + sorted_block_len);
     uint sib_block_end = min(len, sib_block_start + sorted_block_len);
     uint sib_block_len = sib_block_end - sib_block_start;
-    const float *sib_block_src = src + sib_block_start;
+    __local const float *sib_block_src = src + sib_block_start;
 
-    uint dst_flat_id = src_flat_id - own_block % 2 * sorted_block_len;
-    float x = src[src_flat_id];
+    uint dst_id = src_id - own_block % 2 * sorted_block_len;
+    float x = src[src_id];
     bool is_left = own_block % 2 == 0;
     if (is_left) {
-        dst_flat_id += simple_binsearch_lt(x, sib_block_src, sib_block_len);
+        dst_id += binsearch_lt(x, sib_block_src, sib_block_len);
     } else {
-        dst_flat_id += simple_binsearch_le(x, sib_block_src, sib_block_len);
+        dst_id += binsearch_le(x, sib_block_src, sib_block_len);
     }
 
-    dst[dst_flat_id] = x;
+    dst[dst_id] = x;
 }
 
-__kernel void simple_merge_phase_local(__global const float *src, __global float *dst, uint len) {
+__kernel void kmain(__global const float *src, __global float *dst, uint len) {
     __local float buf1[WORK_GROUP_SIZE];
     __local float buf2[WORK_GROUP_SIZE];
 
@@ -76,13 +78,13 @@ __kernel void simple_merge_phase_local(__global const float *src, __global float
     buf1[local_id] = global_id < len ? src[global_id] : 0.0;
     buf2[local_id] = 0.0;
     barrier(CLK_LOCAL_MEM_FENCE);
-    float *local_src = buf1;
-    float *local_dst = buf2;
+    __local float *local_src = buf1;
+    __local float *local_dst = buf2;
 
     for (uint sorted_size = 1; sorted_size < local_len; sorted_size *= 2) {
-        simple_merge_pass(local_src, local_dst, local_len, sorted_size, local_id);
+        merge_pass(local_src, local_dst, local_len, sorted_size, local_id);
         barrier(CLK_LOCAL_MEM_FENCE);
-        float *tmp = local_src;
+        __local float *tmp = local_src;
         local_src = local_dst;
         local_dst = tmp;
     }
@@ -90,10 +92,4 @@ __kernel void simple_merge_phase_local(__global const float *src, __global float
     if (global_id < len) {
         dst[global_id] = local_src[local_id];
     }
-}
-
-__kernel void simple_merge_phase_global(__global const float *src, __global float *dst, uint len,
-                                        uint sorted_block_len) {
-    uint src_flat_id = get_global_id(0);
-    simple_merge_pass(src, dst, len, sorted_block_len, src_flat_id);
 }

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
     context.activate();
 
     constexpr int benchmarkingIters = 10;
-    constexpr cl_uint n = 32 * 64 * 64;
+    constexpr cl_uint n = 32 * 1024 * 1024;
     constexpr cl_uint workGroupSize = 64;
     std::vector<float> as(n, 0);
     FastRandom r(n);

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -13,7 +13,7 @@
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+void raiseFail(const T &a, const T &b, const char *message, const char *filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -30,8 +30,9 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 1;
-    unsigned int n = 32 * 1024 * 1024;
+    int benchmarkingIters = 10;
+    constexpr cl_uint n = 32 * 1024 * 1024;
+    constexpr cl_uint workGroupSize = 64;
     std::vector<float> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -42,38 +43,75 @@ int main(int argc, char **argv) {
     std::vector<float> cpu_sorted;
     {
         timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            cpu_sorted = as;
-            std::sort(cpu_sorted.begin(), cpu_sorted.end());
-            t.nextLap();
-        }
+        //for (int iter = 0; iter < benchmarkingIters; ++iter) {
+        cpu_sorted = as;
+        //for (int i = 0; i < n; i += workGroupSize) {
+        //    std::sort(cpu_sorted.begin() + i, cpu_sorted.begin() + i + workGroupSize);
+        //}
+        std::sort(cpu_sorted.begin(), cpu_sorted.end());
+        t.nextLap();
+        //}
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
     }
+
+    gpu::WorkSize ws(workGroupSize, n);
+    std::ostringstream defines;
+    defines << "-DWORK_GROUP_SIZE=" << workGroupSize;
 
     gpu::gpu_mem_32f as_gpu;
     gpu::gpu_mem_32f bs_gpu;
     as_gpu.resizeN(n);
     bs_gpu.resizeN(n);
+
     {
-        ocl::Kernel merge(merge_kernel, merge_kernel_length, "merge");
+        ocl::Kernel merge(merge_kernel, merge_kernel_length, "simple_merge_phase_global", defines.str());
         merge.compile();
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфера данных
-            unsigned int workGroupSize = 128;
-            gpu::WorkSize ws(workGroupSize, n);
+
             for (cl_uint sortedSize = 1; sortedSize < n; sortedSize *= 2) {
-                merge.exec(ws, as_gpu, bs_gpu, cl_uint(n), sortedSize);
+                merge.exec(ws, as_gpu, bs_gpu, n, sortedSize);
                 std::swap(as_gpu, bs_gpu);
             }
+
             t.nextLap();
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU one phase: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU one phase: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
         as_gpu.readN(as.data(), n);
     }
+
+    {
+        ocl::Kernel phase1(merge_kernel, merge_kernel_length, "simple_merge_phase_local", defines.str());
+        ocl::Kernel phase2(merge_kernel, merge_kernel_length, "simple_merge_phase_global", defines.str());
+        phase1.compile();
+        phase2.compile();
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            as_gpu.writeN(as.data(), n);
+            t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфера данных
+
+            // Выделение фазы, когда сортируемый блок попадает в локальную память,
+            // и можно использовать синхронизацию барьерами, увеличивает производительность
+            // с 193 млн/с до 356 млн/с на GTX 1060, т.е. почти в два раза.
+            phase1.exec(ws, as_gpu, bs_gpu, n);
+            std::swap(as_gpu, bs_gpu);
+
+            for (cl_uint sortedSize = workGroupSize; sortedSize < n; sortedSize *= 2) {
+                phase2.exec(ws, as_gpu, bs_gpu, n, sortedSize);
+                std::swap(as_gpu, bs_gpu);
+            }
+
+            t.nextLap();
+        }
+        std::cout << "GPU two phases: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU two phases: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
+        as_gpu.readN(as.data(), n);
+    }
+
     //for (int i = 0; i < n; ++i) {
     //    std::cerr << "i=" << i << "\tcpu=" << cpu_sorted[i] << "\tgpu=" << as[i] << "\n";
     //}

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -34,8 +34,8 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
-    constexpr cl_uint n = 32 * 1024 * 1024;
+    constexpr int benchmarkingIters = 10;
+    constexpr cl_uint n = 32 * 64 * 64;
     constexpr cl_uint workGroupSize = 64;
     std::vector<float> as(n, 0);
     FastRandom r(n);
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     }
 
     std::string base_path = __FILE__;
-    base_path = base_path.substr(0, base_path.size() - 14);
+    base_path = base_path.substr(0, base_path.size() - 14) + "cl/";
 
     gpu::WorkSize ws(workGroupSize, n);
     std::ostringstream defines;

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
+    int benchmarkingIters = 1;
     unsigned int n = 32 * 1024 * 1024;
     std::vector<float> as(n, 0);
     FastRandom r(n);
@@ -48,11 +48,13 @@ int main(int argc, char **argv) {
             t.nextLap();
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
+    gpu::gpu_mem_32f bs_gpu;
     as_gpu.resizeN(n);
+    bs_gpu.resizeN(n);
     {
         ocl::Kernel merge(merge_kernel, merge_kernel_length, "merge");
         merge.compile();
@@ -61,18 +63,24 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфера данных
             unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            merge.exec(gpu::WorkSize(workGroupSize, global_work_size), as_gpu, n);
+            gpu::WorkSize ws(workGroupSize, n);
+            for (cl_uint sortedSize = 1; sortedSize < n; sortedSize *= 2) {
+                merge.exec(ws, as_gpu, bs_gpu, cl_uint(n), sortedSize);
+                std::swap(as_gpu, bs_gpu);
+            }
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << 1e-6 * n / t.lapAvg() << " millions/s" << std::endl;
         as_gpu.readN(as.data(), n);
     }
+    //for (int i = 0; i < n; ++i) {
+    //    std::cerr << "i=" << i << "\tcpu=" << cpu_sorted[i] << "\tgpu=" << as[i] << "\n";
+    //}
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_merge.cpp
+++ b/src/main_merge.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv) {
 
     {
         std::string src = read_kernel(base_path + "merge_simple.cl");
-        ocl::Kernel merge(src.c_str(), src.size(), "kmain", defines.str());
+        ocl::Kernel merge(src.c_str(), src.size(), "merge", defines.str());
         merge.compile();
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -96,8 +96,8 @@ int main(int argc, char **argv) {
     {
         std::string src1 = read_kernel(base_path + "merge_simple_local.cl");
         std::string src2 = read_kernel(base_path + "merge_simple.cl");
-        ocl::Kernel phase1(src1.c_str(), src1.size(), "kmain", defines.str());
-        ocl::Kernel phase2(src2.c_str(), src2.size(), "kmain", defines.str());
+        ocl::Kernel phase1(src1.c_str(), src1.size(), "merge", defines.str());
+        ocl::Kernel phase2(src2.c_str(), src2.size(), "merge", defines.str());
         phase1.compile();
         phase2.compile();
         timer t;


### PR DESCRIPTION
Локальный вывод:

```
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
Data generated for n=33554432!
CPU: 18.2474+-0.120566 s
CPU: 1.83886 millions/s
GPU one phase: 0.182696+-0.00137108 s
GPU one phase: 183.663 millions/s
GPU two phases: 0.0942235+-0.00054346 s
GPU two phases: 356.115 millions/s
```

Вывод в CI:

```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.60007+-0.000942469 s
CPU: 9.32049 millions/s
GPU one phase: 21.8321+-0.0112811 s
GPU one phase: 1.53693 millions/s
GPU two phases: 7.27412+-0.023674 s
GPU two phases: 4.61285 millions/s
```

Можно видеть, что почти двукратный прирост к производительности даёт дополнительный проход с локальной сортировкой маленьких блоков перед наивным проходом. При этом на процессоре в CI всё равно такая сортировка медленнее, чем `std::sort`, поскольку у неё хуже асимптотика.

Диагональные поиски не реализовал.