### PR TITLE
Task04 Шукшов Андрей ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,95 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+#include <libgpu/opencl/cl/common.cl>
+
+#endif
+
+#line 6
+
+__kernel void matmul_naive(__global float *A, __global float *B, __global float *C,
+                           unsigned int M, unsigned int K, unsigned int N) {
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+    if (i < M && j < K) {
+        float sum_buffer = 0;
+        for (int k = 0; k < K; k++) {
+            sum_buffer = fma(A[j * K + k], B[k * N + i], sum_buffer);
+        }
+
+        C[j * N + i] = sum_buffer;
+    }
 }
+
+#define TILE_SIZE 16
+__kernel void matmul_local(__global const float *a, __global const float *b, __global float *c,
+                           unsigned int M, unsigned int K, unsigned int N) {
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+    int local_x = get_local_id(0);
+    int local_y = get_local_id(1);
+
+
+    __local float ldsA[TILE_SIZE][TILE_SIZE + 1];
+    __local float ldsB[TILE_SIZE][TILE_SIZE + 1];
+    float sum_buffer = 0;
+    for (unsigned step = 0; step * TILE_SIZE < K; step++) {
+        ldsA[local_y][local_x] = a[y * K + local_x + step * TILE_SIZE];
+        ldsB[local_y][local_x] = b[(local_y + step * TILE_SIZE) * N + x];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (unsigned index = 0; index < TILE_SIZE; index++) {
+            sum_buffer = fma(ldsA[local_y][index], ldsB[index][local_x], sum_buffer);
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (x < N && y < M) {
+        c[y * N + x] = sum_buffer;
+    }
+}
+
+#define WPT 8
+#define RTS 2
+__kernel void matmul_wpt(const __global float *a, const __global float *b, __global float *c,
+                                      const unsigned int M, const unsigned int K, const unsigned int N) {
+    unsigned x = get_local_id(0);
+    unsigned y = get_local_id(1);
+
+    int global_x = TILE_SIZE * get_group_id(0) + x;
+    int global_y = TILE_SIZE * get_group_id(1) + y;
+
+    __local float ldsA[TILE_SIZE][TILE_SIZE + 1];
+    __local float ldsB[TILE_SIZE][TILE_SIZE + 1];
+
+    if (x < M && y < K) {
+        float sum_buffer[WPT];
+        for (int w = 0; w < WPT; ++w) {
+            sum_buffer[w] = 0.0f;
+        }
+        const int numTiles = K / TILE_SIZE;
+        for (int t = 0; t < numTiles; ++t) {
+            for (int w = 0; w < WPT; ++w) {
+                const int tiledRow = TILE_SIZE * t + x;
+                const int tiledCol = TILE_SIZE * t + y;
+                ldsA[y + w * RTS][x] = a[(global_y + w * RTS) * K + tiledRow];
+                ldsB[y + w * RTS][x] = b[(tiledCol + w * RTS) * M + global_x];
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+            for (int k = 0; k < TILE_SIZE; ++k) {
+                for (int w = 0; w < WPT; ++w) {
+                    sum_buffer[w] = fma(ldsA[y + w * RTS][k], ldsB[k][x], sum_buffer[w]);
+                }
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+        }
+        for (int w = 0; w < WPT; ++w) {
+            c[(global_y + w * RTS) * M + global_x] = sum_buffer[w];
+        }
+    }
+}
+
+
+
+

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,27 @@
-__kernel void matrix_transpose(...)
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#include <libgpu/opencl/cl/common.cl>
+#endif
+
+#line 6
+
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose(__global const float* src, __global float* dst, const unsigned int M, const unsigned int K)
 {
-    // TODO
+    __local float lds_tile[TILE_SIZE][TILE_SIZE + 1];
+
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+    const unsigned int group_i = get_group_id(0);
+    const unsigned int group_j = get_group_id(1);
+    if (i < K && j < M)
+        lds_tile[local_j][local_i] = src[j * K + i];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (group_i * TILE_SIZE + local_j < K && group_j * TILE_SIZE + local_i < M)
+        dst[(group_i * TILE_SIZE + local_j) * M + group_j * TILE_SIZE + local_i] = lds_tile[local_i][local_j];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -11,8 +11,32 @@
 #include <stdexcept>
 
 
-int main(int argc, char **argv)
-{
+bool check_reference(std::vector<float> cpu_ref, std::vector<float> gpu_res, unsigned M, unsigned N) {
+    double diff_sum = 0;
+    for (int i = 0; i < M * N; ++i) {
+        double a = gpu_res[i];
+        double b = cpu_ref[i];
+        if (std::isnan(a) != std::isnan(b) || std::isinf(a) != std::isinf(b)) {
+            std::cerr << "Unexpected nan/inf value!" << std::endl;
+            return false;
+        }
+        if (a != 0.0 || b != 0.0) {
+            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+            diff_sum += diff;
+        }
+    }
+
+    double diff_avg = diff_sum / (M * N);
+    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+    if (diff_avg > 0.01) {
+        std::cerr << "Too big difference!" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
@@ -23,13 +47,14 @@ int main(int argc, char **argv)
     unsigned int M = 1024;
     unsigned int K = 1024;
     unsigned int N = 1024;
-    const size_t gflops = ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
+    const size_t gflops =
+            ((size_t) M * K * N * 2) / (1000 * 1000 * 1000); // умножить на два, т.к. операция сложения и умножения
 
-    std::vector<float> as(M*K, 0);
-    std::vector<float> bs(K*N, 0);
-    std::vector<float> cs(M*N, 0);
+    std::vector<float> as(M * K, 0);
+    std::vector<float> bs(K * N, 0);
+    std::vector<float> cs(M * N, 0);
 
-    FastRandom r(M+K+N);
+    FastRandom r(M + K + N);
     for (unsigned int i = 0; i < as.size(); ++i) {
         as[i] = r.nextf();
     }
@@ -58,52 +83,92 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
+
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
+    as_gpu.resizeN(M * K);
+    bs_gpu.resizeN(K * N);
+    cs_gpu.resizeN(M * N);
 
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
+    as_gpu.writeN(as.data(), M * K);
+    bs_gpu.writeN(bs.data(), K * N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
+    ocl::Kernel matmul_naive_kernel(matrix_multiplication, matrix_multiplication_length, "matmul_naive");
+    matmul_naive_kernel.compile();
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+            unsigned int work_group_size = 16;
+            unsigned int grid_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+            unsigned int grid_size_y = (K + work_group_size - 1) / work_group_size * work_group_size;
+            matmul_naive_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, grid_size_x, grid_size_y), as_gpu,
+                                     bs_gpu, cs_gpu, M,
+                                     K, N);
 
             t.nextLap();
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << "GPU naive: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU naive: " << gflops / t.lapAvg() << " GFlops" << std::endl;
     }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+    cs_gpu.readN(cs.data(), M * N);
+
+
 
     // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+    check_reference(cs_cpu_reference, cs, M, N);
+
+    ocl::Kernel matmul_local_kernel(matrix_multiplication, matrix_multiplication_length, "matmul_local");
+    matmul_local_kernel.compile();
+
+    {
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int work_group_size = 16;
+            unsigned int grid_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+            unsigned int grid_size_y = (N + work_group_size - 1) / work_group_size * work_group_size;
+            matmul_local_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, grid_size_x, grid_size_y), as_gpu,
+                                     bs_gpu, cs_gpu, M,
+                                     K, N);
+
+            t.nextLap();
         }
+        std::cout << "GPU local: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU local: " << gflops / t.lapAvg() << " GFlops" << std::endl;
     }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+    cs_gpu.readN(cs.data(), M * N);
+
+
+    // Проверяем корректность результатов
+    check_reference(cs_cpu_reference, cs, M, N);
+
+    ocl::Kernel matmul_wpt_kernel(matrix_multiplication, matrix_multiplication_length, "matmul_wpt");
+    matmul_wpt_kernel.compile();
+    {
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            // TODO]
+            unsigned int wpt = 8;
+            unsigned int work_group_size = 16;
+            unsigned int grid_size_x = (M + work_group_size - 1) / work_group_size * work_group_size;
+            unsigned int grid_size_y = ((K + wpt - 1) / wpt);
+
+            matmul_wpt_kernel.exec(gpu::WorkSize(work_group_size, work_group_size / wpt, grid_size_x,
+                                                 grid_size_y),
+                                   as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+            t.nextLap();
+        }
+        std::cout << "GPU wpt: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU wpt: " << gflops / t.lapAvg() << " GFlops" << std::endl;
     }
+
+    cs_gpu.readN(cs.data(), M * N);
+
+
+    // Проверяем корректность результатов
+    check_reference(cs_cpu_reference, cs, M, N);
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод transpose:</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=2048, K=2048
GPU: 0.00823933+-0.000633922 s
GPU: 509.059 millions/s
</pre>

</p></details>
<details><summary>Вывод Github CI:</summary><p>

<pre>
Data generated for n=100000000!
Log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <aplusb> was successfully vectorized (16)
Kernel <vecadd_pt> was successfully vectorized (16)
Done.
Kernel average time: 0.0448511+-0.000152256 s
GFlops: 2.2296e+09
VRAM bandwidth: 26.7552 GB/s
Result data transfer time: 0.0360313+-0.000560571 s
VRAM -> RAM bandwidth: 11.1014 GB/s
</pre>

</p></details>
<details><summary>Локальный вывод matmul:</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1036). Free memory: 24485/24566 Mb
  Device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Using device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 2.81667+-0.144039 s
CPU: 0.710059 GFlops
GPU naive: 0.00166667+-0.000471405 s
GPU naive: 1200 GFlops
Average difference: 0.000196008%
GPU local: 0.001+-0 s
GPU local: 2000 GFlops
Average difference: 0.000196008%
GPU wpt: 0.001+-0 s
GPU wpt: 2000 GFlops
Average difference: 0.000196008%
</pre>

</p></details>
<details><summary>Вывод Github CI:</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 4.1697+-0.000311953 s
CPU: 0.479651 GFlops
GPU naive: 0.0845195+-0.000642329 s
GPU naive: 23.6632 GFlops
Average difference: 0.000149043%
GPU local: 0.145802+-0.000146801 s
GPU local: 13.7173 GFlops
Average difference: 0.000149043%
GPU wpt: 0.140947+-0.000105255 s
GPU wpt: 14.1898 GFlops
Average difference: 0.000149043%
</pre>

</p></details>
