### PR TITLE
Task06 Илья Тюряев SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,22 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(
+    __global float *as,
+    const unsigned int lvl,
+    const unsigned int outer_lvl) 
+{
+    const unsigned x = get_global_id(0);
+
+    int shift = (1<<lvl);
+    int gid = x/shift, lid = x - gid*shift; 
+    int a = gid*(shift<<1) + lid, b = a + shift;    
+    if (((x/(1<<outer_lvl))&1) > 0) {
+        int dop = b;
+        b = a;
+        a = dop;
+    }
+
+    if(as[a]>as[b]) {
+        float dop = as[b];
+        as[b] = as[a];
+        as[a] = dop;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,24 @@
-// TODO
+__kernel void accum(
+    __global unsigned int *ss,
+    const unsigned int block,
+    const unsigned int n) 
+{
+    const unsigned int x = get_global_id(0);
+    unsigned int i = x*block, j = i+block/2;
+    if(i>=n) 
+        return;
+
+    ss[i] += ss[j];
+}
+
+__kernel void prefix_sum(
+    __global unsigned int *as,
+    __global const unsigned int *ss,
+    const unsigned int bit) 
+{
+    const unsigned int x = get_global_id(0);
+
+    if(((x+1)&bit)!=0) {
+        as[x] += ss[((x+1)/bit-1)*bit];
+    }
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -48,9 +48,9 @@ int main(int argc, char **argv) {
             t.nextLap();
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+    
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -63,11 +63,19 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            
+            const int lgn = log2(n);
+            const int work_group_size = 128;
+            for(int i=lgn-1; i>=0; --i) {
+                for(int j=i; j<=lgn-1; ++j) {
+                    bitonic.exec(gpu::WorkSize(work_group_size, (n>>1)), as_gpu, lgn - j - 1, lgn - i - 1);
+                }
+            }
 
-            // TODO
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
     }
@@ -76,6 +84,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+    
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод bitonic</summary><p>

<pre>
$ ./bitonic 
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 3700U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 7 3700U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for n=33554432!
CPU: 17.0385+-0.0406331 s
CPU: 1.96933 millions/s
GPU: 5.31243+-0.674258 s
GPU: 6.31621 millions/s

</pre>

</p></details>

<details><summary>Вывод Github CI bitonic</summary><p>

<pre>
$ ./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.3636+-0.000395186 s
CPU: 7.68962 millions/s
GPU: 5.61435+-0.0223197 s
GPU: 5.97654 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод prefix_sum</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD Ryzen 7 3700U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 7 3700U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4.66667e-05+-4.71405e-07 s
CPU: 87.7714 millions/s
GPU: 0.004363+-0 s
GPU: 0.938804 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000184+-5.7735e-07 s
CPU: 89.0435 millions/s
GPU: 0.002036+-0 s
GPU: 8.04715 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000624+-3.82971e-06 s
CPU: 105.026 millions/s
GPU: 0.002686+-0 s
GPU: 24.3991 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0025035+-6.1765e-05 s
CPU: 104.711 millions/s
GPU: 0.007406+-0 s
GPU: 35.3962 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0103808+-4.28657e-05 s
CPU: 101.011 millions/s
GPU: 0.017425+-0 s
GPU: 60.1765 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0436245+-0.00173067 s
CPU: 96.1456 millions/s
GPU: 0.066571+-0 s
GPU: 63.005 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.158299+-0.00362741 s
CPU: 105.984 millions/s
GPU: 0.246395+-0 s
GPU: 68.0907 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI prefix_sum</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.25e-05+-1.11803e-06 s
CPU: 327.68 millions/s
GPU: 0.000443+-0 s
GPU: 9.24605 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.41667e-05+-8.97527e-07 s
CPU: 370.958 millions/s
GPU: 0.000648+-0 s
GPU: 25.284 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000186833+-4.7052e-06 s
CPU: 350.773 millions/s
GPU: 0.001156+-0 s
GPU: 56.692 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000715333+-6.52346e-06 s
CPU: 366.464 millions/s
GPU: 0.00337+-0 s
GPU: 77.7875 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0028505+-3.77492e-06 s
CPU: 367.857 millions/s
GPU: 0.009664+-0 s
GPU: 108.503 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0114702+-1.85689e-05 s
CPU: 365.671 millions/s
GPU: 0.038547+-0 s
GPU: 108.81 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0460388+-1.46676e-05 s
CPU: 364.414 millions/s
GPU: 0.185924+-0 s
GPU: 90.237 millions/s
</pre>

</p></details>