### PR TITLE
Task06 Антон Суркис ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 cmake-build*
 .vs
+compile_commands.json
+.cache

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -2,7 +2,7 @@
     #include "clion_defines.cl"
 #endif
 
-__kernel void bitonic_global(__global float *as, uint len, uint bitonic_len, uint sorted_len) {
+__kernel void bitonic_global(__global float *as, uint len, uint half_bitonic_len, uint sorted_len) {
     uint gid = get_global_id(0);
     // 2: 0 1 2 3 4 5 -> 0 1 4 5 8 9
     // uint pos1 = gid / block_len * 2 * block_len + gid % block_len;
@@ -12,7 +12,7 @@ __kernel void bitonic_global(__global float *as, uint len, uint bitonic_len, uin
         return;
     }
     // If odd block, sort backwards
-    if (gid / bitonic_len % 2 == 1) {
+    if (gid / half_bitonic_len % 2 == 1) {
         uint t = i;
         i = j;
         j = t;
@@ -26,4 +26,40 @@ __kernel void bitonic_global(__global float *as, uint len, uint bitonic_len, uin
         // printf(", swapping");
     }
     // printf("\n");
+}
+
+__kernel void bitonic_local(__global float *as, uint len) {
+    __local float buf[2 * WORK_GROUP_SIZE];
+    uint gid = get_global_id(0);
+    uint lid = get_local_id(0);
+
+    buf[2 * lid + 0] = 2 * gid + 0 < len ? as[2 * gid + 0] : INFINITY;
+    buf[2 * lid + 1] = 2 * gid + 1 < len ? as[2 * gid + 1] : INFINITY;
+
+    for (uint half_bitonic_len = 1; half_bitonic_len < WORK_GROUP_SIZE; half_bitonic_len *= 2) {
+        for (uint sorted_len = half_bitonic_len; sorted_len > 0; sorted_len /= 2) {
+            uint i = 2 * lid - lid % sorted_len;
+            uint j = i + sorted_len;
+            if (lid / half_bitonic_len % 2 == 1) {
+                uint t = i;
+                i = j;
+                j = t;
+            }
+            barrier(CLK_LOCAL_MEM_FENCE);
+            float x = buf[i];
+            float y = buf[j];
+            if (x > y) {
+                buf[i] = y;
+                buf[j] = x;
+            }
+        }
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (2 * gid + 0 < len) {
+        as[2 * gid + 0] = buf[2 * lid + 0];
+    }
+    if (2 * gid + 1 < len) {
+        as[2 * gid + 1] = buf[2 * lid + 1];
+    }
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,29 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifndef WORK_GROUP_SIZE
+    #include "clion_defines.cl"
+#endif
+
+__kernel void bitonic_global(__global float *as, uint len, uint bitonic_len, uint sorted_len) {
+    uint gid = get_global_id(0);
+    // 2: 0 1 2 3 4 5 -> 0 1 4 5 8 9
+    // uint pos1 = gid / block_len * 2 * block_len + gid % block_len;
+    uint i = 2 * gid - gid % sorted_len;
+    uint j = i + sorted_len;
+    if (j >= len) {
+        return;
+    }
+    // If odd block, sort backwards
+    if (gid / bitonic_len % 2 == 1) {
+        uint t = i;
+        i = j;
+        j = t;
+    }
+    float x = as[i];
+    float y = as[j];
+    // printf("[%u] = %f, [%u] = %f", i, x, j, y);
+    if (x > y) {
+        as[i] = y;
+        as[j] = x;
+        // printf(", swapping");
+    }
+    // printf("\n");
 }

--- a/src/cl/clion_defines.cl
+++ b/src/cl/clion_defines.cl
@@ -9,9 +9,9 @@
 #define __constant
 #define __private
 
-#define half float
+using half = float;
 
-struct float2 { float x;          };
+struct float2 { float x, y;       };
 struct float3 { float x, y, z;    };
 struct float4 { float x, y, z, w; };
 
@@ -71,5 +71,6 @@ void atomic_add(...);
 
 // 64 for AMD, 32 for NVidia, 8 for intel GPUs, 1 for CPU
 #define WARP_SIZE 64
+#define WORK_GROUP_SIZE 64
 
 #endif // pragma once

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,4 +1,8 @@
-__kernel void cumsum_global(__global const uint *src, __global uint *dst, uint len, uint ready_len) {
+#ifndef WORK_GROUP_SIZE
+    #include "clion_defines.cl"
+#endif
+
+__kernel void cumsum_naive(__global const uint *src, __global uint *dst, uint len, uint ready_len) {
     uint gid = get_global_id(0);
     uint x = src[gid];
     if (gid >= ready_len) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,8 @@
-// TODO
+__kernel void cumsum_global(__global const uint *src, __global uint *dst, uint len, uint ready_len) {
+    uint gid = get_global_id(0);
+    uint x = src[gid];
+    if (gid >= ready_len) {
+        x += src[gid - ready_len];
+    }
+    dst[gid] = x;
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -2,11 +2,44 @@
     #include "clion_defines.cl"
 #endif
 
-__kernel void cumsum_naive(__global const uint *src, __global uint *dst, uint len, uint ready_len) {
+__kernel void cumsum_naive(__global const uint *src, __global uint *dst, uint len, uint step) {
     uint gid = get_global_id(0);
+    if (gid >= len) {
+        return;
+    }
     uint x = src[gid];
-    if (gid >= ready_len) {
-        x += src[gid - ready_len];
+    if (gid >= step) {
+        x += src[gid - step];
     }
     dst[gid] = x;
+}
+
+// Must ensure that array len is 2^n
+__kernel void cumsum_sweep_up(__global uint *as, uint len, uint step) {
+    uint gid = get_global_id(0);
+    if (gid >= len) {
+        return;
+    }
+    uint k = 2 * step * gid;
+    as[k + 2 * step - 1] += as[k + step - 1];
+}
+
+__kernel void cumsum_sweep_down(__global uint *as, uint len, uint step) {
+    uint gid = get_global_id(0);
+    if (gid >= len) {
+        return;
+    }
+    uint k = 2 * step * gid;
+    uint left = as[k + step - 1];
+    uint right = as[k + 2 * step - 1];
+    as[k + step - 1] = right;
+    as[k + 2 * step - 1] = left + right;
+}
+
+__kernel void shift_left(__global const uint *src, __global uint *dst, uint len) {
+    uint gid = get_global_id(0);
+    if (gid + 1 >= len) {
+        return;
+    }
+    dst[gid] = src[gid + 1];
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -78,6 +78,11 @@ int main(int argc, char **argv) {
         std::cout << "GPU naive: " << n * 1e-6 / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
+
+        // Проверяем корректность результатов
+        for (int i = 0; i < n; ++i) {
+            EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
+        }
     }
 
     {
@@ -107,12 +112,12 @@ int main(int argc, char **argv) {
         std::cout << "GPU local mem: " << n * 1e-6 / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
-    }
 
-    // Проверяем корректность результатов
-    for (int i = 0; i < n; ++i) {
-        EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
-    }// */
+        // Проверяем корректность результатов
+        for (int i = 0; i < n; ++i) {
+            EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
+        }
+    }
 
     return 0;
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     as_gpu.resizeN(n);
 
     {
-        cl_uint workGroupSize = 64;
+        constexpr cl_uint workGroupSize = 64;
         gpu::WorkSize ws(workGroupSize, (n + 1) / 2);
         std::ostringstream defines;
         defines << "-DWORK_GROUP_SIZE=" << workGroupSize;

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -30,8 +30,8 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    constexpr int benchmarkingIters = 1;// 10;
-    constexpr cl_uint n = 1024 * 1024;  // 32 * 1024 * 1024;
+    constexpr int benchmarkingIters = 10;
+    constexpr cl_uint n = 32 * 1024 * 1024;
     std::vector<float> as(n, 0);
     FastRandom r(n);
     for (cl_uint i = 0; i < n; ++i) {

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    constexpr int benchmarkingIters = 1;// 10;
+    constexpr int benchmarkingIters = 10;
 
     constexpr cl_uint workGroupSize = 64;
     std::ostringstream defines;

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,83 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    int benchmarkingIters = 1;// 10;
+    cl_uint max_n = 4096;// (1 << 24);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    for (cl_uint n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        cl_uint values_range = std::min<cl_uint>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+        std::vector<cl_uint> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+        std::vector<cl_uint> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<cl_uint> reference_result = bs;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        {
+            {
+                std::vector<cl_uint> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+            std::vector<cl_uint> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << n * 1e-6 / t.lapAvg() << " millions/s" << std::endl;
+        }
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            gpu::gpu_mem_32u as_gpu;
+            as_gpu.resizeN(n);
+            // TODO: implement on OpenCL
+        }
+    }
 }


### PR DESCRIPTION
# Сортировка

## Локальный вывод

```
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
Data generated for n=33554432!
CPU: 17.8105+-0.301715 s
CPU: 1.88397 millions/s
GPU naive: 0.479452+-0.000938147 s
GPU naive: 69.985 millions/s
GPU local mem: 0.414019+-0.006524 s
GPU local mem: 81.0457 millions/s
```

## Вывод в CI

```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.6062+-0.00109597 s
CPU: 9.30464 millions/s
GPU naive: 11.5628+-0.0286623 s
GPU naive: 2.90192 millions/s
GPU local mem: 8.63379+-0.0329631 s
GPU local mem: 3.88641 millions/s
```

## Вывод

Можно видеть, что использование локальной памяти для первой фазы даёт небольшой прирост в производительности.

# Префиксная сумма

## Локальный вывод

```
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
______________________________________________
n = 2^12 = 4096 values in range: [0; 1023]
CPU: 3.63333e-05+-4.71405e-07 s
CPU: 112.734 millions/s
GPU naive: 0.000129667+-2.86744e-06 s
GPU naive: 31.5887 millions/s
GPU tree: 0.0002775+-6.13052e-06 s
GPU tree: 14.7604 millions/s
______________________________________________
n = 2^14 = 16384 values in range: [0; 1023]
CPU: 0.000158+-2.57244e-12 s
CPU: 103.696 millions/s
GPU naive: 0.000155333+-7.45356e-07 s
GPU naive: 105.476 millions/s
GPU tree: 0.000321+-2.44949e-06 s
GPU tree: 51.0405 millions/s
______________________________________________
n = 2^16 = 65536 values in range: [0; 1023]
CPU: 0.000872833+-3.24726e-05 s
CPU: 75.0842 millions/s
GPU naive: 0.000225667+-1.97203e-06 s
GPU naive: 290.411 millions/s
GPU tree: 0.000625833+-0.000410808 s
GPU tree: 104.718 millions/s
______________________________________________
n = 2^18 = 262144 values in range: [0; 1023]
CPU: 0.00247133+-7.15021e-05 s
CPU: 106.074 millions/s
GPU naive: 0.000435833+-3.0777e-06 s
GPU naive: 601.478 millions/s
GPU tree: 0.000461833+-3.71558e-06 s
GPU tree: 567.616 millions/s
______________________________________________
n = 2^20 = 1048576 values in range: [0; 1023]
CPU: 0.0107502+-0.00016038 s
CPU: 97.5404 millions/s
GPU naive: 0.00141133+-2.45198e-05 s
GPU naive: 742.968 millions/s
GPU tree: 0.00102283+-5.17741e-06 s
GPU tree: 1025.17 millions/s
______________________________________________
n = 2^22 = 4194304 values in range: [0; 511]
CPU: 0.0422943+-0.000398465 s
CPU: 99.1694 millions/s
GPU naive: 0.00599883+-0.000400306 s
GPU naive: 699.187 millions/s
GPU tree: 0.00296383+-1.32466e-05 s
GPU tree: 1415.16 millions/s
______________________________________________
n = 2^24 = 16777216 values in range: [0; 127]
CPU: 0.167859+-0.00190835 s
CPU: 99.9484 millions/s
GPU naive: 0.0242895+-0.000339438 s
GPU naive: 690.719 millions/s
GPU tree: 0.0107633+-9.30352e-06 s
GPU tree: 1558.74 millions/s
```

## Вывод в CI

```

OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n = 2^12 = 4096 values in range: [0; 1023]
CPU: 8e-06+-0 s
CPU: 512 millions/s
GPU naive: 0.000281333+-0.000293224 s
GPU naive: 14.5592 millions/s
GPU tree: 0.000187667+-2.4267e-06 s
GPU tree: 21.8259 millions/s
______________________________________________
n = 2^14 = 16384 values in range: [0; 1023]
CPU: 3.11667e-05+-3.72678e-07 s
CPU: 525.69 millions/s
GPU naive: 0.000273667+-2.35702e-06 s
GPU naive: 59.8685 millions/s
GPU tree: 0.000373833+-5.2731e-06 s
GPU tree: 43.827 millions/s
______________________________________________
n = 2^16 = 65536 values in range: [0; 1023]
CPU: 0.0001235+-5e-07 s
CPU: 530.656 millions/s
GPU naive: 0.000522+-6.90411e-06 s
GPU naive: 125.548 millions/s
GPU tree: 0.0005805+-1.80069e-05 s
GPU tree: 112.896 millions/s
______________________________________________
n = 2^18 = 262144 values in range: [0; 1023]
CPU: 0.000504167+-1.95078e-06 s
CPU: 519.955 millions/s
GPU naive: 0.00139517+-1.32843e-05 s
GPU naive: 187.894 millions/s
GPU tree: 0.00116233+-2.86046e-05 s
GPU tree: 225.533 millions/s
______________________________________________
n = 2^20 = 1048576 values in range: [0; 1023]
CPU: 0.00202533+-5.40576e-06 s
CPU: 517.73 millions/s
GPU naive: 0.004764+-4.42041e-05 s
GPU naive: 220.104 millions/s
GPU tree: 0.0035555+-0.000126354 s
GPU tree: 294.917 millions/s
______________________________________________
n = 2^22 = 4194304 values in range: [0; 511]
CPU: 0.0080945+-1.3997e-05 s
CPU: 518.167 millions/s
GPU naive: 0.0258488+-0.000331879 s
GPU naive: 162.263 millions/s
GPU tree: 0.0138522+-6.81284e-05 s
GPU tree: 302.79 millions/s
______________________________________________
n = 2^24 = 16777216 values in range: [0; 127]
CPU: 0.032406+-3.08815e-05 s
CPU: 517.719 millions/s
GPU naive: 0.156924+-0.000574376 s
GPU naive: 106.913 millions/s
GPU tree: 0.0683452+-0.000372999 s
GPU tree: 245.478 millions/s
```

## Вывод

Несмотря на лучшую асимптотику, алгоритм с деревом выигрывает у наивного подхода только на достаточно больших массивах.