### PR TITLE
Task06 Александр Тульчинский SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,26 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+
+__kernel void bitonic(__global float *as, const unsigned int block, const unsigned int depth) {
+    int gid = get_global_id(0);
+    int i = 2 * gid - gid % depth;
+    int j = i + depth;
+
+    int block_num = gid / block;
+    if (block_num % 2 == 1) {
+        int t = i;
+        i = j;
+        j = t;
+    }
+
+    if (as[i] > as[j]) {
+        float t = as[j];
+        as[j] = as[i];
+        as[i] = t;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,19 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+
+__kernel void prefix(__global float *as, __global float *res, const unsigned int n, const unsigned int offset) {
+    int i = get_global_id(0);
+
+    res[i] = as[i];
+
+    int j = i - offset;
+
+    if (j >= 0) {
+        res[i] += as[i];
+    }
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,13 +50,13 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
     {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
+        gpu::WorkSize ws(128, n / 2);
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -64,7 +64,13 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (int i = 1; i < n; i *= 2) {
+                for (int j = i; j > 0; j /= 2) {
+                    bitonic.exec(ws, as_gpu, i, j);
+                }
+            }
+
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +82,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -22,6 +22,12 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
 	int benchmarkingIters = 10;
 	unsigned int max_n = (1 << 24);
 
@@ -73,11 +79,40 @@ int main(int argc, char **argv)
 				t.nextLap();
 			}
 			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+			std::cout << "CPU: " << (n / 1e-6) / t.lapAvg() << " millions/s" << std::endl;
 		}
 
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        gpu::gpu_mem_32u temp_gpu;
+        temp_gpu.resizeN(n);
+
 		{
-			// TODO: implement on OpenCL
-		}
+            ocl::Kernel prefix(prefix_sum_kernel, prefix_sum_kernel_length, "prefix");
+            prefix.compile();
+            gpu::WorkSize ws(2, n);
+
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(bs.data(), n);
+
+                t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+
+                for (int off = 1; off < n; off *= 2) {
+                    prefix.exec(ws, as_gpu, temp_gpu, n, off);
+                }
+
+                t.nextLap();
+            }
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1e-6) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(as.data(), n);
+        }
+
+        // Проверяем корректность результатов
+        for (int i = 0; i < n; ++i) {
+            EXPECT_THE_SAME(as[i], reference_result[i], "GPU results should be equal to CPU results!");
+        }
 	}
 }


### PR DESCRIPTION
<details><summary>Локальный вывод bitonic для CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
Data generated for n=33554432!
CPU: 12.2607+-0.0850526 s
CPU: 2.69153 millions/s
GPU: 4.89227+-0.00857247 s
GPU: 6.74534 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод bitonic для GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Data generated for n=33554432!
CPU: 12.436+-0.138645 s
CPU: 2.65358 millions/s
GPU: 1.71376+-0.000235667 s
GPU: 19.2559 millions/s
</pre>

</p></details>

<details><summary>Вывод GitHub CI на bitonic</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.45464+-0.00273757 s
CPU: 7.408 millions/s
GPU: 7.7129+-0.00856347 s
GPU: 4.27855 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод prefix sum для CPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.3e-05+-0 s
CPU: 1.78087e+14 millions/s
GPU: 0.000392333+-1.59025e-05 s
GPU: 1.04401e+13 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 9.2e-05+-0 s
CPU: 1.78087e+14 millions/s
GPU: 0.000778167+-7.73206e-05 s
GPU: 2.10546e+13 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000377333+-1.29829e-05 s
CPU: 1.73682e+14 millions/s
GPU: 0.00167267+-7.70534e-05 s
GPU: 3.91806e+13 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00152567+-3.55793e-05 s
CPU: 1.71823e+14 millions/s
GPU: 0.00580917+-0.000140791 s
GPU: 4.51259e+13 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0065015+-0.000150978 s
CPU: 1.61282e+14 millions/s
GPU: 0.0266917+-0.000425387 s
GPU: 3.92848e+13 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0264822+-0.000303925 s
CPU: 1.58382e+14 millions/s
GPU: 0.118066+-0.000636732 s
GPU: 3.55251e+13 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.107967+-0.000300873 s
CPU: 1.55393e+14 millions/s
GPU: 0.536019+-0.00353503 s
GPU: 3.12996e+13 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод prefix sum для GPU</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-1035G1 CPU @ 1.00GHz. Intel(R) Corporation. Total memory: 7725 Mb
  Device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
Using device #1: GPU. NVIDIA GeForce MX230. Total memory: 2002 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.3e-05+-0 s
CPU: 1.78087e+14 millions/s
GPU: 0.000478+-2.62361e-05 s
GPU: 8.56904e+12 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000114833+-1.00236e-05 s
CPU: 1.42676e+14 millions/s
GPU: 0.00168217+-1.83976e-05 s
GPU: 9.73982e+12 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000417333+-4.45371e-05 s
CPU: 1.57035e+14 millions/s
GPU: 0.00824017+-2.07639e-05 s
GPU: 7.95324e+12 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00174533+-3.36485e-05 s
CPU: 1.50197e+14 millions/s
GPU: 0.0359923+-1.13382e-05 s
GPU: 7.28333e+12 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00735433+-5.78437e-05 s
CPU: 1.42579e+14 millions/s
GPU: 0.159375+-2.84937e-05 s
GPU: 6.57929e+12 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0293817+-4.35227e-05 s
CPU: 1.42752e+14 millions/s
GPU: 0.700398+-3.39088e-05 s
GPU: 5.98846e+12 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.117878+-0.000130109 s
CPU: 1.42328e+14 millions/s
GPU: 3.05813+-5.51566e-05 s
GPU: 5.4861e+12 millions/s
</pre>

</p></details>

<details><summary>Вывод GitHub CI на prefix sum</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.2e-05+-1.1547e-06 s
CPU: 3.41333e+14 millions/s
GPU: 0.000348+-6.4291e-06 s
GPU: 1.17701e+13 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.33333e-05+-3.34996e-06 s
CPU: 3.78092e+14 millions/s
GPU: 0.000886833+-1.027e-05 s
GPU: 1.84747e+13 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000186167+-2.03443e-06 s
CPU: 3.52029e+14 millions/s
GPU: 0.00327217+-0.000126702 s
GPU: 2.00283e+13 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0007015+-4.31084e-06 s
CPU: 3.73691e+14 millions/s
GPU: 0.0159287+-0.00157545 s
GPU: 1.64574e+13 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00283983+-9.65085e-06 s
CPU: 3.69239e+14 millions/s
GPU: 0.091174+-0.000941951 s
GPU: 1.15008e+13 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0113227+-2.34497e-05 s
CPU: 3.70434e+14 millions/s
GPU: 0.516324+-0.000429315 s
GPU: 8.1234e+12 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0458815+-3.85606e-05 s
CPU: 3.65664e+14 millions/s
GPU: 2.36793+-0.00978461 s
GPU: 7.08519e+12 millions/s
</pre>

</p></details>