### PR TITLE
Task06 Шакиров Игорь ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,28 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+inline bool compare(const float x, const float y, bool is_less) {
+    return is_less ? (x < y) : (x > y);
+}
+
+__kernel void bitonic(__global float *arr, const uint N, const uint sorted_size, const uint inner_block_len) {
+    const size_t g_id = get_global_id(0);
+
+    if (g_id >= N / 2) {
+        return;
+    }
+
+    // first try
+    // const size_t sequence_index = (g_id * 2) / seq_len;
+    // const size_t block_index = (g_id * 2) / block_len;
+    // const size_t element_id = (g_id % (block_len / 2)) + block_index * block_len;
+    // const size_t paired_element_id = element_id + (block_len / 2);
+    
+    const size_t sorted_block_id = g_id / sorted_size;
+
+    const size_t element_id = 2 * g_id - g_id % inner_block_len;
+    const size_t paired_element_id = element_id + inner_block_len;
+
+    if (compare(arr[element_id], arr[paired_element_id], sorted_block_id & 1)) {
+        float temp = arr[element_id];
+        arr[element_id] = arr[paired_element_id];
+        arr[paired_element_id] = temp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,36 @@
-// TODO
+__kernel void prefix_sum_naive(__global const uint *src, __global uint *res, const uint size, const uint d) {
+    const size_t g_id = get_global_id(0);
+    if (g_id >= size)
+        return;
+    const size_t pw = 1 << (d - 1);
+    if (g_id >= pw) {
+        res[g_id] = src[g_id - pw] + src[g_id];
+    } else {
+        res[g_id] = src[g_id];
+    }
+}
+
+__kernel void reduce(__global unsigned int *data, __global unsigned int *partial_sums, const unsigned int size,
+                     const uint d) {
+    const size_t g_id = get_global_id(0);
+
+    if (g_id < size / 2 / d) {
+        uint k = 2 * d * g_id;
+        data[k + 2 * d - 1] += data[k + d - 1];
+    }
+    if (g_id == 0 && (d << 1) >= size) {
+        *partial_sums = data[size - 1];
+        data[size - 1] = 0;
+    }
+}
+
+__kernel void downsweep(__global unsigned int *data, const unsigned int size, const uint d) {
+    const size_t g_id = get_global_id(0);
+
+    if (g_id < size / 2 / d) {
+        uint k = 2 * d * g_id;
+        uint l = data[k + d - 1];
+        data[k + d - 1] = data[k + 2 * d - 1];
+        data[k + 2 * d - 1] += l;
+    }
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -81,8 +81,6 @@ int main(int argc, char **argv) {
 
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
-        //   std::cout << as[i] << '\n';
-        // if (i > 100) return 0;
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
 

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -58,13 +58,20 @@ int main(int argc, char **argv) {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
 
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu::WorkSize work_size(workGroupSize, global_work_size);
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
-
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
-
-            // TODO
+            for (uint sorted_size = 1; sorted_size < n; sorted_size <<= 1) {
+                for (uint block_len = sorted_size; block_len > 0; block_len >>= 1) {
+                    bitonic.exec(work_size, as_gpu, n, sorted_size, block_len);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -74,8 +81,10 @@ int main(int argc, char **argv) {
 
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
+        //   std::cout << as[i] << '\n';
+        // if (i > 100) return 0;
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,154 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+#include <vector>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
+#include "libgpu/work_size.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            ocl::Kernel prefix(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_naive");
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u res_gpu;
+            as_gpu.resizeN(n);
+            res_gpu.resizeN(n);
+            prefix.compile();
+            unsigned int workGroupSize = 128;
+            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            gpu::WorkSize work_size(workGroupSize, global_work_size);
+            timer t;
+            for (size_t i = 0; i < benchmarkingIters; i++) {
+                as_gpu.writeN(as.data(), n);
+                t.restart();
+                for (uint i = 1, d = 1; i < n; i <<= 1, ++d) {
+                    prefix.exec(work_size, as_gpu, res_gpu, n, d);
+                    std::swap(as_gpu, res_gpu);
+                }
+                t.nextLap();
+            }
+            t.stop();
+            std::cout << "GPU (naive scan): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (naive scan): " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            std::vector<uint> result(n);
+            as_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "GPU result should be consistent!");
+            }
+        }
+        {
+            ocl::Kernel reduce(prefix_sum_kernel, prefix_sum_kernel_length, "reduce");
+            ocl::Kernel downsweep(prefix_sum_kernel, prefix_sum_kernel_length, "downsweep");
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u last_el_gpu;
+            as_gpu.resizeN(n);
+            last_el_gpu.resizeN(1);
+            reduce.compile();
+            downsweep.compile();
+
+            unsigned int workGroupSize = 128;
+            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            gpu::WorkSize work_size(workGroupSize, global_work_size);
+            timer t;
+
+            unsigned int last_element = 0;
+            for (size_t i = 0; i < benchmarkingIters; i++) {
+                as_gpu.writeN(as.data(), n);
+                t.restart();
+                for (uint d = 1; d < n; d <<= 1) {
+                    reduce.exec(work_size, as_gpu, last_el_gpu, n, d);
+                }
+                last_el_gpu.readN(&last_element, 1);
+                for (uint d = n >> 1; d > 0; d >>= 1) {
+                    downsweep.exec(work_size, as_gpu, n, d);
+                }
+                t.nextLap();
+            }
+            t.stop();
+            std::cout << "GPU (efficient scan): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (efficient scan):" << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+            std::vector<uint> result(n + 1);
+            as_gpu.readN(result.data(), n);
+            result.back() = last_element;
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i + 1], "GPU result should be consistent!");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Сортировка чет-нечет

<details><summary>Локальный вывод</summary><p>

<pre>
mx550
Data generated for n=33554432!
CPU: 8.853+-0 s
CPU: 3.72755 millions/s
GPU: 0.903084+-0 s
GPU: 36.5415 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
Data generated for n=33554432!
CPU: 4.4606+-0.00347757 s
CPU: 7.3981 millions/s
GPU: 26.8174+-0.0246504 s
GPU: 1.23055 millions/s
</pre>

</p></details>
GPU от ci 💀. 

Данная сортировка работает хуже merge, т.к., возможно, из-за того, что мы O(nlogn) раз вызываем кернел, тогда как в merge сорте O(logn) (+ доступ на чтение coalesced).

## Скан

<details><summary>Локальный вывод</summary><p>

<pre>
n=4096 values in range: [0; 1023]
CPU: 1.3e-05+-0 s
CPU: 315.077 millions/s
GPU (naive scan): 9.18333e-05+-6.87184e-07 s
GPU (naive scan): 44.6025 millions/s
GPU (efficient scan): 0.000188667+-1.24722e-06 s
GPU (efficient scan):21.7102 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 5.26667e-05+-4.71405e-07 s
CPU: 311.089 millions/s
GPU (naive scan): 0.000117667+-7.45356e-07 s
GPU (naive scan): 139.241 millions/s
GPU (efficient scan): 0.000233333+-1.69967e-06 s
GPU (efficient scan):70.2171 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000212+-2.88675e-06 s
CPU: 309.132 millions/s
GPU (naive scan): 0.000204+-7.97914e-06 s
GPU (naive scan): 321.255 millions/s
GPU (efficient scan): 0.000321333+-1.10554e-06 s
GPU (efficient scan):203.95 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000871333+-1.27236e-05 s
CPU: 300.854 millions/s
GPU (naive scan): 0.000585667+-7.45356e-07 s
GPU (naive scan): 447.599 millions/s
GPU (efficient scan): 0.000750167+-2.54406e-06 s
GPU (efficient scan):349.448 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00350417+-4.0313e-05 s
CPU: 299.237 millions/s
GPU (naive scan): 0.0022175+-8.18026e-06 s
GPU (naive scan): 472.864 millions/s
GPU (efficient scan): 0.00259517+-3.18416e-06 s
GPU (efficient scan):404.05 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0140908+-0.000189062 s
CPU: 297.662 millions/s
GPU (naive scan): 0.00949083+-7.35791e-06 s
GPU (naive scan): 441.932 millions/s
GPU (efficient scan): 0.00894067+-8.51795e-06 s
GPU (efficient scan):469.127 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0575633+-0.000597165 s
CPU: 291.457 millions/s
GPU (naive scan): 0.0426725+-0.00031736 s
GPU (naive scan): 393.162 millions/s
GPU (efficient scan): 0.035859+-1.78885e-05 s
GPU (efficient scan):467.866 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.13333e-05+-1.37437e-06 s
CPU: 361.412 millions/s
GPU (naive scan): 0.000160167+-2.40947e-06 s
GPU (naive scan): 25.5734 millions/s
GPU (efficient scan): 0.000321667+-2.13437e-06 s
GPU (efficient scan):12.7337 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.31667e-05+-2.11476e-06 s
CPU: 379.552 millions/s
GPU (naive scan): 0.000273833+-2.26691e-06 s
GPU (naive scan): 59.832 millions/s
GPU (efficient scan): 0.000556833+-1.16106e-05 s
GPU (efficient scan):29.4235 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000178+-2.23607e-06 s
CPU: 368.18 millions/s
GPU (naive scan): 0.000457+-7.78888e-06 s
GPU (naive scan): 143.405 millions/s
GPU (efficient scan): 0.000901667+-7.7603e-06 s
GPU (efficient scan):72.6832 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000703833+-6.56802e-06 s
CPU: 372.452 millions/s
GPU (naive scan): 0.00122083+-0.000137692 s
GPU (naive scan): 214.725 millions/s
GPU (efficient scan): 0.0021995+-6.74926e-05 s
GPU (efficient scan):119.183 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00301417+-2.81153e-05 s
CPU: 347.883 millions/s
GPU (naive scan): 0.004569+-9.48455e-05 s
GPU (naive scan): 229.498 millions/s
GPU (efficient scan): 0.007285+-1.47309e-05 s
GPU (efficient scan):143.936 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0116382+-2.70149e-05 s
CPU: 360.392 millions/s
GPU (naive scan): 0.0240427+-0.00114992 s
GPU (naive scan): 174.453 millions/s
GPU (efficient scan): 0.0299543+-0.000194883 s
GPU (efficient scan):140.023 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0458973+-3.75795e-05 s
CPU: 365.538 millions/s
GPU (naive scan): 0.154151+-0.00193886 s
GPU (naive scan): 108.836 millions/s
GPU (efficient scan): 0.143201+-0.00166022 s
GPU (efficient scan):117.159 millions/s
</pre>

</p></details>

### n = 4,096
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 1.3e-05+-0 s                     | 315.077           |
| GPU (naive scan)  | 9.18333e-05+-6.87184e-07 s       | 44.6025           |
| GPU (efficient)   | 0.000188667+-1.24722e-06 s       | 21.7102           |

### n = 16,384
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 5.26667e-05+-4.71405e-07 s       | 311.089           |
| GPU (naive scan)  | 0.000117667+-7.45356e-07 s       | 139.241           |
| GPU (efficient)   | 0.000233333+-1.69967e-06 s       | 70.2171           |

### n = 65,536 
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 0.000212+-2.88675e-06 s          | 309.132           |
| GPU (naive scan)  | 0.000204+-7.97914e-06 s          | 321.255           |
| GPU (efficient)   | 0.000321333+-1.10554e-06 s       | 203.95            |

### n = 262,144
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 0.000871333+-1.27236e-05 s       | 300.854           |
| GPU (naive scan)  | 0.000585667+-7.45356e-07 s       | 447.599           |
| GPU (efficient)   | 0.000750167+-2.54406e-06 s       | 349.448           |

### n = 1,048,576
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 0.00350417+-4.0313e-05 s         | 299.237           |
| GPU (naive scan)  | 0.0022175+-8.18026e-06 s         | 472.864           |
| GPU (efficient)   | 0.00259517+-3.18416e-06 s        | 404.05            |

### n = 4,194,304 
| Device            | Time (s)                         | Speed (millions/s) |
|-------------------|----------------------------------|-------------------|
| CPU               | 0.0140908+-0.000189062 s         | 297.662           |
| GPU (naive scan)  | 0.00949083+-7.35791e-06 s        | 441.932           |
| GPU (efficient)   | 0.00894067+-8.51795e-06 s        | 469.127           |

### n = 16,777,216
| Device            | Time (s)                             | Speed (millions/s) |
|-------------------|--------------------------------------|-------------------|
| CPU               | 0.0575633+-0.000597165 s             | 291.457           |
| GPU (naive scan)  | 0.0426725+-0.00031736 s              | 393.162           |
| GPU (efficient)   | 0.035859+-1.78885e-05 s              | 467.866           |

### Вывод
На небольших данных, выигрываем CPU, на среднем количестве лучше наивный подход (меньше вызовов kernel), на больших данных оптимизация бин. деревом показала наилучший результат.

Ну а результаты ci 💀.  

