### PR TITLE
Task06 Овчинников Егор ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -4,14 +4,15 @@
 __kernel void bitonic(__global float *as, const unsigned window, const unsigned arrow, const unsigned size) {
     unsigned id = get_global_id(0);
     unsigned id2x = id << 1;
+
     if (id2x >= size) {
         return;
     }
-    unsigned start = (id2x / window) * window;
-    int decreasing = (id2x / window) % 2;
-    if (id == 1) {
-        printf("\nid: %d\n\ndecreasing: %d\n\n", id2x, decreasing);
-    }
+
+    unsigned start = (id2x / window);
+    int decreasing = start % 2;
+
+    start = start * window;
     unsigned arrow2x = arrow << 1;
     id = start + id % arrow + (id2x - start) / arrow2x * arrow2x;
 

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -10,11 +10,11 @@ __kernel void bitonic(__global float *as, const unsigned window, const unsigned 
     }
 
     unsigned start = (id2x / window);
-    int decreasing = start % 2;
+    int decreasing = start & 1;
 
     start = start * window;
     unsigned arrow2x = arrow << 1;
-    id = start + id % arrow + (id2x - start) / arrow2x * arrow2x;
+    id = start + (id - id / arrow * arrow) + (id2x - start) / arrow2x * arrow2x;
 
     float max = max(as[id], as[id + arrow]);
     float min = min(as[id], as[id + arrow]);

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,27 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#define max(x, y) x > y ? x : y
+#define min(x, y) x < y ? x : y
+
+__kernel void bitonic(__global float *as, const unsigned len) {
+    unsigned gid = get_global_id(0);
+    unsigned point = len;
+
+    while (point) {
+        gid = get_global_id(0);
+        unsigned decreasing = (2 * gid / len) % 2;
+        gid = (2 * gid) / point * point + gid % (point / 2);
+        point = point / 2;
+        float max = max(as[gid], as[gid + point]);
+        float min = min(as[gid], as[gid + point]);
+        if (decreasing) {
+            as[gid] = max;
+            as[gid + point] = min;
+        } else {
+            as[gid] = min;
+            as[gid + point] = max;
+        }
+
+        point /= 2;
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,10 @@
-// TODO
+__kernel void prefix_sum_naive(__global unsigned *as, __global unsigned *bs, const unsigned offset,
+                               const unsigned size) {
+    unsigned gid = get_global_id(0);
+
+    if (gid >= offset) {
+        bs[gid] = as[gid] + as[gid - offset];
+    } else {
+        bs[gid] = as[gid];
+    }
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -20,18 +20,16 @@ __kernel void prefix_sum_up_sweep(__global unsigned *as, const unsigned offset, 
     }
 }
 
-__kernel void prefix_sum_down_sweep(__global unsigned *as, __global unsigned *bs, const unsigned offset,
-                                    const unsigned size) {
+__kernel void prefix_sum_down_sweep(__global unsigned *as, const unsigned offset, const unsigned size) {
     unsigned gid = get_global_id(0);
 
     if (gid >= size)
         return;
 
     if (!((gid + 1) % (offset << 1))) {
-        bs[gid - offset] = as[gid];
-        bs[gid] = as[gid] + as[gid - offset];
-    } else if ((1 + gid) % offset) {
-        bs[gid] = as[gid];
+        unsigned temp = as[gid];
+        as[gid] = temp + as[gid - offset];
+        as[gid - offset] = temp;
     }
 }
 

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -8,3 +8,40 @@ __kernel void prefix_sum_naive(__global unsigned *as, __global unsigned *bs, con
         bs[gid] = as[gid];
     }
 }
+
+__kernel void prefix_sum_up_sweep(__global unsigned *as, __global unsigned *bs, const unsigned offset,
+                                  const unsigned size) {
+    unsigned gid = get_global_id(0);
+
+    if (gid >= size)
+        return;
+
+    if (!((gid + 1) % (offset << 1))) {
+        bs[gid] = as[gid] + as[gid - offset];
+    } else {
+        bs[gid] = as[gid];
+    }
+}
+
+__kernel void prefix_sum_down_sweep(__global unsigned *as, __global unsigned *bs, const unsigned offset,
+                                    const unsigned size) {
+    unsigned gid = get_global_id(0);
+
+    if (gid >= size)
+        return;
+
+    if (!((gid + 1) % (offset << 1))) {
+        bs[gid - offset] = as[gid];
+        bs[gid] = as[gid] + as[gid - offset];
+    } else if ((1 + gid) % offset) {
+        bs[gid] = as[gid];
+    }
+}
+
+__kernel void prefix_sum_shift(__global unsigned *as, __global unsigned *bs, const unsigned total, const unsigned size) {
+    unsigned gid = get_global_id(0), ngid = gid + 1;
+    if (ngid > size)
+        return;
+    
+    bs[gid] = (ngid == size) ? total : as[ngid] - total;
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -9,17 +9,14 @@ __kernel void prefix_sum_naive(__global unsigned *as, __global unsigned *bs, con
     }
 }
 
-__kernel void prefix_sum_up_sweep(__global unsigned *as, __global unsigned *bs, const unsigned offset,
-                                  const unsigned size) {
+__kernel void prefix_sum_up_sweep(__global unsigned *as, const unsigned offset, const unsigned size) {
     unsigned gid = get_global_id(0);
 
     if (gid >= size)
         return;
 
     if (!((gid + 1) % (offset << 1))) {
-        bs[gid] = as[gid] + as[gid - offset];
-    } else {
-        bs[gid] = as[gid];
+        as[gid] = as[gid] + as[gid - offset];
     }
 }
 
@@ -38,10 +35,11 @@ __kernel void prefix_sum_down_sweep(__global unsigned *as, __global unsigned *bs
     }
 }
 
-__kernel void prefix_sum_shift(__global unsigned *as, __global unsigned *bs, const unsigned total, const unsigned size) {
+__kernel void prefix_sum_shift(__global unsigned *as, __global unsigned *bs, const unsigned total,
+                               const unsigned size) {
     unsigned gid = get_global_id(0), ngid = gid + 1;
     if (ngid > size)
         return;
-    
+
     bs[gid] = (ngid == size) ? total : as[ngid] - total;
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,6 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -64,7 +63,12 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (unsigned k = 2; k <= n; k *= 2) {
+                for (unsigned arrow = k / 2; arrow > 0; arrow /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n / 2), as_gpu, k, arrow, n);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +80,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -122,8 +122,7 @@ int main(int argc, char **argv) {
                 bs_gpu.writeN(std::vector<unsigned>(n, 0).data(), n);
                 t.restart();
                 for (unsigned offset = 1; offset < n; offset *= 2) {
-                    prefix_sum_up_sweep.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, offset, n);
-                    std::swap(as_gpu, bs_gpu);
+                    prefix_sum_up_sweep.exec(gpu::WorkSize(128, n), as_gpu, offset, n);
                 }
                 unsigned total = 0;
                 as_gpu.readN(&total, 1, n - 1);

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,107 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+#include <utility>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+            }
+        }
+
+        {
+            gpu::gpu_mem_32u as_gpu, bs_gpu;
+            as_gpu.resizeN(2 * n);
+            bs_gpu.resizeN(n);
+
+            as.resize(2 * n, 0);
+
+            ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_naive");
+            prefix_sum.compile();
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), 2 * n);
+                bs_gpu.writeN(std::vector<unsigned>(n, 0).data(), n);
+                t.restart();
+                for (unsigned offset = 1; offset < n; offset *= 2) {
+                    prefix_sum.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, offset, n);
+                    std::swap(as_gpu, bs_gpu);
+                }
+                t.nextLap();
+            }
+            std::cout << "GPU (naive): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (naive): " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+            }
+        }
+    }
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -74,10 +74,8 @@ int main(int argc, char **argv) {
 
         {
             gpu::gpu_mem_32u as_gpu, bs_gpu;
-            as_gpu.resizeN(2 * n);
+            as_gpu.resizeN(n);
             bs_gpu.resizeN(n);
-
-            as.resize(2 * n, 0);
 
             ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_naive");
             prefix_sum.compile();
@@ -85,7 +83,7 @@ int main(int argc, char **argv) {
             std::vector<unsigned int> result(n);
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                as_gpu.writeN(as.data(), 2 * n);
+                as_gpu.writeN(as.data(), n);
                 bs_gpu.writeN(std::vector<unsigned>(n, 0).data(), n);
                 t.restart();
                 for (unsigned offset = 1; offset < n; offset *= 2) {

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -127,8 +127,7 @@ int main(int argc, char **argv) {
                 unsigned total = 0;
                 as_gpu.readN(&total, 1, n - 1);
                 for (unsigned offset = n / 2; offset > 0; offset /= 2) {
-                    prefix_sum_down_sweep.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, offset, n);
-                    std::swap(as_gpu, bs_gpu);
+                    prefix_sum_down_sweep.exec(gpu::WorkSize(128, n), as_gpu, offset, n);
                 }
                 prefix_sum_shift.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, total, n);
                 std::swap(as_gpu, bs_gpu);


### PR DESCRIPTION
Bitonic sort
=========

Локальный вывод
```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13846 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11798 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
Data generated for n=33554432!
CPU: 17.247+-0.110546 s
CPU: 1.91338 millions/s
GPU: 0.796831+-0.00084889 s
GPU: 41.414 millions/s
```

Вывод Github CI
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.38893+-0.0907986 s
CPU: 7.51892 millions/s
GPU: 43.6129+-0.171641 s
GPU: 0.756656 millions/s
```

Реализация `Bitonic sort` с помощью `OpenCL` показывает лучшие результаты только локально, только на видеокарте.

Prefix sum
=========

Локальный вывод
```
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13846 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11798 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 3.7e-05+-0 s
CPU: 110.703 millions/s
GPU (naive): 0.0001565+-1.3376e-05 s
GPU (naive): 26.1725 millions/s
GPU (tree): 0.000293+-4.54606e-06 s
GPU (tree): 13.9795 millions/s

______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000173333+-1.59861e-06 s
CPU: 94.5231 millions/s
GPU (naive): 0.000160833+-6.87184e-07 s
GPU (naive): 101.869 millions/s
GPU (tree): 0.000349333+-1.0274e-05 s
GPU (tree): 46.9008 millions/s

______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000708167+-1.27987e-05 s
CPU: 92.5432 millions/s
GPU (naive): 0.000216833+-6.25611e-06 s
GPU (naive): 302.241 millions/s
GPU (tree): 0.000443333+-2.55125e-05 s
GPU (tree): 147.826 millions/s

______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00242667+-4.50136e-05 s
CPU: 108.026 millions/s
GPU (naive): 0.0005605+-1.10868e-05 s
GPU (naive): 467.697 millions/s
GPU (tree): 0.000745+-2.27303e-05 s
GPU (tree): 351.871 millions/s

______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00989783+-0.000256883 s
CPU: 105.94 millions/s
GPU (naive): 0.00183917+-6.87184e-07 s
GPU (naive): 570.136 millions/s
GPU (tree): 0.00195567+-5.52771e-06 s
GPU (tree): 536.173 millions/s

______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0395472+-0.000343445 s
CPU: 106.058 millions/s
GPU (naive): 0.00760817+-5.48769e-05 s
GPU (naive): 551.29 millions/s
GPU (tree): 0.00671383+-3.89087e-06 s
GPU (tree): 624.726 millions/s

______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.162723+-0.00537797 s
CPU: 103.103 millions/s
GPU (naive): 0.0331435+-0.000144571 s
GPU (naive): 506.199 millions/s
GPU (tree): 0.0251332+-0.00104289 s
GPU (tree): 667.533 millions/s
```

Вывод Github CI
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) CPU E5-2673 v4 @ 2.30GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8.83333e-06+-3.72678e-07 s
CPU: 463.698 millions/s
GPU (naive): 0.000200167+-1.25488e-05 s
GPU (naive): 20.4629 millions/s
GPU (tree): 0.000577833+-4.73195e-05 s
GPU (tree): 7.08855 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.1e-05+-0 s
CPU: 399.61 millions/s
GPU (naive): 0.000419333+-5.92556e-05 s
GPU (naive): 39.0715 millions/s
GPU (tree): 0.00124717+-6.1915e-05 s
GPU (tree): 13.137 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0001475+-4.31084e-06 s
CPU: 444.312 millions/s
GPU (naive): 0.000721667+-3.60262e-05 s
GPU (naive): 90.812 millions/s
GPU (tree): 0.00345383+-7.10854e-05 s
GPU (tree): 18.9749 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000634833+-4.77682e-05 s
CPU: 412.934 millions/s
GPU (naive): 0.00211533+-0.00023924 s
GPU (naive): 123.926 millions/s
GPU (tree): 0.0130738+-0.000242356 s
GPU (tree): 20.051 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00249+-8.04964e-05 s
CPU: 421.115 millions/s
GPU (naive): 0.0072885+-0.000524533 s
GPU (naive): 143.867 millions/s
GPU (tree): 0.0562722+-0.00181473 s
GPU (tree): 18.634 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0107698+-0.00032725 s
CPU: 389.449 millions/s
GPU (naive): 0.0372878+-0.00283845 s
GPU (naive): 112.485 millions/s
GPU (tree): 0.244046+-0.00560303 s
GPU (tree): 17.1865 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0436615+-0.00122719 s
CPU: 384.257 millions/s
GPU (naive): 0.249494+-0.00298282 s
GPU (naive): 67.2451 millions/s
GPU (tree): 1.07126+-0.0050193 s
GPU (tree): 15.6612 millions/s
```

Реализация `Prefix sum` с помощью `OpenCL` показывает лучшие результаты только локально, только на видеокарте, в `CI` же обычная реализация на процессоре выигрывает в скорости за счет линейной асимптотики. 

При этом можно также заметить, что реализация `Prefix sum` с помощью дерева выигрывает наивную реализацию только при больших количествах элементов.