### PR TITLE
Task06 Николай Стойко ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,22 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+__kernel void bitonic(__global float *as, int n, int global_width, int width) {
+    int gid = get_global_id(0);
+    int step = width / 2;
+
+    int block = 2 * gid / width;
+    int dir = (2 * gid / global_width) % 2;
+
+    int i = block * width + gid % step;
+    int j = i + step;
+    float asi = as[i];
+    float asj = as[j];
+    if (j < n) {
+        if (dir ? asi < asj : asi > asj) {
+            as[i] = asj;
+            as[j] = asi;
+        }
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,17 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+__kernel void prefix_sum_scan(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+    int lid = gid % w_half;
+    int index = gid / w_half;
+
+    int to = w_half + index * w;
+    int from = to - 1;
+    to += lid;
+    if (to < n) {
+        as[to] += as[from];
+    }
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -15,3 +15,30 @@ __kernel void prefix_sum_scan(__global unsigned int *as, int n, int w) {
         as[to] += as[from];
     }
 }
+
+__kernel void prefix_sum_map(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+
+    int from = w_half - 1 + w * gid;
+    int to = from + w_half;
+    if (to < n) {
+        as[to] += as[from];
+    }
+}
+
+__kernel void prefix_sum_reduce(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+
+    int from = w_half - 1 + w * gid;
+    int to = from + w_half;
+    unsigned int to_v = 0;
+    if (to < n) {
+        to_v = as[to];
+    } else {
+        to = from + 1;
+    }
+    as[to] += as[from];
+    as[from] = to_v;
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -39,6 +39,8 @@ __kernel void prefix_sum_reduce(__global unsigned int *as, int n, int w) {
     } else {
         to = from + 1;
     }
-    as[to] += as[from];
-    as[from] = to_v;
+    if (from < n) {
+        as[to] += as[from];
+        as[from] = to_v;
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -58,13 +58,22 @@ int main(int argc, char **argv) {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
 
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n / 2 + workGroupSize - 1) / workGroupSize * workGroupSize;
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
-            t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            t.restart(); // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (int global_width = 2; global_width < 2 * n; global_width <<= 1) {
+                for (int width = global_width; width > 1; width >>= 1) {
+                    bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                                 as_gpu, n, global_width, width);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +85,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
### **Задание 6.1. Bitonic sort**

<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Data generated for n=33554432!
CPU: 4.149+-0.0211503 s
CPU: 7.95372 millions/s
GPU: 1.19567+-0.000942809 s
GPU: 27.5997 millions/s
</pre>
</p></details>

Очевидно, хорошо параллелится на GPU

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.63066+-0.0015216 s
CPU: 9.08926 millions/s
GPU: 10.1409+-0.0169516 s
GPU: 3.25415 millions/s
</pre>
</p></details>


### **Задание 6.2. Prefix sum**

<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
A sum scan algorithm
GPU: 0.001+-0 s
GPU: 4.096 millions/s
A sum parallel scan
GPU: 0.00183333+-0.000372678 s
GPU: 2.23418 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
A sum scan algorithm
GPU: 0.000833333+-0.000372678 s
GPU: 19.6608 millions/s
A sum parallel scan
GPU: 0.002+-0 s
GPU: 8.192 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
A sum scan algorithm
GPU: 0.001+-0 s
GPU: 65.536 millions/s
A sum parallel scan
GPU: 0.00233333+-0.000471405 s
GPU: 28.0869 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
A sum scan algorithm
GPU: 0.002+-0 s
GPU: 131.072 millions/s
A sum parallel scan
GPU: 0.00316667+-0.000372678 s
GPU: 82.7823 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000333333+-0.000471405 s
CPU: 3145.73 millions/s
A sum scan algorithm
GPU: 0.0035+-0.0005 s
GPU: 299.593 millions/s
A sum parallel scan
GPU: 0.00516667+-0.000372678 s
GPU: 202.95 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00216667+-0.000372678 s
CPU: 1935.83 millions/s
A sum scan algorithm
GPU: 0.0095+-0.0005 s
GPU: 441.506 millions/s
A sum parallel scan
GPU: 0.0113333+-0.000471405 s
GPU: 370.086 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.00866667+-0.000471405 s
CPU: 1935.83 millions/s
A sum scan algorithm
GPU: 0.0328333+-0.000372678 s
GPU: 510.981 millions/s
A sum parallel scan
GPU: 0.0373333+-0.000745356 s
GPU: 449.39 millions/s
</pre>
</p></details>

Наивная версия оказалась немного быстрее, чем асимптотически лучшая реализация. 
Это обуславливается coalesced доступом в простой версии и отсутствием code-divergence.
Наверное, если бы получилось сделать вторую версию с coalesced доступом, то она бы выиграла.

CPU в релизной сборке вовсе в 4 раза быстрее посчитал, чем GPU. 
Все таки встроенная графика слабовата.

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8e-06+-0 s
CPU: 512 millions/s
A sum scan algorithm
GPU: 0.0001665+-2.36291e-06 s
GPU: 24.6006 millions/s
A sum parallel scan
GPU: 0.0002495+-4.82183e-06 s
GPU: 16.4168 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.16667e-05+-4.71405e-07 s
CPU: 517.389 millions/s
A sum scan algorithm
GPU: 0.000353833+-3.43592e-06 s
GPU: 46.3043 millions/s
A sum parallel scan
GPU: 0.000347167+-5.07992e-06 s
GPU: 47.1935 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000123833+-3.72678e-07 s
CPU: 529.227 millions/s
A sum scan algorithm
GPU: 0.000903167+-3.45129e-05 s
GPU: 72.5625 millions/s
A sum parallel scan
GPU: 0.000546167+-1.48931e-05 s
GPU: 119.993 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000504667+-7.45356e-07 s
CPU: 519.44 millions/s
A sum scan algorithm
GPU: 0.00316167+-0.000103448 s
GPU: 82.9132 millions/s
A sum parallel scan
GPU: 0.00101567+-3.28667e-05 s
GPU: 258.1 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00202583+-3.76017e-06 s
CPU: 517.602 millions/s
A sum scan algorithm
GPU: 0.0159335+-0.0021099 s
GPU: 65.8095 millions/s
A sum parallel scan
GPU: 0.00314183+-6.24964e-05 s
GPU: 333.747 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0081125+-3.3541e-06 s
CPU: 517.017 millions/s
A sum scan algorithm
GPU: 0.0537902+-0.000220195 s
GPU: 77.9753 millions/s
A sum parallel scan
GPU: 0.0114548+-0.00019235 s
GPU: 366.16 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0324342+-5.10014e-05 s
CPU: 517.27 millions/s
A sum scan algorithm
GPU: 0.238053+-0.00038922 s
GPU: 70.4767 millions/s
A sum parallel scan
GPU: 0.0584108+-0.000161987 s
GPU: 287.228 millions/s
</pre>
</p></details>

В CI асимптотически более эффективная версия значительно лучше наивной, потому что вычислялось на CPU.
