### PR TITLE
Task06 Артем Каширин SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,43 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void bitonic(__global float *as,
+					  unsigned int size,
+					  unsigned int iter_size,
+					  unsigned int iter_stage) {
+	unsigned int gid = get_global_id(0);
+	const int direction = (gid / iter_size) % 2 ? 0 : 1;
+	const unsigned int start = (gid / iter_stage) * iter_stage * 2 + gid % iter_stage;
+	const unsigned int end = start + iter_stage;
+
+	if (end < size)
+	{
+		if ((as[start] > as[end]) == direction) {
+			float tmp = as[start];
+			as[start] = as[end];
+			as[end] = tmp;
+		}
+	}
+}
+
+__kernel void bitonic_fast(__global float *as,
+					  unsigned int size,
+					  unsigned int iter_size_pow_2,
+					  unsigned int iter_stage_pow_2) {
+	unsigned int gid = get_global_id(0);
+	const int direction = ((gid >> iter_size_pow_2) & 1) ? 0 : 1;
+	const unsigned int start = ((gid >> iter_stage_pow_2) << (iter_stage_pow_2 + 1)) + (gid & ((1 << iter_stage_pow_2) - 1));
+	const unsigned int end = start + (1 << iter_stage_pow_2);
+
+	if (end < size)
+	{
+		if ((as[start] > as[end]) == direction) {
+			float tmp = as[start];
+			as[start] = as[end];
+			as[end] = tmp;
+		}
+	}
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,37 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+// scan - in-place prefix sum.
+// Reduce - pre-calculate every (offset*2)-th element
+// offset: must be a power of 2; offset * 2 <= limit
+__kernel void scan_reduce(__global unsigned int *array,
+						  const unsigned int limit,
+						  const unsigned int offset)
+{
+	const unsigned int gid = get_global_id(0);
+	unsigned int index_cur = (gid + 1) * offset * 2 - 1;
+	if (index_cur >= limit)
+		return;
+
+	unsigned int index_prev = index_cur - offset;
+	array[index_cur] += array[index_prev];
+}
+
+// scan - in-place prefix sum.
+// DownSweep - calculate every other (offset*2)-th element
+// offset: must be a power of 2; offset * 2 <= limit
+__kernel void scan_down_sweep(__global unsigned int *array,
+							  const unsigned int limit,
+							  const unsigned int offset)
+{
+	const unsigned int gid = get_global_id(0);
+//	const unsigned int limit = limit_w * limit_h;
+	unsigned long index_prev = (gid + 1) * offset * 2 - 1;
+	unsigned long index_cur = index_prev + offset;
+	if (index_cur >= limit)
+		return;
+	array[index_cur] += array[index_prev];
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -97,6 +97,7 @@ int main(int argc, char **argv)
 			timer t;
 			for (int iter = 0; iter < benchmarkingIters; ++iter) {
 				as_gpu.writeN(as.data(), n);
+				t.restart();
 				unsigned int offset;
 				for (offset = 1; offset * 2 <= n; offset <<= 1) {
 					scan_reduce.exec(gpu::WorkSize(workGroupSize, (n + offset - 1) / offset),
@@ -111,12 +112,12 @@ int main(int argc, char **argv)
 										 n,
 										 offset);
 				}
-				as_gpu.readN(result.data(), n);
 				t.nextLap();
 			}
 			std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
 			std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
+			as_gpu.readN(result.data(), n);
 			for (int i = 0; i < n; ++i) {
 				EXPECT_THE_SAME(reference_result[i], result[i], "GPU result should be consistent!");
 			}


### PR DESCRIPTION
## 1. bitonic sort
<details><summary>Локальный вывод</summary><p>
<pre>$./bitonic 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 15862 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1050 Ti. Total memory: 4038 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1050 Ti. Total memory: 4038 Mb
Data generated for n=33554432!
CPU: 2.74601+-0.0246092 s
CPU: 12.0175 millions/s
GPU: 0.917961+-0.00133125 s
GPU: 35.9492 millions/s
GPU "fast": 0.842977+-0.00172219 s
GPU "fast": 39.147 millions/s

Process finished with exit code 0</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>Run ./bitonic
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.59153+-0.00049722 s
CPU: 9.18827 millions/s
GPU: 12.8005+-0.0139215 s
GPU: 2.57803 millions/s
GPU "fast": 9.12144+-0.00378646 s
GPU "fast": 3.61785 millions/s
</pre>
</p></details>

## 2. prefix sum
<details><summary>Локальный вывод</summary><p>
<pre>$./prefix_sum 1
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i5-8300H CPU @ 2.30GHz. Intel(R) Corporation. Total memory: 15862 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1050 Ti. Total memory: 4038 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1050 Ti. Total memory: 4038 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.33333e-06+-4.71405e-07 s
CPU: 1755.43 millions/s
GPU: 0.0001585+-5e-07 s
GPU: 25.8423 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1e-05+-1.13687e-13 s
CPU: 1638.4 millions/s
GPU: 0.000200167+-1.2348e-05 s
GPU: 81.8518 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.11667e-05+-3.72678e-07 s
CPU: 1591.97 millions/s
GPU: 0.000228333+-1.24722e-06 s
GPU: 287.019 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000185333+-9.42809e-07 s
CPU: 1414.45 millions/s
GPU: 0.000348333+-1.09949e-05 s
GPU: 752.567 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0007675+-3.23973e-05 s
CPU: 1366.22 millions/s
GPU: 0.00110117+-1.56569e-05 s
GPU: 952.241 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00428933+-0.000204329 s
CPU: 977.845 millions/s
GPU: 0.00378233+-1.30852e-05 s
GPU: 1108.92 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0150832+-0.000126161 s
CPU: 1112.31 millions/s
GPU: 0.0145125+-3.57013e-05 s
GPU: 1156.05 millions/s

Process finished with exit code 0</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>Run ./prefix_sum
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 7.83333e-06+-3.72678e-07 s
CPU: 522.894 millions/s
GPU: 0.000243833+-3.3375e-06 s
GPU: 16.7984 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.06667e-05+-4.71405e-07 s
CPU: 534.261 millions/s
GPU: 0.0003435+-2.87228e-06 s
GPU: 47.6972 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000126333+-4.71405e-07 s
CPU: 518.755 millions/s
GPU: 0.000552+-1.05987e-05 s
GPU: 118.725 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0005055+-2.81366e-06 s
CPU: 518.584 millions/s
GPU: 0.0011065+-2.00894e-05 s
GPU: 236.913 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00201467+-1.20508e-05 s
CPU: 520.471 millions/s
GPU: 0.00433233+-0.000525695 s
GPU: 242.035 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00828167+-1.29701e-05 s
CPU: 506.457 millions/s
GPU: 0.0115357+-0.000107893 s
GPU: 363.594 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.03359+-2.97546e-05 s
CPU: 499.471 millions/s
GPU: 0.0617857+-0.000462042 s
GPU: 271.539 millions/s</pre>
</p></details>