### PR TITLE
Task06 Скальт Альберт SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,20 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+
+__kernel void bitonic(__global float *as, const int block_size, int offset) {
+    int id = get_global_id(0);
+    int am_i_blue = ((id / block_size) % 2 == 0);
+    int inner_id = id % (offset * 2);
+    if (inner_id >= offset)
+        return;
+    if ((am_i_blue && as[id + offset] < as[id]) || (!am_i_blue && as[id + offset] > as[id])) {
+        float temp = as[id + offset];
+        as[id + offset] = as[id];
+        as[id] = temp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,26 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+
+__kernel void prefix_sum_sparse(const __global unsigned *sparse_in, __global unsigned *sparse_out, int sz, int n) {
+    int i = get_global_id(0);
+    sparse_out[i] = sparse_in[i];
+    if (i + sz < n) {
+        sparse_out[i] += sparse_in[i + sz];
+    }
+}
+
+__kernel void prefix_sum_supplement(__global unsigned *sparse, __global unsigned *res, int sz) {
+    int i = get_global_id(0);
+    int j = (i + 1) % (2 * sz);
+    if (sz == 1) {
+        res[i] = 0;
+    }
+    if (j >= sz) {
+        res[i] += sparse[j - sz];
+    }
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -63,8 +63,19 @@ int main(int argc, char **argv) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
-
-            // TODO
+            int block_size = 2;
+            while (block_size <= n) {
+                int offset = block_size / 2;
+                while (offset > 0) {
+                    unsigned int workGroupSize = 128;
+                    unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+                    bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                                 as_gpu,block_size, offset);
+                    offset /= 2;
+                }
+                block_size *= 2;
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +87,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
### bitonic sort
Локально:
```
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Data generated for n=33554432!
CPU: 12.3934+-0.322023 s
CPU: 2.66271 millions/s
GPU: 2.6936+-0.018438 s
GPU: 12.2513 millions/s
```

CI:
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.95176+-0.0561536 s
CPU: 8.3507 millions/s
GPU: 6.51739+-0.0530193 s
GPU: 5.06338 millions/s
```
### preifx sum 
Локально:
```
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz. Intel(R) Corporation. Total memory: 15768 Mb
  Device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
Using device #1: GPU. Intel(R) Iris(R) Xe Graphics. Total memory: 12615 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.4e-05+-0 s
CPU: 170.667 millions/s
GPU: 0.000888667+-4.06885e-06 s
GPU: 4.60915 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 9.5e-05+-0 s
CPU: 172.463 millions/s
GPU: 0.0010355+-4.34933e-06 s
GPU: 15.8223 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000383833+-2.73354e-06 s
CPU: 170.741 millions/s
GPU: 0.00193183+-0.000760477 s
GPU: 33.9243 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00155533+-1.06406e-05 s
CPU: 168.545 millions/s
GPU: 0.001903+-7.99291e-05 s
GPU: 137.753 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00623383+-3.25342e-05 s
CPU: 168.207 millions/s
GPU: 0.00543383+-6.15424e-05 s
GPU: 192.972 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0290488+-0.00284592 s
CPU: 144.388 millions/s
GPU: 0.0491425+-0.000603478 s
GPU: 85.3498 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.101987+-0.00140756 s
CPU: 164.503 millions/s
GPU: 0.217291+-0.00232278 s
GPU: 77.2109 millions/s

```

CI:
```
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 9.33333e-06+-4.71405e-07 s
CPU: 438.857 millions/s
GPU: 0.000458833+-3.81026e-05 s
GPU: 8.92699 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.5e-05+-4.54747e-13 s
CPU: 468.114 millions/s
GPU: 0.000928667+-4.11001e-05 s
GPU: 17.6425 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000136833+-6.66875e-06 s
CPU: 478.948 millions/s
GPU: 0.001466+-0.000161341 s
GPU: 44.704 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000520167+-3.99934e-05 s
CPU: 503.962 millions/s
GPU: 0.00432633+-0.000160896 s
GPU: 60.5926 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.002165+-8.22233e-05 s
CPU: 484.331 millions/s
GPU: 0.0183205+-0.00122923 s
GPU: 57.2351 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.008728+-0.000167372 s
CPU: 480.557 millions/s
GPU: 0.085407+-0.00679271 s
GPU: 49.1096 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0342582+-0.000329145 s
CPU: 489.729 millions/s
GPU: 0.414357+-0.00753512 s
GPU: 40.4898 millions/s
```