### PR TITLE
task06 Петров Леонид SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,14 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *as, unsigned int n, unsigned int step, unsigned int size) {
+    // 'n' and 'size' should be a power of 2 (we can add inf's to as to increase 'n')
+
+    int global_i = get_global_id(0);
+    global_i = global_i / (size / 2) * size + global_i % (size / 2);
+    int group_number = global_i / step;
+    int mult = (int)(group_number % 2 == 0) * 2 - 1;
+
+    if (global_i < n && as[global_i] * mult > as[global_i + size / 2] * mult) {
+        float tmp = as[global_i + size / 2];
+        as[global_i + size / 2] = as[global_i];
+        as[global_i] = tmp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,21 @@
-// TODO
+__kernel void prefix_sum(__global unsigned int* as, __global unsigned int* res, unsigned int n, unsigned int depth, unsigned int compress) {
+    // 'n' and should be a power of 2 (we can add inf's to as to increase 'n')
+
+    int i = get_global_id(0);
+    int j = ((i + 1) >> depth) % 2;
+
+    if (i < n) {
+        res[i] += j * as[(i / compress) * compress];
+    }
+}
+
+__kernel void compress(__global unsigned int* as, unsigned int n, unsigned int compress) {
+    // 'n' and should be a power of 2 (we can add inf's to as to increase 'n')
+
+    int i = get_global_id(0);
+    int j = i + compress / 2;
+
+    if (i % compress == 0 && j < n) {
+        as[i] += as[j];
+    }
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -5,17 +5,17 @@ __kernel void prefix_sum(__global unsigned int* as, __global unsigned int* res, 
     int j = ((i + 1) >> depth) % 2;
 
     if (i < n) {
-        res[i] += j * as[(i / compress) * compress];
+        res[i] += j * as[i / compress * 2];
     }
 }
 
-__kernel void compress(__global unsigned int* as, unsigned int n, unsigned int compress) {
+
+__kernel void compress(__global unsigned int* as, __global unsigned int* bs, unsigned int n) {
     // 'n' and should be a power of 2 (we can add inf's to as to increase 'n')
 
     int i = get_global_id(0);
-    int j = i + compress / 2;
 
-    if (i % compress == 0 && j < n) {
-        as[i] += as[j];
+    if (2 * i < n) {
+        bs[i] = as[2 * i] + as[2 * i + 1];
     }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -48,9 +48,9 @@ int main(int argc, char **argv) {
             t.nextLap();
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU: " << (static_cast<float>(n) / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+    
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -58,16 +58,24 @@ int main(int argc, char **argv) {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
 
+        unsigned int work_group_size = 128;
+        unsigned int global_work_size = ((n + 1) / 2 + work_group_size - 1) / work_group_size * work_group_size;
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (unsigned int step = 2; step <= n; step *= 2) {
+                for (unsigned int size = step; size >= 2; size /= 2) {
+                    bitonic.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, n, step, size);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << (static_cast<float>(n) / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
     }
@@ -76,6 +84,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод (bitonic)</summary><p>

<pre>
$ ./bitonic
OpenCL devices:
  Device #0: CPU. AMD A12-9700P RADEON R7, 10 COMPUTE CORES 4C+6G. Intel(R) Corporation. Total memory: 7385 Mb
Using device #0: CPU. AMD A12-9700P RADEON R7, 10 COMPUTE CORES 4C+6G. Intel(R) Corporation. Total memory: 7385 Mb
Data generated for n=33554432!
CPU: 23.4188+-0.524837 s
CPU: 1.4328 millions/s
GPU: 40.8395+-0.77121 s
GPU: 0.821617 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI (bitonic)</summary><p>

<pre>
$ ./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.60868+-0.000531623 s
CPU: 9.29826 millions/s
GPU: 13.214+-0.0508012 s
GPU: 2.53932 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод (prefix_sum)</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD A12-9700P RADEON R7, 10 COMPUTE CORES 4C+6G. Intel(R) Corporation. Total memory: 7385 Mb
Using device #0: CPU. AMD A12-9700P RADEON R7, 10 COMPUTE CORES 4C+6G. Intel(R) Corporation. Total memory: 7385 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 4.4e-05+-9.09495e-13 s
CPU: 93.0909 millions/s
GPU: 0.0010845+-9.60777e-05 s
GPU: 3.77686 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000322+-2.5364e-05 s
CPU: 50.882 millions/s
GPU: 0.00215517+-0.000274041 s
GPU: 7.6022 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0012655+-7.07996e-05 s
CPU: 51.7866 millions/s
GPU: 0.00457517+-0.000372165 s
GPU: 14.3243 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00478+-0.000270193 s
CPU: 54.8418 millions/s
GPU: 0.0161835+-0.000628779 s
GPU: 16.1982 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.019353+-0.000109583 s
CPU: 54.1816 millions/s
GPU: 0.0580477+-0.000727172 s
GPU: 18.0641 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.076854+-0.00104594 s
CPU: 54.575 millions/s
GPU: 0.231517+-0.00265529 s
GPU: 18.1166 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.310246+-0.012684 s
CPU: 54.0772 millions/s
GPU: 0.959088+-0.00280065 s
GPU: 17.4929 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI (prefix_sum)</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 9.16667e-06+-3.72678e-07 s
CPU: 446.836 millions/s
GPU: 0.000399+-7.81025e-06 s
GPU: 10.2657 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.76667e-05+-4.71405e-07 s
CPU: 434.973 millions/s
GPU: 0.000908333+-5.24743e-05 s
GPU: 18.0374 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000148167+-6.87184e-07 s
CPU: 442.313 millions/s
GPU: 0.0017465+-6.11031e-05 s
GPU: 37.5242 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000604833+-3.72678e-07 s
CPU: 433.415 millions/s
GPU: 0.0056415+-0.000213381 s
GPU: 46.4671 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.002429+-1.23962e-05 s
CPU: 431.69 millions/s
GPU: 0.0207127+-9.90954e-05 s
GPU: 50.6249 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00966783+-2.97625e-05 s
CPU: 433.841 millions/s
GPU: 0.087313+-0.000157511 s
GPU: 48.0376 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0386865+-4.70239e-05 s
CPU: 433.671 millions/s
GPU: 0.378078+-0.00322063 s
GPU: 44.375 millions/s
</pre>

</p></details>