### PR TITLE
Task06 Никита Потапов SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,18 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *as, const unsigned int window, const unsigned int arrow, const unsigned int n) {
+    unsigned int id = get_global_id(0);
+
+    if ((id << 1) >= n)
+        return;
+
+    unsigned int begin = ((id << 1) / window);
+    const int dec = begin & 1;
+
+    begin = begin * window;
+    id = begin + (id - id / arrow * arrow) + ((id << 1) - begin) / (arrow << 1) * (arrow << 1);
+
+    const float max = as[id] > as[id + arrow] ? as[id] : as[id + arrow];
+    const float min = as[id] < as[id + arrow] ? as[id] : as[id + arrow];
+
+    as[id] = (dec) ? max : min;
+    as[id + arrow] = (dec) ? min : max;
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,44 @@
-// TODO
+__kernel void prefix_sum_naive(__global const unsigned int *as, __global unsigned int *bs, const unsigned int offset,
+                               const unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= offset)
+        bs[gid] = as[gid] + as[gid - offset];
+    else
+        bs[gid] = as[gid];
+}
+
+__kernel void prefix_sum_next(__global unsigned int *as, const unsigned int off, const unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n)
+        return;
+
+    if (!((gid + 1) % (off << 1))) {
+        as[gid] = as[gid] + as[gid - off];
+    }
+}
+
+__kernel void prefix_sum_down(__global unsigned int *as, const unsigned int off, const unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n)
+        return;
+
+    unsigned int tmp;
+    if (!((gid + 1) % (off << 1))) {
+        tmp = as[gid];
+        as[gid] = tmp + as[gid - off];
+        as[gid - off] = tmp;
+    }
+}
+
+__kernel void prefix_sum_normal(__global const unsigned int *as, __global unsigned int *bs, const unsigned int total,
+                                const unsigned int n) {
+    const unsigned int gid = get_global_id(0);
+
+    if (gid >= n)
+        return;
+
+    bs[gid] = (gid + 1 == n) ? total : as[gid + 1] - total;
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -48,9 +48,8 @@ int main(int argc, char **argv) {
             t.nextLap();
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -65,9 +64,15 @@ int main(int argc, char **argv) {
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
             // TODO
+            for (unsigned k = 2; k <= n; k *= 2) {
+                for (unsigned arrow = k / 2; arrow > 0; arrow /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n / 2), as_gpu, k, arrow, n);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
     }
@@ -76,6 +81,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,157 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+
+        {
+            gpu::gpu_mem_32u as_gpu, bs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+
+            ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_naive");
+            prefix_sum.compile();
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(std::vector<unsigned>(n, 0).data(), n);
+                t.restart();
+                for (unsigned offset = 1; offset < n; offset *= 2) {
+                    prefix_sum.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, offset, n);
+                    std::swap(as_gpu, bs_gpu);
+                }
+                t.nextLap();
+            }
+            std::cout << "GPU (naive): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (naive): " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+            }
+        }
+
+        {
+            gpu::gpu_mem_32u as_gpu, bs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+
+            ocl::Kernel prefix_sum_up_sweep(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_next");
+            ocl::Kernel prefix_sum_down_sweep(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_down");
+            ocl::Kernel prefix_sum_shift(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_normal");
+
+            prefix_sum_up_sweep.compile();
+            prefix_sum_down_sweep.compile();
+            prefix_sum_shift.compile();
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(std::vector<unsigned>(n, 0).data(), n);
+                t.restart();
+                for (unsigned offset = 1; offset < n; offset *= 2) {
+                    prefix_sum_up_sweep.exec(gpu::WorkSize(128, n), as_gpu, offset, n);
+                }
+                unsigned total = 0;
+                as_gpu.readN(&total, 1, n - 1);
+                for (unsigned offset = n / 2; offset > 0; offset /= 2) {
+                    prefix_sum_down_sweep.exec(gpu::WorkSize(128, n), as_gpu, offset, n);
+                }
+                prefix_sum_shift.exec(gpu::WorkSize(128, n), as_gpu, bs_gpu, total, n);
+                std::swap(as_gpu, bs_gpu);
+
+                t.nextLap();
+            }
+            std::cout << "GPU (tree): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (tree): " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+            }
+            std::cout << std::endl;
+        }
+    }
 }


### PR DESCRIPTION
## Bitonic

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 444/512 Mb
Using device #0: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 444/512 Mb
Data generated for n=33554432!
CPU: 10.6844+-0.00309361 s
CPU: 3.14051 millions/s
GPU: 1.95627+-0.00279334 s
GPU: 17.1523 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.27028+-0.00873697 s
CPU: 7.85767 millions/s
GPU: 16.8239+-0.108016 s
GPU: 1.99445 millions/s
</pre>

</p></details>

## Prefix sum

<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 466/512 Mb
Using device #0: GPU. AMD Radeon Graphics (gfx90c:xnack-). Free memory: 466/512 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.71667e-05+-3.72678e-07 s
CPU: 150.773 millions/s
GPU (naive): 0.000294833+-1.15962e-05 s
GPU (naive): 13.8926 millions/s
GPU (tree): 0.000598333+-4.33692e-05 s
GPU (tree): 6.84568 millions/s

______________________________________________
n=16384 values in range: [0; 1023]
CPU: 8.2e-05+-5.7735e-07 s
CPU: 199.805 millions/s
GPU (naive): 0.000809+-1.73205e-05 s
GPU (naive): 20.2522 millions/s
GPU (tree): 0.00116467+-1.50518e-05 s
GPU (tree): 14.0675 millions/s

______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000329667+-1.88562e-06 s
CPU: 198.795 millions/s
GPU (naive): 0.000502167+-5.8713e-06 s
GPU (naive): 130.506 millions/s
GPU (tree): 0.000981833+-4.81029e-06 s
GPU (tree): 66.7486 millions/s

______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00221283+-0.000919504 s
CPU: 118.465 millions/s
GPU (naive): 0.00159417+-0.000181716 s
GPU (naive): 164.44 millions/s
GPU (tree): 0.002209+-5.65862e-05 s
GPU (tree): 118.671 millions/s

______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00516333+-1.05462e-05 s
CPU: 203.081 millions/s
GPU (naive): 0.00473383+-0.00013454 s
GPU (naive): 221.507 millions/s
GPU (tree): 0.005868+-0.000172088 s
GPU (tree): 178.694 millions/s

______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.021227+-1.98158e-05 s
CPU: 197.593 millions/s
GPU (naive): 0.0196875+-0.00113031 s
GPU (naive): 213.044 millions/s
GPU (tree): 0.0207452+-0.00130232 s
GPU (tree): 202.182 millions/s

______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0845918+-0.00150176 s
CPU: 198.331 millions/s
GPU (naive): 0.0914025+-0.00161638 s
GPU (naive): 183.553 millions/s
GPU (tree): 0.126652+-0.0497432 s
GPU (tree): 132.467 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 9.5e-06+-5e-07 s
CPU: 431.158 millions/s
GPU (naive): 0.000184333+-1.38404e-05 s
GPU (naive): 22.2206 millions/s
GPU (tree): 0.000400167+-1.15818e-05 s
GPU (tree): 10.2357 millions/s

______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.8e-05+-0 s
CPU: 431.158 millions/s
GPU (naive): 0.0003055+-9.99583e-06 s
GPU (naive): 53.6301 millions/s
GPU (tree): 0.000858833+-1.80501e-05 s
GPU (tree): 19.077 millions/s

______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000145333+-2.92499e-06 s
CPU: 450.936 millions/s
GPU (naive): 0.000580333+-4.42179e-05 s
GPU (naive): 112.928 millions/s
GPU (tree): 0.0019245+-4.72643e-05 s
GPU (tree): 34.0535 millions/s

______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.0006045+-1.89297e-06 s
CPU: 433.654 millions/s
GPU (naive): 0.00133567+-4.71581e-05 s
GPU (naive): 196.265 millions/s
GPU (tree): 0.006577+-0.000207644 s
GPU (tree): 39.8577 millions/s

______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00241933+-5.15321e-06 s
CPU: 433.415 millions/s
GPU (naive): 0.00468333+-1.17568e-05 s
GPU (naive): 223.895 millions/s
GPU (tree): 0.0226393+-0.000231375 s
GPU (tree): 46.3166 millions/s

______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0096315+-6.66702e-05 s
CPU: 435.478 millions/s
GPU (naive): 0.0275735+-0.000184153 s
GPU (naive): 152.114 millions/s
GPU (tree): 0.0947243+-0.000866077 s
GPU (tree): 44.2791 millions/s

______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0379585+-0.000171908 s
CPU: 441.988 millions/s
GPU (naive): 0.164404+-0.00162588 s
GPU (naive): 102.048 millions/s
GPU (tree): 0.397817+-0.00344121 s
GPU (tree): 42.1731 millions/s
</pre>

</p></details>