### PR TITLE
Task06 Илья Асадуллин ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,25 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include "clion_defines.cl"
+#endif
+
+#line 6
+
+__kernel void bitonic(__global float *as,
+                      const unsigned N,
+                      const unsigned int K,
+                      const unsigned int K_curr)
+{
+    const int gid = get_global_id(0);
+
+    if (gid * 2 >= N)
+        return;
+
+    const int idx = (gid / K_curr) * K_curr * 2 + (gid % K_curr);
+    const int pr = (gid / K) % 2 ? -1 : 1;
+    float lhs = as[idx];
+    float rhs = as[idx + K_curr];
+    if (pr * lhs > pr * rhs) {
+        as[idx] = rhs;
+        as[idx + K_curr] = lhs;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,17 @@
-// TODO
+#ifdef __CLION_IDE__
+#include "clion_defines.cl"
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global const unsigned int *as,
+                         __global unsigned int *bs,
+                         const unsigned int N,
+                         const unsigned int offset)
+{
+    const int gid = get_global_id(0);
+    if (gid >= N)
+        return;
+
+    bs[gid] = gid >= offset ? as[gid] + as[gid - offset] : as[gid];
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -64,7 +64,16 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            unsigned int workGroupSize = 128;
+            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize / 2;
+            gpu::WorkSize ws(workGroupSize, global_work_size);
+
+            for (int K = 1; K <= n/2; K *= 2) {
+                for (int K_curr = K; K_curr > 0; K_curr /= 2) {
+                    bitonic.exec(ws, as_gpu, n, K, K_curr);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +85,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -22,6 +22,12 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+
 	int benchmarkingIters = 10;
 	unsigned int max_n = (1 << 24);
 
@@ -77,7 +83,41 @@ int main(int argc, char **argv)
 		}
 
 		{
-			// TODO: implement on OpenCL
+            std::vector<unsigned int> result(n, 0);
+
+            ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+            prefix_sum.compile();
+
+            gpu::gpu_mem_32u as_gpu;
+            gpu::gpu_mem_32u bs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+
+            timer t;
+            unsigned int workGroupSize = 128;
+            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+            gpu::WorkSize ws(workGroupSize, global_work_size);
+
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(result.data(), n);
+
+                t.restart();
+                for (unsigned int offset = 1; offset < n ; offset *= 2) {
+                    prefix_sum.exec(ws, as_gpu, bs_gpu, n, offset);
+                    as_gpu.swap(bs_gpu);
+                }
+                t.nextLap();
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "GPU results should be equal to CPU results!");
+            }
 		}
 	}
 }


### PR DESCRIPTION
Bitonic sort:
```
OpenCL devices:
  Device #0: GPU. Intel(R) HD Graphics 630. Total memory: 12695 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Data generated for n=33554432!
CPU: 3.42146+-0.0448687 s
CPU: 9.645 millions/s
GPU: 0.36418+-0.0012463 s
GPU: 90.6146 millions/s
```

Prefix_sum:
```
OpenCL devices:
  Device #0: GPU. Intel(R) HD Graphics 630. Total memory: 12695 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2e-06+-0 s
CPU: 2048 millions/s
GPU: 0.000397+-0.000105292 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 6.3e-05+-3.65148e-06 s
CPU: 260.063 millions/s
GPU: 0.0001045+-5e-07 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 3.63333e-05+-4.71405e-07 s
CPU: 1803.74 millions/s
GPU: 0.0003715+-9.19692e-06 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000204667+-1.335e-05 s
CPU: 1280.83 millions/s
GPU: 0.000598667+-0.000137592 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000780833+-7.41382e-05 s
CPU: 1342.89 millions/s
GPU: 0.00119233+-7.59532e-05 s
GPU: 838.692 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0043955+-0.000216254 s
CPU: 954.227 millions/s
GPU: 0.0045715+-0.000283925 s
GPU: 874.986 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0158743+-0.000219213 s
CPU: 1056.88 millions/s
GPU: 0.0183302+-2.73216e-05 s
GPU: 872.878 millions/s
```

Забавно, что префиксные суммы на процессоре так быстро считаются. Собирал и запускал код в релизе для сбора статистики. Для интереса запустил также в дебаге, сразу видно насколько хорошо оптимизирует некоторые вещи компилятор:
```
OpenCL devices:
  Device #0: GPU. Intel(R) HD Graphics 630. Total memory: 12695 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8.96667e-05+-9.42809e-07 s
CPU: 45.6803 millions/s
GPU: 0.0001375+-5e-07 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.000156167+-3.72678e-07 s
CPU: 104.914 millions/s
GPU: 0.000137333+-1.20231e-05 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.0006535+-2.70231e-05 s
CPU: 100.285 millions/s
GPU: 0.0001895+-4.42446e-05 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00268283+-4.72702e-05 s
CPU: 97.7116 millions/s
GPU: 0.0003015+-8.64807e-05 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0114443+-0.000334532 s
CPU: 91.624 millions/s
GPU: 0.00109933+-1.78201e-05 s
GPU: 909.642 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.044775+-0.000418959 s
CPU: 93.6751 millions/s
GPU: 0.004489+-0.000102872 s
GPU: 891.067 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.185062+-0.00631213 s
CPU: 90.6574 millions/s
GPU: 0.018695+-0.000378734 s
GPU: 855.844 millions/s
```