### PR TITLE
Task06 Артём Пешков SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,12 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *as, const unsigned int block_size, const unsigned int step) {
+    const int id = get_global_id(0);
+    int fst_ind = 2 * id - id % step;
+    int snd_ind = fst_ind + step;
+    int direction = ((id / block_size) % 2) * 2 - 1;
+    
+    if (as[fst_ind] * direction < as[snd_ind] * direction) {
+        float tmp = as[fst_ind];
+        as[fst_ind] = as[snd_ind];
+        as[snd_ind] = tmp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,10 @@
-// TODO
+__kernel void reduce_a(__global unsigned int *as, __global unsigned int *bs) {
+    int id = get_global_id(0);
+    as[id] = bs[id * 2] + bs[id * 2 + 1];
+}
+
+__kernel void prefix_sum(__global const unsigned int *as, __global unsigned int *res, unsigned int block_size) {
+    int id = get_global_id(0);
+    if ((id + 1) & block_size)
+        res[id] += as[(id + 1) / block_size - 1];
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -64,7 +64,11 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (unsigned int block_size = 1; block_size < n; block_size *= 2)
+                for (unsigned int step = block_size; step > 0; step /= 2)
+                    bitonic.exec(gpu::WorkSize(128, n / 2), as_gpu, block_size, step);
+
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +80,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
Bitonic sort:
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Data generated for n=33554432!
CPU: 15.1543+-0.12928 s
CPU: 2.17759 millions/s
GPU: 3.98417+-0.040511 s
GPU: 8.28279 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.32012+-0.00734737 s
CPU: 7.63868 millions/s
GPU: 10.5922+-0.0362109 s
GPU: 3.1155 millions/s
</pre>

</p></details>
Prefix sum:
<details><summary>Локальный вывод</summary><p>

<pre>
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.000666667+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.001+-0 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000833333+-0.000372678 s
CPU: 78.6432 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.00133333+-0.000471405 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00266667+-0.000471405 s
CPU: 98.304 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.002+-0 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0108333+-0.000372678 s
CPU: 96.7916 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.005+-0 s
GPU: 200 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0438333+-0.00106719 s
CPU: 95.6875 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.0316667+-0.00422953 s
GPU: 126.316 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.166667+-0.000745356 s
CPU: 100.663 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
Using device #0: CPU. AMD Ryzen 5 5600H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15732 Mb
GPU: 0.111833+-0.00226691 s
GPU: 143.07 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 9.33333e-06+-4.71405e-07 s
CPU: 438.857 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.000382333+-1.64587e-05 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.6e-05+-1.41421e-06 s
CPU: 455.111 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.0006315+-1.58614e-05 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000139333+-4.71405e-07 s
CPU: 470.354 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.0013295+-0.000214813 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000589667+-1.94565e-05 s
CPU: 444.563 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.00318667+-1.57445e-05 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00234517+-2.82455e-05 s
CPU: 447.122 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.012252+-0.00149298 s
GPU: 81.6193 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.009512+-6.45084e-05 s
CPU: 440.949 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.0471273+-0.00106275 s
GPU: 84.8764 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0385222+-0.000252277 s
CPU: 435.521 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
GPU: 0.198209+-0.00192103 s
GPU: 80.7228 millions/s
</pre>

</p></details>