### PR TITLE
Task06 Дмитрий Васильев SPbU 

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,2 @@
 __kernel void bitonic(__global float *as) {
-    // TODO
 }

--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,2 +1,21 @@
-__kernel void bitonic(__global float *as) {
+#ifdef __Clocal_yON_IDE__
+    #include <local_ybgpu/opencl/cl/clocal_yon_defines.cl>
+#endif
+
+#line 5
+
+__kernel void bitonic(__global float *as, int current_size, int target_size) {
+    const unsigned int global_id = get_global_id(0);
+    int block_id = global_id / target_size;
+    int direction = block_id % 2;
+    int small_blocks_to_skip = global_id % target_size / current_size * 2;
+    int small_block_offset = global_id % target_size % current_size;
+
+    int i = block_id * 2 * target_size + current_size * small_blocks_to_skip + small_block_offset;
+
+    if (direction == as[i] < as[i + current_size]) {
+        float tmp = as[i];
+        as[i] = as[i + current_size];
+        as[i + current_size] = tmp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,17 @@
-// TODO
+#ifdef __Clocal_yON_IDE__
+    #include <local_ybgpu/opencl/cl/clocal_yon_defines.cl>
+#endif
+
+#line 5
+
+__kernel void calculate_parts(__global unsigned int *part_sums, unsigned int size) {
+    const unsigned int id = get_global_id(0);
+    part_sums[id * size] += part_sums[id * size + size / 2];
+}
+
+__kernel void calculate_prefix_sums(__global unsigned int *result, __global const unsigned int *part_sums,
+                                    unsigned int size) {
+    const unsigned int id = get_global_id(0) + 1;
+    if (id & size)
+        result[id] += part_sums[(id - size) / size * size];
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -2,7 +2,7 @@
     #include <local_ybgpu/opencl/cl/clocal_yon_defines.cl>
 #endif
 
-#line 5
+#line 6
 
 __kernel void calculate_parts(__global unsigned int *part_sums, unsigned int size) {
     const unsigned int id = get_global_id(0);
@@ -12,6 +12,8 @@ __kernel void calculate_parts(__global unsigned int *part_sums, unsigned int siz
 __kernel void calculate_prefix_sums(__global unsigned int *result, __global const unsigned int *part_sums,
                                     unsigned int size) {
     const unsigned int id = get_global_id(0) + 1;
-    if (id & size)
+
+    if (id & size) {
         result[id] += part_sums[(id - size) / size * size];
+    }
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -61,10 +61,16 @@ int main(int argc, char **argv) {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
+            t.restart();
+            for (int target_size = 1; target_size <= n / 2; target_size *= 2) {
+                for (int current_size = target_size; current_size >= 1; current_size /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n / 2), as_gpu, current_size, target_size);
+                }
+            }
 
-            t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+            // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -76,6 +76,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -100,7 +100,7 @@ int main(int argc, char **argv) {
 
                     for (int size = 1; size <= n; size *= 2) {
                         if (size != 1)
-                            calculate_parts.exec(gpu::WorkSize(128, n / size), part_sums_gpu, size);
+                            calculate_parts.exec(gpu::WorkSize(std::min(128u, n / size), n / size), part_sums_gpu, size);
                         calculate_prefix_sums.exec(gpu::WorkSize(128, n), result_gpu, part_sums_gpu, size);
                     }
 

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,120 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            gpu::gpu_mem_32u result_gpu, part_sums_gpu;
+            result_gpu.resizeN(n + 1);
+            part_sums_gpu.resizeN(n);
+            std::vector results(n + 1, 0u);
+
+            {
+                ocl::Kernel calculate_parts(prefix_sum_kernel, prefix_sum_kernel_length, "calculate_parts");
+                ocl::Kernel calculate_prefix_sums(prefix_sum_kernel, prefix_sum_kernel_length, "calculate_prefix_sums");
+                calculate_parts.compile();
+                calculate_prefix_sums.compile();
+                timer t;
+
+                for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                    result_gpu.writeN(results.data(), n + 1);
+                    part_sums_gpu.writeN(as.data(), n);
+                    t.restart();
+
+                    for (int size = 1; size <= n; size *= 2) {
+                        if (size != 1)
+                            calculate_parts.exec(gpu::WorkSize(128, n / size), part_sums_gpu, size);
+                        calculate_prefix_sums.exec(gpu::WorkSize(128, n), result_gpu, part_sums_gpu, size);
+                    }
+
+                    t.nextLap();
+                }
+
+                std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+                std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+                result_gpu.readN(results.data(), n + 1);
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(results[i + 1], reference_result[i], "GPU results should be equal to CPU results!");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
./bitonic
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Data generated for n=33554432!
CPU: 2.79594+-0.0114365 s
CPU: 11.8028 millions/s
GPU: 0.484012+-0.00596624 s
GPU: 68.1802 millions/s

./prefix_sum
OpenCL devices:
  Device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
Using device #0: GPU. Apple M1 Pro. Total memory: 10922 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.9e-05+-0 s
CPU: 215.579 millions/s
GPU: 0.00533467+-0.000203326 s
GPU: 0.767808 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 7.26667e-05+-1.10554e-06 s
CPU: 225.468 millions/s
GPU: 0.00565167+-0.000208024 s
GPU: 2.89897 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000289667+-1.59861e-06 s
CPU: 226.246 millions/s
GPU: 0.00706267+-0.000770101 s
GPU: 9.27921 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00123783+-2.19273e-05 s
CPU: 211.776 millions/s
GPU: 0.00951783+-0.00116325 s
GPU: 27.5424 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00474933+-3.39346e-05 s
CPU: 220.784 millions/s
GPU: 0.0116223+-0.000310722 s
GPU: 90.2208 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0196752+-9.29344e-05 s
CPU: 213.178 millions/s
GPU: 0.0186703+-0.000157553 s
GPU: 224.651 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0745302+-8.3623e-05 s
CPU: 225.106 millions/s
GPU: 0.0412305+-0.00342973 s
GPU: 406.913 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.64232+-0.000339843 s
CPU: 9.06017 millions/s
GPU: 12.1541+-0.055247 s
GPU: 2.71514 millions/s

./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 7.66667e-06+-4.71405e-07 s
CPU: 534.261 millions/s
GPU: 0.000332167+-8.59102e-06 s
GPU: 12.3312 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.11667e-05+-3.72678e-07 s
CPU: 525.69 millions/s
GPU: 0.000601333+-6.44636e-06 s
GPU: 27.2461 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000125833+-6.87184e-07 s
CPU: 520.816 millions/s
GPU: 0.00116683+-4.8872e-05 s
GPU: 56.1657 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000504833+-2.11476e-06 s
CPU: 519.268 millions/s
GPU: 0.00341533+-5.19027e-05 s
GPU: 76.755 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0020285+-6.89807e-06 s
CPU: 516.922 millions/s
GPU: 0.0156293+-0.00232131 s
GPU: 67.0903 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.008392+-1.8e-05 s
CPU: 499.798 millions/s
GPU: 0.0554928+-0.00041632 s
GPU: 75.5828 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0336907+-4.33692e-05 s
CPU: 497.978 millions/s
GPU: 0.260493+-0.000575483 s
GPU: 64.4058 millions/s
</pre>

</p></details>