### PR TITLE
Task06 Шукшов Андрей ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,57 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define WG_SIZE 128
+
+__kernel void bitonic_local(__global float* in, unsigned int block_size, unsigned int size, unsigned int length) {
+    unsigned int local_id = get_local_id(0);
+    unsigned int gid = get_global_id(0);
+
+    __local float block[WG_SIZE];
+
+    if (gid < length) {
+        block[local_id] = in[gid];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    int f = gid % (2 * size) < size;
+
+    while (block_size >= 1) {
+
+        if (gid % (2 * block_size) < block_size && gid + block_size < length) {
+            float a = block[local_id];
+            float b = block[local_id + block_size];
+
+            if ((a > b) == f) {
+                block[local_id] = b;
+                block[local_id + block_size] = a;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        block_size >>= 1;
+    }
+
+    if (gid < length) {
+        in[gid] = block[local_id];
+    }
+}
+
+
+__kernel void bitonic(__global float* in, unsigned int block_size, unsigned int size, unsigned int length) {
+    unsigned int gid = get_global_id(0);
+
+    int f = gid % (2 * size) < size;
+
+    if (gid % (2 * block_size) < block_size && gid + block_size < length) {
+        float a = in[gid];
+        float b = in[gid + block_size];
+        if ((a > b) == f) {
+            in[gid] = b;
+            in[gid + block_size] = a;
+        }
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,28 @@
-// TODO
+#ifdef __CLION_IDE__
+
+#include <cl/clion_defines.cl>
+
+#endif
+
+#line 6
+
+__kernel void prefix_sum(__global const unsigned int *in,
+                         __global unsigned int *out,
+                         unsigned int length,
+                         unsigned int level) {
+    const unsigned int i = get_global_id(0);
+    if (i < length) {
+        if (((i + 1) >> level) & 1) {
+            out[i] += in[((i + 1) >> level) - 1];
+        }
+    }
+}
+
+__kernel void prefix_sum_other(__global const unsigned int *in,
+                               __global unsigned int *out,
+                               unsigned int length) {
+    const unsigned int i = get_global_id(0);
+    if (i < length) {
+        out[i] = in[2 * i] + in[2 * i + 1];
+    }
+}

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -9,75 +9,122 @@
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        {
+            bs.assign(n, 0);
+            gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu;
+            as_gpu.resizeN(n);
+            bs_gpu.resizeN(n);
+            cs_gpu.resizeN(n);
+
+            ocl::Kernel prefix_sum_bin(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+            prefix_sum_bin.compile();
+            ocl::Kernel prefix_sum_other(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_other");
+            prefix_sum_other.compile();
+
+            unsigned int wg_size = 128;
+            unsigned int grid_size = (n + wg_size - 1) / wg_size * wg_size;
+
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(bs.data(), n);
+                t.restart();
+
+                for (unsigned int level = 0; (1 << level) <= n; level++) {
+                    prefix_sum_bin.exec(gpu::WorkSize(wg_size, grid_size),
+                                        as_gpu, bs_gpu, n, level);
+
+                    unsigned int grid_size_for_level = (n / (1 << (level + 1)) + wg_size - 1) / wg_size * wg_size;
+                    if (grid_size_for_level > 0) {
+                        prefix_sum_other.exec(gpu::WorkSize(wg_size, grid_size_for_level),
+                                              as_gpu, cs_gpu, n / (1 << (level + 1)));
+                    }
+                    as_gpu.swap(cs_gpu);
+                }
+
+                t.nextLap();
+            }
+
+            bs_gpu.readN(bs.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(bs[i], reference_result[i], "GPU results should be equal to CPU results!");
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+
+        }
+    }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод bitonic:</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1036). Free memory: 24485/24566 Mb
  Device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Using device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Data generated for n=33554432!
CPU: 2.19017+-0.0206915 s
CPU: 15.0673 millions/s
GPU: 0.0703333+-0.000471405 s
GPU: 469.194 millions/s
</pre>

</p></details>
<details><summary>Вывод Github CI:</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.59942+-0.000399622 s
CPU: 9.16815 millions/s
GPU: 9.27949+-0.00997631 s
GPU: 3.55623 millions/s
</pre>

</p></details>

<details><summary>Локальный вывод prefix_sum:</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1036). Free memory: 24485/24566 Mb
  Device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
Using device #1: GPU. AMD Radeon RX 7900 XTX (gfx1100). Free memory: 24557/24560 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00133333+-0.000471405 s
GPU: 3.072 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0015+-0.0005 s
GPU: 10.9227 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.002+-0 s
GPU: 32.768 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00233333+-0.000471405 s
GPU: 112.347 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0005+-0.0005 s
CPU: 2097.15 millions/s
GPU: 0.003+-4.1159e-11 s
GPU: 349.525 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00166667+-0.000471405 s
CPU: 2516.58 millions/s
GPU: 0.004+-0 s
GPU: 1048.58 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.00683333+-0.000372678 s
CPU: 2455.2 millions/s
GPU: 0.00716667+-0.000372678 s
GPU: 2341.01 millions/s</pre>

</p></details>

<details><summary>Вывод Github CI prefix_sum:</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 8e-06+-0 s
CPU: 512 millions/s
GPU: 0.000319167+-1.48371e-05 s
GPU: 12.8334 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 3.15e-05+-5e-07 s
CPU: 520.127 millions/s
GPU: 0.000518667+-8.35996e-06 s
GPU: 31.5887 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000123667+-7.45356e-07 s
CPU: 529.941 millions/s
GPU: 0.0009495+-1.29968e-05 s
GPU: 69.0216 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000501333+-1.97203e-06 s
CPU: 522.894 millions/s
GPU: 0.002624+-0.000352933 s
GPU: 99.9024 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00202883+-1.53777e-05 s
CPU: 516.837 millions/s
GPU: 0.00786467+-7.93739e-05 s
GPU: 133.327 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00832583+-1.57207e-05 s
CPU: 503.77 millions/s
GPU: 0.0338923+-0.000244817 s
GPU: 123.754 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0336573+-9.53357e-06 s
CPU: 498.471 millions/s
GPU: 0.173708+-0.000676868 s
GPU: 96.5828 millions/s
</pre>

</p></details>
