### PR TITLE
Task06 Константин Гамора ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,24 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *a, const int big_window_size, const int small_window_size) {
+    int gid = get_global_id(0);
+
+    int small_half_window_size = small_window_size >> 1;
+    int window_id = gid / small_half_window_size;
+    int big_half_window_size = big_window_size >> 1;
+    int big_window_id = gid / big_half_window_size;
+    bool is_direct = big_window_id % 2 == 0;
+    int up_i = (gid % small_half_window_size) + (window_id * small_window_size);
+    int down_i = up_i + small_half_window_size;
+
+    // printf("gid: %d\nup_i: %d\ndown_i: %d\n", gid, up_i, down_i);
+
+    float up_elem = a[up_i];
+    float down_elem = a[down_i];
+
+    bool swap_direct = is_direct && (up_elem > down_elem);
+    bool swap_backwards = (!is_direct) && (down_elem > up_elem);
+
+    bool to_swap = swap_direct || swap_backwards;
+
+    a[up_i] = to_swap ? down_elem : up_elem;
+    a[down_i] = to_swap ? up_elem : down_elem;
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,6 +1,7 @@
 #define _uint unsigned int
 #define CHECK_BIT(var, pos) ((var) & (1 << (pos)))
 #define MAX_NUM_OFSIZE(n) ((1 << (n + 1)) - 1)
+#define BITWISE_AND(lhs, rhs) ((lhs) & (rhs))
 
 __kernel void prefix_sum_reduce(__global _uint *reduce_lst, const int power) {
     const int gid = get_global_id(0);
@@ -20,6 +21,6 @@ __kernel void prefix_sum_write(__global _uint *reduce_lst, __global _uint *resul
     const int gid_from_one = gid + 1;
     const bool need_this_power = CHECK_BIT(gid_from_one, power);
     const int max_num = MAX_NUM_OFSIZE(power);
-    const int needed_ind = gid_from_one - (max_num & gid_from_one);
+    const int needed_ind = gid_from_one - BITWISE_AND(max_num, gid_from_one);
     result[gid] += need_this_power ? reduce_lst[needed_ind] : 0;
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -7,11 +7,14 @@ __kernel void prefix_sum_reduce(__global _uint *reduce_lst, const int power) {
     const int gid = get_global_id(0);
     const int n = get_global_size(0);
 
+    if (power == 0) return;
+
     const int chunk_size = 1 << power;
-    const int power_zero = power == 0;
-    const int rhs = power_zero ? gid : gid + (1 << (power - 1));
+    const int lhs = gid * chunk_size;
+    const int rhs = lhs + (1 << (power - 1));
+    
     const bool addition = rhs < n && gid % chunk_size == 0;
-    reduce_lst[gid] = power_zero ? reduce_lst[gid] : (addition ? reduce_lst[gid] + reduce_lst[rhs] : reduce_lst[gid]);
+    reduce_lst[lhs] = reduce_lst[lhs] + reduce_lst[rhs];
 }
 
 __kernel void prefix_sum_write(__global _uint *reduce_lst, __global _uint *result, const int power) {

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,25 @@
-// TODO
+#define _uint unsigned int
+#define CHECK_BIT(var, pos) ((var) & (1 << (pos)))
+#define MAX_NUM_OFSIZE(n) ((1 << (n + 1)) - 1)
+
+__kernel void prefix_sum_reduce(__global _uint *reduce_lst, const int power) {
+    const int gid = get_global_id(0);
+    const int n = get_global_size(0);
+
+    const int chunk_size = 1 << power;
+    const int power_zero = power == 0;
+    const int rhs = power_zero ? gid : gid + (1 << (power - 1));
+    const bool addition = rhs < n && gid % chunk_size == 0;
+    reduce_lst[gid] = power_zero ? reduce_lst[gid] : (addition ? reduce_lst[gid] + reduce_lst[rhs] : 0);
+}
+
+__kernel void prefix_sum_write(__global _uint *reduce_lst, __global _uint *result, const int power) {
+    const int gid = get_global_id(0);
+    const int n = get_global_size(0);
+
+    const int gid_from_one = gid + 1;
+    const bool need_this_power = CHECK_BIT(gid_from_one, power);
+    const int max_num = MAX_NUM_OFSIZE(power);
+    const int needed_ind = gid_from_one - (max_num & gid_from_one);
+    result[gid] += need_this_power ? reduce_lst[needed_ind] : 0;
+}

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -10,7 +10,7 @@ __kernel void prefix_sum_reduce(__global _uint *reduce_lst, const int power) {
     const int power_zero = power == 0;
     const int rhs = power_zero ? gid : gid + (1 << (power - 1));
     const bool addition = rhs < n && gid % chunk_size == 0;
-    reduce_lst[gid] = power_zero ? reduce_lst[gid] : (addition ? reduce_lst[gid] + reduce_lst[rhs] : 0);
+    reduce_lst[gid] = power_zero ? reduce_lst[gid] : (addition ? reduce_lst[gid] + reduce_lst[rhs] : reduce_lst[gid]);
 }
 
 __kernel void prefix_sum_write(__global _uint *reduce_lst, __global _uint *result, const int power) {

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -31,7 +31,8 @@ int main(int argc, char **argv) {
     context.activate();
 
     int benchmarkingIters = 10;
-    unsigned int n = 32 * 1024 * 1024;
+    int log2_size_ceil = 25;
+    unsigned int n = (1 << log2_size_ceil);
     std::vector<float> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -65,7 +66,6 @@ int main(int argc, char **argv) {
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
             // TODO
-            int log2_size_ceil = 25;
             int work_size = n >> 1;
             for (int p = 1; p <= log2_size_ceil; ++p)
             {

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+    
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -65,6 +65,18 @@ int main(int argc, char **argv) {
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
             // TODO
+            int log2_size_ceil = 25;
+            int work_size = n >> 1;
+            for (int p = 1; p <= log2_size_ceil; ++p)
+            {
+                int big_window_size = (1 << p);
+                for (int cur_p = p; cur_p > 0; --cur_p) {
+                    const unsigned int workGroupSize = 128;
+                    int small_window_size = (1 << cur_p);
+                    bitonic.exec(gpu::WorkSize(work_size < workGroupSize ? work_size : workGroupSize, work_size), as_gpu, big_window_size, small_window_size);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +88,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -106,9 +106,9 @@ int main(int argc, char **argv) {
                 for (int p = 0; p <= n_pow; ++p) {
                     int work_size_reduce = n / (1 << iter);
                     const unsigned int workGroupSize = 128;
-                    prefix_sum_reduce.exec(gpu::WorkSize(work_size_reduce < workGroupSize ? work_size : workGroupSize, work_size),
+                    prefix_sum_reduce.exec(gpu::WorkSize(work_size_reduce < workGroupSize ? work_size_reduce : workGroupSize, work_size_reduce),
                                     as_gpu, p);
-					prefix_sum_write.exec(gpu::WorkSize(work_size_write < workGroupSize ? work_size : workGroupSize, work_size),
+					prefix_sum_write.exec(gpu::WorkSize(work_size_write < workGroupSize ? work_size_write : workGroupSize, work_size_write),
                                     as_gpu, result_gpu, p);
                 }
                 t.nextLap();

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,125 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    int benchmarkingIters = 10;
+    int log2_size_ceil = 24;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+    for (unsigned int n_pow = 4; n_pow <= log2_size_ceil; n_pow += 4) {
+        unsigned int n = 1 << n_pow;
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
+
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        std::vector<unsigned int> result(n, 0);
+
+        gpu::gpu_mem_32u as_gpu;
+        as_gpu.resizeN(n);
+        gpu::gpu_mem_32u result_gpu;
+        result_gpu.resizeN(n);
+
+        {
+            ocl::Kernel prefix_sum_reduce(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_reduce");
+            prefix_sum_reduce.compile();
+            ocl::Kernel prefix_sum_write(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_write");
+            prefix_sum_write.compile();
+
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                result_gpu.writeN(result.data(), n);
+
+                t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+
+                int work_size = n;
+                for (int p = 0; p <= n_pow; ++p) {
+                    const unsigned int workGroupSize = 128;
+                    prefix_sum_reduce.exec(gpu::WorkSize(work_size < workGroupSize ? work_size : workGroupSize, work_size),
+                                    as_gpu, p);
+					prefix_sum_write.exec(gpu::WorkSize(work_size < workGroupSize ? work_size : workGroupSize, work_size),
+                                    as_gpu, result_gpu, p);
+                }
+                t.nextLap();
+            }
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+
+            result_gpu.readN(result.data(), n);
+
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(reference_result[i], result[i], "GPU result should be consistent!");
+            }
+        }
+    }
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -102,13 +102,13 @@ int main(int argc, char **argv) {
 
                 t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-                int work_size_write = n;
+                int workSizeWrite = n;
                 for (int p = 0; p <= n_pow; ++p) {
-                    int work_size_reduce = n / (1 << iter);
+                    const unsigned int workSizeReduce = n >> p;
                     const unsigned int workGroupSize = 128;
-                    prefix_sum_reduce.exec(gpu::WorkSize(work_size_reduce < workGroupSize ? work_size_reduce : workGroupSize, work_size_reduce),
+                    prefix_sum_reduce.exec(gpu::WorkSize(workSizeReduce < workGroupSize ? workSizeReduce : workGroupSize, workSizeReduce),
                                     as_gpu, p);
-					prefix_sum_write.exec(gpu::WorkSize(work_size_write < workGroupSize ? work_size_write : workGroupSize, work_size_write),
+					prefix_sum_write.exec(gpu::WorkSize(workSizeWrite < workGroupSize ? workSizeWrite : workGroupSize, workSizeWrite),
                                     as_gpu, result_gpu, p);
                 }
                 t.nextLap();

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -102,12 +102,13 @@ int main(int argc, char **argv) {
 
                 t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-                int work_size = n;
+                int work_size_write = n;
                 for (int p = 0; p <= n_pow; ++p) {
+                    int work_size_reduce = n / (1 << iter);
                     const unsigned int workGroupSize = 128;
-                    prefix_sum_reduce.exec(gpu::WorkSize(work_size < workGroupSize ? work_size : workGroupSize, work_size),
+                    prefix_sum_reduce.exec(gpu::WorkSize(work_size_reduce < workGroupSize ? work_size : workGroupSize, work_size),
                                     as_gpu, p);
-					prefix_sum_write.exec(gpu::WorkSize(work_size < workGroupSize ? work_size : workGroupSize, work_size),
+					prefix_sum_write.exec(gpu::WorkSize(work_size_write < workGroupSize ? work_size : workGroupSize, work_size),
                                     as_gpu, result_gpu, p);
                 }
                 t.nextLap();


### PR DESCRIPTION
## Bitonic sort

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./bitonic 
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Data generated for n=33554432!
CPU: 17.3163+-0.0397365 s
CPU: 1.90572 millions/s
GPU: 18.4035+-0.42307 s
GPU: 1.79313 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./bitonic
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.11233+-0.0240863 s
CPU: 8.02464 millions/s
GPU: 13.5345+-0.184271 s
GPU: 2.43821 millions/s
</pre>

</p></details>

## Prefix sum

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./prefix_sum 
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
Using device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6857 Mb
______________________________________________
n=16 values in range: [0; 1023]
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 24 millions/s
GPU: 0.000169667+-4.49691e-06 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 4e-06+-0 s
CPU: 64 millions/s
GPU: 0.000341833+-7.10438e-06 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 5.7e-05+-9.09495e-13 s
CPU: 71.8596 millions/s
GPU: 0.000836333+-1.60693e-05 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000914667+-6.42045e-06 s
CPU: 71.6501 millions/s
GPU: 0.00399383+-2.50826e-05 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0198387+-0.000224115 s
CPU: 52.8552 millions/s
GPU: 0.040129+-0.00163453 s
GPU: 24.9196 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.251343+-0.00238633 s
CPU: 66.7502 millions/s
GPU: 0.731573+-0.0208124 s
GPU: 21.8707 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8171M CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=16 values in range: [0; 1023]
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.0001025+-1.02754e-05 s
GPU: 0 millions/s
______________________________________________
n=256 values in range: [0; 1023]
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 384 millions/s
GPU: 0.000235667+-1.92585e-05 s
GPU: 0 millions/s
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 9.5e-06+-5e-07 s
CPU: 431.158 millions/s
GPU: 0.000459833+-1.13198e-05 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000137833+-1.34371e-06 s
CPU: 475.473 millions/s
GPU: 0.00289767+-0.00043587 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00239417+-3.36522e-05 s
CPU: 437.971 millions/s
GPU: 0.041114+-0.00277165 s
GPU: 24.3226 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.035174+-0.00054212 s
CPU: 476.978 millions/s
GPU: 0.727421+-0.0052915 s
GPU: 21.9955 millions/s
</pre>

</p></details>