### PR TITLE
Task06 Иван Кузнецов SPbU

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,19 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+__kernel void bitonic(__global float *as, const uint superBlockSize, const uint smallBlockSize, const uint n) {
+    const uint gid = get_global_id(0);
+    if (gid >= n) {
+        return;
+    }
+
+    uint start = (gid / smallBlockSize) * (smallBlockSize * 2);
+    uint offset = gid % smallBlockSize;
+
+    bool isAscending = (gid / superBlockSize) % 2 == 0;
+    uint i = start + offset + (isAscending ? smallBlockSize : 0);
+    uint j = start + offset + (isAscending ? 0 : smallBlockSize);
+
+    if (i < n && j < n && as[i] < as[j]) {
+        float temp = as[i];
+        as[i] = as[j];
+        as[j] = temp;
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,13 @@
-// TODO
+__kernel void prefix_sum(__global uint *as, __global uint *result, const uint blockSize, const uint n) {
+    const uint gid = get_global_id(0);
+    if (gid >= n) {
+        return;
+    }
+
+    const uint sumWithIdx = gid - blockSize;
+    const bool flag = (sumWithIdx >= 0) && (sumWithIdx < n);
+    // Хотел написать: (но не получалось скастить bool -> int)
+    // sumWith = flag * as[sumWithIdx]
+    const uint sumWith = flag ? as[sumWithIdx] : 0;
+    result[gid] = as[gid] + sumWith;
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -32,6 +32,7 @@ int main(int argc, char **argv) {
 
     int benchmarkingIters = 10;
     unsigned int n = 32 * 1024 * 1024;
+    // unsigned int n = 16;
     std::vector<float> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -50,7 +51,6 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -64,7 +64,13 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (uint superBlockSize = 1; superBlockSize < n; superBlockSize *= 2) {
+                for (uint smallBlockSize = superBlockSize; smallBlockSize > 0; smallBlockSize /= 2) {
+                    bitonic.exec(gpu::WorkSize(128, n / 2), as_gpu, superBlockSize, smallBlockSize, n);
+                }
+            }
+
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -73,9 +79,12 @@ int main(int argc, char **argv) {
     }
 
     // Проверяем корректность результатов
+    // for (int i = 0; i < 16; ++i) {
+    //     std::cout << as[i] << std::endl;
+    // }
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }


### PR DESCRIPTION
<h1>Bitonic sort</h1>
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz. Intel(R) Corporation. Total memory: 23703 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Data generated for n=33554432!
CPU: 9.98486+-0.207072 s
CPU: 3.305 millions/s
GPU: 0.23199+-0.000192169 s
GPU: 142.247 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.45273+-0.00401459 s
CPU: 7.41118 millions/s
GPU: 13.2555+-0.00535096 s
GPU: 2.48953 millions/s
</pre>
</p></details>

<h1>Prefix sum</h1>
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz. Intel(R) Corporation. Total memory: 23703 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.1e-05+-0 s
CPU: 195.048 millions/s
GPU: 0.000124+-1.95959e-05 s
GPU: 33.0323 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 8.33333e-05+-4.71405e-07 s
CPU: 196.608 millions/s
GPU: 0.000157+-2.37697e-05 s
GPU: 104.357 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000347+-1.38684e-05 s
CPU: 188.865 millions/s
GPU: 0.000225667+-3.59985e-05 s
GPU: 290.411 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00149433+-7.2965e-05 s
CPU: 175.425 millions/s
GPU: 0.000263833+-1.43459e-05 s
GPU: 993.597 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.0057775+-0.000184605 s
CPU: 181.493 millions/s
GPU: 0.000848667+-4.74787e-05 s
GPU: 1235.56 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0229632+-0.000226778 s
CPU: 182.654 millions/s
GPU: 0.00285967+-1.7792e-05 s
GPU: 1466.71 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0917163+-0.00101294 s
CPU: 182.925 millions/s
GPU: 0.011903+-2.29637e-05 s
GPU: 1409.49 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 1.11667e-05+-1.06719e-06 s
CPU: 366.806 millions/s
GPU: 0.0002435+-0.000235906 s
GPU: 16.8214 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 4.36667e-05+-9.42809e-07 s
CPU: 375.206 millions/s
GPU: 0.000402+-4.00832e-05 s
GPU: 40.7562 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000202+-4.39697e-06 s
CPU: 324.436 millions/s
GPU: 0.000506667+-2.88656e-05 s
GPU: 129.347 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000758333+-1.60797e-05 s
CPU: 345.684 millions/s
GPU: 0.00116217+-1.3082e-05 s
GPU: 225.565 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.003059+-2.77789e-05 s
CPU: 342.784 millions/s
GPU: 0.0048505+-0.000176554 s
GPU: 216.179 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.0119217+-7.31224e-05 s
CPU: 351.822 millions/s
GPU: 0.0210147+-0.00014682 s
GPU: 199.589 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0459473+-4.09498e-05 s
CPU: 365.14 millions/s
GPU: 0.144778+-0.000379033 s
GPU: 115.882 millions/s
</pre>
</p></details>
