### PR TITLE
Task07 Николай Стойко ITMO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(libs)
 
 project(task7)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 23)
 
 # OpenMP позволит распараллеливать циклы на все ядра процессора простыми директивами
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 
 add_subdirectory(libs)
 
-project(task5)
+project(task7)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -20,6 +20,14 @@ endif()
 # Она считывает все байты из файла src/cl/aplusb.cl (т.е. весь исходный код кернела) и преобразует их в массив байтов в файле src/cl/aplusb_cl.h aplusb_kernel
 # Обратите внимание что это происходит на этапе компиляции, кроме того необходимо чтобы файл src/cl/aplusb_cl.h был перечислен среди исходников для компиляции при вызове add_executable
 
+convertIntoHeader(src/cl/prefix_sum.cl src/cl/prefix_sum_cl.h prefix_sum_kernel)
+convertIntoHeader(src/cl/matrix_transpose.cl src/cl/matrix_transpose_cl.h matrix_transpose_kernel)
+convertIntoHeader(src/cl/merge_sort.cl src/cl/merge_sort_cl.h merge_sort_kernel)
 convertIntoHeader(src/cl/radix.cl src/cl/radix_cl.h radix_kernel)
-add_executable(radix src/main_radix.cpp src/cl/radix_cl.h)
+add_executable(radix
+        src/prefix_sum.hpp src/cl/prefix_sum_cl.h
+        src/matrix_transpose.hpp src/cl/matrix_transpose_cl.h
+        src/merge_sort.hpp src/cl/merge_sort_cl.h
+        src/main_radix.cpp src/cl/radix_cl.h
+        src/prefix_sum.hpp)
 target_link_libraries(radix libclew libgpu libutils)

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,0 +1,21 @@
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose(__global const float *a, __global float *at, unsigned int m, unsigned int k)
+{
+    __local float tile[TILE_SIZE][TILE_SIZE];
+
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    tile[local_j][(local_i + local_j) % TILE_SIZE] = a[j * k + i]; // To solve bank conflict
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    at[i * m + j] = tile[local_j][(local_i + local_j) % TILE_SIZE];
+}

--- a/src/cl/merge_sort.cl
+++ b/src/cl/merge_sort.cl
@@ -1,0 +1,106 @@
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#include <float.h>
+#endif
+
+#define get_masked(x, shift, mask) (((x) >> (shift)) & (mask))
+
+__kernel void merge_sort(__global const unsigned int *as,
+                        __global unsigned int *bs,
+                        const unsigned int n,
+                        const unsigned int width,
+                        const unsigned int shift,
+                        const unsigned int mask)
+{
+    int globalId = get_global_id(0);
+    int groupId = globalId / width;
+
+    int leftA = groupId * width;
+    int rightA = leftA + width;
+    int localId = globalId - leftA;
+
+    bool isRight = groupId % 2;
+
+    int otherL = isRight ? leftA - width : rightA;
+    int otherR = isRight ? leftA : rightA + width;
+    int start = isRight ? leftA - width : leftA;
+
+    int l = otherL - 1, r = otherR, m = 0;
+
+    const unsigned int uint_max = (1L << sizeof(unsigned int) * 8) - 1;
+    const unsigned int uint_min = 0;
+    bool isLeft = !isRight;
+    unsigned int v = globalId < n ? as[globalId] : uint_max;
+    unsigned int masked_v = get_masked(v, shift, mask);
+    unsigned int base = 0;
+
+    while (r - l > 1) {
+        m = (l + r) / 2;
+        base = get_masked(as[m], shift, mask);
+
+        if (m >= otherR){
+            base = uint_max;
+        } else if (m < otherL) {
+            base = uint_min;
+        }
+
+        if (masked_v < base || isLeft && masked_v <= base)
+            r = m;
+        else
+            l = m;
+    }
+
+    unsigned int index = start + localId + r - otherL;
+
+    if (globalId < n && index < n){
+        bs[index] = v;
+    }
+}
+
+__kernel void merge_sort_float(__global const float *as,
+                        __global float *bs,
+                        const unsigned int n,
+                        const unsigned int width) {
+    int globalId = get_global_id(0);
+    int groupId = globalId / width;
+
+    int leftA = groupId * width;
+    int rightA = leftA + width;
+    int localId = globalId - leftA;
+
+    bool isRight = groupId % 2;
+
+    int otherL = isRight ? leftA - width : rightA;
+    int otherR = isRight ? leftA : rightA + width;
+    int start = isRight ? leftA - width : leftA;
+
+    int l = otherL - 1, r = otherR, m = 0;
+
+    bool isLeft = !isRight;
+    float v = globalId < n ? as[globalId] : FLT_MAX;
+    float base = FLT_MIN;
+
+    while (r - l > 1) {
+        m = (l + r) / 2;
+        base = as[m];
+
+        if (m >= otherR){
+            base = FLT_MAX;
+        } else if (m < otherL) {
+            base = FLT_MIN;
+        }
+
+        if (v < base || isLeft && v <= base)
+            r = m;
+        else
+            l = m;
+    }
+
+    unsigned int index = start + localId + r - otherL;
+
+    if (globalId < n && index < n){
+        bs[index] = v;
+    }
+}
+
+#undef get_masked

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,0 +1,46 @@
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+__kernel void prefix_sum_scan(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+    int lid = gid % w_half;
+    int index = gid / w_half;
+
+    int to = w_half + index * w;
+    int from = to - 1;
+    to += lid;
+    if (to < n) {
+        as[to] += as[from];
+    }
+}
+
+__kernel void prefix_sum_map(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+
+    int from = w_half - 1 + w * gid;
+    int to = from + w_half;
+    if (to < n) {
+        as[to] += as[from];
+    }
+}
+
+__kernel void prefix_sum_reduce(__global unsigned int *as, int n, int w) {
+    int w_half = w >> 1;
+    int gid = get_global_id(0);
+
+    int from = w_half - 1 + w * gid;
+    int to = from + w_half;
+    unsigned int to_v = 0;
+    if (to < n) {
+        to_v = as[to];
+    } else {
+        to = from + 1;
+    }
+    if (from < n) {
+        as[to] += as[from];
+        as[from] = to_v;
+    }
+}

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,55 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifdef __CLION_IDE__
+
+#include <libgpu/opencl/cl/clion_defines.cl>
+
+#endif
+
+#define WIDTH (4)
+#define WIDTH_POWER (1 << WIDTH)
+#define get_masked(x, shift) (((x) >> ((shift) * WIDTH)) & (WIDTH_POWER - 1))
+
+__kernel void count(__global const unsigned int *as, __global int *cs, unsigned int shift) {
+    unsigned int gid = get_global_id(0);
+    unsigned int lid = get_local_id(0);
+
+    __local int counters[WIDTH_POWER];
+
+    if (lid < WIDTH_POWER) {
+        counters[lid] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    atomic_add(&counters[get_masked(as[gid], shift)], 1);
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int base = get_group_id(0) * WIDTH_POWER;
+    if (lid < WIDTH_POWER) {
+        cs[base + lid] = counters[lid];
+    }
 }
+
+__kernel void radix(__global const unsigned int *as, unsigned int shift,
+                    __global const unsigned int *prefix_c,
+                    __global const unsigned int *prefix_p_t,
+                    __global unsigned int *res) {
+    unsigned int lid = get_local_id(0);
+    unsigned int value = as[get_global_id(0)];
+    unsigned int masked = get_masked(value, shift);
+    unsigned int group_id = get_group_id(0);
+    unsigned int num_groups = get_num_groups(0);
+
+    int p_index = prefix_p_t[masked * num_groups + group_id];
+    int delta_c_index = prefix_c[group_id * WIDTH_POWER + masked] - prefix_c[group_id * WIDTH_POWER];
+
+    int res_idx = p_index + lid - delta_c_index;
+//    printf("global_id: %d, masked: %d, group_id: %d, num_groups: %d\n"
+//           "value: %d (p_index(%d) + lid(%d) - delta_c_index(%d) => res_idx: %d)\n",
+//           get_global_id(0), masked, group_id, num_groups,
+//           value, p_index, lid, delta_c_index, res_idx);
+
+    res[res_idx] = value;
+}
+
+#undef get_masked

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -1,3 +1,7 @@
+#include "matrix_transpose.hpp"
+#include "merge_sort.hpp"
+#include "prefix_sum.hpp"
+
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
 #include <libutils/fast_random.h>
@@ -22,6 +26,23 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+
+void print_data(const std::vector<uint32_t>& data, size_t n, const std::string& header, size_t new_line = 1) {
+    std::cout << std::endl << header;
+    for (size_t i = 0; i < n; ++i) {
+        if (i % new_line == 0) {
+            std::cout << std::endl;
+        }
+        std::cout << std::hex << data[i] << '\t';
+    }
+    std::cout << std::endl;
+}
+
+void print_gpu(const gpu::gpu_mem_32u &as_gpu, size_t n, const std::string& header, size_t new_line = 1) {
+    std::vector<uint32_t> data(n, 0);
+    as_gpu.readN(data.data(), n);
+    print_data(data, n, header, new_line);
+}
 
 int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
@@ -48,34 +69,78 @@ int main(int argc, char **argv) {
             t.nextLap();
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU: " << (n / 1e6) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
-    gpu::gpu_mem_32u as_gpu;
+
+    gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu, cs_gpu_t, res;
     as_gpu.resizeN(n);
+    bs_gpu.resizeN(n);
+    res.resizeN(n);
+
+    auto merge_sort = MergeSort();
+    auto transpose = Transpose();
+    auto prefix = PrefixSum();
 
     {
+        ocl::Kernel count(radix_kernel, radix_kernel_length, "count");
+        count.compile();
         ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
         radix.compile();
+
+        constexpr auto width = 4;
+        constexpr auto border = 1 << width;
+
+        auto workGroupSize = 128;
+        auto workSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+//        print_data(cpu_sorted, n, "cpu sorted", workGroupSize);
+
+        size_t counter_rows = workSize / workGroupSize;
+        size_t counter_size = border * counter_rows;
+        cs_gpu.resizeN(counter_size + 1);
+        cs_gpu_t.resizeN(counter_size + 1);
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
-            t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+//            print_gpu(as_gpu, n, "init", workGroupSize);
+            t.restart(); // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (int i = 0; i < (sizeof(unsigned int) * 8) / width; ++i) {
+                merge_sort.merge_sort(n, as_gpu, bs_gpu, width * i, border - 1, workGroupSize);
+//                print_gpu(as_gpu, n, "sorted", workGroupSize);
+                count.exec(gpu::WorkSize(workGroupSize, workSize),
+                           as_gpu, cs_gpu, i);
+//                print_gpu(cs_gpu, counter_size, "counted", border);
+
+                transpose.transpose(border, counter_rows, cs_gpu, cs_gpu_t);
+//                print_gpu(cs_gpu_t, counter_size, "transposed", counter_rows);
+
+                prefix.prefix_sum(counter_size, cs_gpu);
+//                print_gpu(cs_gpu, counter_size, "prefix", border);
+
+                prefix.prefix_sum(counter_size, cs_gpu_t);
+//                print_gpu(cs_gpu_t, counter_size, "prefix t", counter_rows);
+
+                radix.exec(gpu::WorkSize(workGroupSize, workSize),
+                           as_gpu, i, cs_gpu, cs_gpu_t, res);
+//                print_gpu(res, n, "res", workGroupSize);
+
+                as_gpu.swap(res);
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << (n / 1e6) / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
     }
 
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
-        EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
+        EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results! At: " + std::to_string(i));
     }
-*/
+
     return 0;
 }

--- a/src/matrix_transpose.hpp
+++ b/src/matrix_transpose.hpp
@@ -1,0 +1,29 @@
+#pragma once
+//
+// Created by Nikolai on 26.10.2023.
+//
+#include "cl/matrix_transpose_cl.h"
+
+#include <libutils/misc.h>
+
+class Transpose {
+private:
+    ocl::Kernel matrix_transpose_kernel_;
+    const unsigned int work_group_size = 16;
+
+public:
+    Transpose():
+        matrix_transpose_kernel_(matrix_transpose_kernel, matrix_transpose_kernel_length, "matrix_transpose")
+    {
+        matrix_transpose_kernel_.compile();
+    }
+
+    template<typename T>
+    void transpose(size_t K, size_t M, const T& as_gpu, T& bs_gpu)
+    {
+        unsigned int work_group_size_K = std::min(K, work_group_size);
+        unsigned int work_group_size_M = std::min(M, work_group_size);
+        matrix_transpose_kernel_.exec(gpu::WorkSize(work_group_size_K, work_group_size_M, K, M),
+                                     as_gpu, bs_gpu, M, K);
+    }
+};

--- a/src/matrix_transpose.hpp
+++ b/src/matrix_transpose.hpp
@@ -6,6 +6,8 @@
 
 #include <libutils/misc.h>
 
+#include <algorithm>
+
 class Transpose {
 private:
     ocl::Kernel matrix_transpose_kernel_;
@@ -19,7 +21,7 @@ public:
     }
 
     template<typename T>
-    void transpose(size_t K, size_t M, const T& as_gpu, T& bs_gpu)
+    void transpose(unsigned int K, unsigned int M, const T& as_gpu, T& bs_gpu)
     {
         unsigned int work_group_size_K = std::min(K, work_group_size);
         unsigned int work_group_size_M = std::min(M, work_group_size);

--- a/src/merge_sort.hpp
+++ b/src/merge_sort.hpp
@@ -6,6 +6,8 @@
 
 #include <libutils/misc.h>
 
+#include <algorithm>
+
 class MergeSort {
 private:
     ocl::Kernel merge_sort_kernel_;
@@ -18,13 +20,15 @@ public:
     }
 
     template<typename T>
-    void merge_sort(size_t n, T& as_gpu, T& bs_gpu, unsigned int shift, unsigned int mask, size_t border = 0)
+    void merge_sort(unsigned int n, T& as_gpu, T& bs_gpu, unsigned int shift, unsigned int mask, size_t border = 0)
     {
         if (border == 0) {
             border = n;
         }
-        unsigned int workGroupSize = std::min(n, 128U);
-        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        unsigned int workGroupSize = 128;
+        workGroupSize = std::min(n, workGroupSize);
+        const unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
         for (unsigned int w = 1; w < border; w <<= 1) {
             merge_sort_kernel_.exec(gpu::WorkSize(workGroupSize, global_work_size),

--- a/src/merge_sort.hpp
+++ b/src/merge_sort.hpp
@@ -1,0 +1,35 @@
+#pragma once
+//
+// Created by Nikolai on 26.10.2023.
+//
+#include "cl/merge_sort_cl.h"
+
+#include <libutils/misc.h>
+
+class MergeSort {
+private:
+    ocl::Kernel merge_sort_kernel_;
+
+public:
+    MergeSort() :
+        merge_sort_kernel_(merge_sort_kernel, merge_sort_kernel_length, "merge_sort")
+    {
+        merge_sort_kernel_.compile();
+    }
+
+    template<typename T>
+    void merge_sort(size_t n, T& as_gpu, T& bs_gpu, unsigned int shift, unsigned int mask, size_t border = 0)
+    {
+        if (border == 0) {
+            border = n;
+        }
+        unsigned int workGroupSize = std::min(n, 128U);
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        for (unsigned int w = 1; w < border; w <<= 1) {
+            merge_sort_kernel_.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                       as_gpu, bs_gpu, n, w, shift, mask);
+            as_gpu.swap(bs_gpu);
+        }
+    }
+};

--- a/src/prefix_sum.hpp
+++ b/src/prefix_sum.hpp
@@ -1,0 +1,64 @@
+#pragma once
+//
+// Created by Nikolai on 26.10.2023.
+//
+#include "cl/prefix_sum_cl.h"
+
+#include <libutils/misc.h>
+
+class PrefixSum {
+private:
+    ocl::Kernel prefix_sum_scan_;
+    ocl::Kernel prefix_sum_map_;
+    ocl::Kernel prefix_sum_reduce_;
+
+public:
+    PrefixSum() :
+        prefix_sum_scan_(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_scan"),
+        prefix_sum_map_(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_map"),
+        prefix_sum_reduce_(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum_reduce")
+    {
+        prefix_sum_scan_.compile();
+        prefix_sum_map_.compile();
+        prefix_sum_reduce_.compile();
+    }
+
+    template<typename T>
+    void prefix_sum_scan(size_t n, T& as_gpu)
+    // as_gpu.resizeN(n);
+    // as_gpu.writeN(as.data(), n);
+    // as_gpu.readN(res.data(), n);
+    {
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n / 2 + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+        for (int width = 2; width < 2 * n; width <<= 1) {
+            prefix_sum_scan_.exec(gpu::WorkSize(workGroupSize, global_work_size),
+                                 as_gpu, n, width);
+        }
+    }
+
+    template<typename T>
+    void prefix_sum(size_t n, T& as_gpu)
+    // as_gpu.resizeN(n + 1);
+    // as_gpu.writeN(as.data(), n + 1); // нужно занулить последний элемент для многократного исполнения ядра
+    // as_gpu.readN(res.data(), n, 1);
+    {
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = 0;
+        int width;
+        for (width = 2; width < 2 * n; width <<= 1) {
+            global_work_size = (n / width + workGroupSize - 1) / workGroupSize * workGroupSize;
+            global_work_size = std::max(global_work_size, 1U);
+            prefix_sum_map_.exec(gpu::WorkSize(std::min(workGroupSize, global_work_size), global_work_size),
+                                as_gpu, n, width);
+        }
+
+        for (; width > 1; width >>= 1) {
+            global_work_size = (n / width + workGroupSize - 1) / workGroupSize * workGroupSize;
+            global_work_size = std::max(global_work_size, 1U);
+            prefix_sum_reduce_.exec(gpu::WorkSize(std::min(workGroupSize, global_work_size), global_work_size),
+                                   as_gpu, n, width);
+        }
+    }
+};

--- a/src/prefix_sum.hpp
+++ b/src/prefix_sum.hpp
@@ -6,6 +6,8 @@
 
 #include <libutils/misc.h>
 
+#include <algorithm>
+
 class PrefixSum {
 private:
     ocl::Kernel prefix_sum_scan_;
@@ -39,7 +41,7 @@ public:
     }
 
     template<typename T>
-    void prefix_sum(size_t n, T& as_gpu)
+    void prefix_sum(unsigned int n, T& as_gpu)
     // as_gpu.resizeN(n + 1);
     // as_gpu.writeN(as.data(), n + 1); // нужно занулить последний элемент для многократного исполнения ядра
     // as_gpu.readN(res.data(), n, 1);


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 12850139499439/3072 Mb
Data generated for n=33554432!
CPU: 2.19083+-0.0163648 s
CPU: 15.3158 millions/s
GPU: 0.567667+-0.00596285 s
GPU: 59.1094 millions/s
</pre>
</p></details>

Алгоритм с линейной асимптотикой, получил 4-х кратный прирост производительности.

> AMD Radeon 680M - встроенная графика для процессоров AMD Ryzen 6000 (Rembrandt). Основана на архитектуре RDNA2 и имеет 12 блоков (768 шейдеров) и способна работать на частоте до 2.4 ГГц (зависит от модели процессора). 

Учитывая накладные расходы на распараллеливание и копирование данных, и то что частота процессора  4,7 ГГц, получились хорошие результаты.

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
Device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 3.62189+-0.000747799 s
CPU: 9.26433 millions/s
GPU: 8.26587+-0.00636718 s
GPU: 4.0594 millions/s
</pre>
</p></details>


### Сравнение
Bitonic sort GPU: 27.5997 millions/s
Radix sort GPU: 59.1094 millions/s
Merge sort GPU: 111.486 millions/s

Удалось обогнать bitonic sort. 
Возможно merge sort не удалось обойти, так как использовал merge sort на этапе сортировки в локальных группах.
