### PR TITLE
Task07 Шакиров Игорь ITMO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,6 @@ endif()
 # Обратите внимание что это происходит на этапе компиляции, кроме того необходимо чтобы файл src/cl/aplusb_cl.h был перечислен среди исходников для компиляции при вызове add_executable
 
 convertIntoHeader(src/cl/radix.cl src/cl/radix_cl.h radix_kernel)
+
 add_executable(radix src/main_radix.cpp src/cl/radix_cl.h)
 target_link_libraries(radix libclew libgpu libutils)

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,125 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifndef TILE_SIZE
+    #error "Tile size must be init"
+#endif
+
+#ifndef NUM_BITS
+    #error "Num bits must be init"
+#endif
+
+#define NUM_VALS (1 << NUM_BITS)
+
+inline uint extract_value(const uint val, const uint iter) {
+    return (val >> (iter * NUM_BITS)) & (NUM_VALS - 1);
+}
+
+__kernel void radix(__global const uint *as, __global const uint *prefix_matrix, __global uint *res, const uint as_size,
+                    const uint num_rows, const uint num_cols, const uint iter) {
+    const size_t g_id = get_global_id(0);
+    if (g_id >= as_size) {
+        return;
+    }
+    
+    const size_t k = extract_value(as[g_id], iter);
+    const size_t group_id = get_group_id(0);
+    const size_t l_id = get_local_id(0);
+    
+    size_t idx = l_id;
+    
+    if (group_id + k > 0) {
+        idx += prefix_matrix[k * num_cols + group_id - 1];
+    }
+    
+    const size_t work_size = get_local_size(0);
+    const size_t start_pos = group_id * work_size;
+
+    for (uint i = 0; i < l_id; ++i) {
+        const uint as_el = extract_value(as[start_pos + i], iter);
+        if (as_el == k)
+            break;
+        --idx;
+    }
+
+    res[idx] = as[g_id];
+}
+
+__kernel void fill_count_matrix(__global const uint *as, __global uint *matrix, const uint size, const uint iter) {
+    const size_t g_id = get_global_id(0);
+    if (g_id >= size) {
+        return;
+    }
+    const size_t group_id = get_group_id(0);
+    const size_t l_id = get_local_id(0);
+    
+    __local uint local_matrix[NUM_VALS];
+    
+    if (l_id < NUM_VALS) {
+        local_matrix[l_id] = 0;
+    }
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    atomic_inc(&local_matrix[extract_value(as[g_id], iter)]);
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (l_id < NUM_VALS) {
+        matrix[group_id * NUM_VALS + l_id] = local_matrix[l_id];
+    }
+}
+
+__kernel void matrix_transpose(__global const uint *matrix, __global uint *res, const uint M, const uint K) {
+    const int g_col = get_global_id(0);
+    const int g_row = get_global_id(1);
+
+    __local uint tile[TILE_SIZE][TILE_SIZE];
+
+    const int l_col = get_local_id(0);
+    const int l_row = get_local_id(1);
+
+    if (g_row < M && g_col < K)
+        tile[l_row][l_col] = matrix[g_row * K + g_col];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const int diff = l_row - l_col;
+    const int res_row = g_col + diff;
+    const int res_col = g_row - diff;
+    if (res_row < K && res_col < M) {
+        res[res_row * M + res_col] = tile[l_col][l_row];
+    }
+}
+
+
+__kernel void sort_workgroup(__global const uint *arr, __global uint *res, const uint n, const uint iter) {
+    const uint g_id = get_global_id(0);
+    if (g_id >= n) {
+        return;
+    }
+    const uint l_id = get_local_id(0);
+    const uint g_size = get_local_size(0);
+    const uint group_id = get_group_id(0);
+
+    const uint src_el = arr[g_id];
+    const uint el = extract_value(arr[g_id], iter);
+
+    const uint start_index = g_size * group_id;
+
+    uint res_id = 0;
+    for (int i = 0; i < g_size; ++i) {
+        if (start_index + i >= n)
+            break;
+        const uint arr_val = extract_value(arr[start_index + i], iter);
+        if (arr_val < el || (arr_val == el && i < l_id))
+            ++res_id;
+    }
+    res[start_index + res_id] = src_el;
+}
+
+// naive impl
+__kernel void prefix_sum(__global const uint *src, __global uint *res, const uint size, const uint d) {
+    const size_t g_id = get_global_id(0);
+    if (g_id >= size)
+        return;
+    const size_t pw = 1 << (d - 1);
+    res[g_id] = src[g_id] + (g_id >= pw ? src[g_id - pw] : 0);
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -6,6 +6,7 @@
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/radix_cl.h"
+#include "libgpu/work_size.h"
 
 #include <iostream>
 #include <stdexcept>
@@ -22,6 +23,8 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+constexpr uint NUM_BITS = 4;
+constexpr uint TILE_SIZE = 16;
 
 int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
@@ -50,22 +53,68 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32u as_gpu;
     as_gpu.resizeN(n);
 
+    std::string defines = "-DTILE_SIZE=" + std::to_string(TILE_SIZE) + " -DNUM_BITS=" + std::to_string(NUM_BITS);
     {
-        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
+        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix", defines);
+        ocl::Kernel sort_workgroup(radix_kernel, radix_kernel_length, "sort_workgroup", defines);
+        ocl::Kernel matrix_transpose(radix_kernel, radix_kernel_length, "matrix_transpose", defines);
+        ocl::Kernel fill_count_matrix(radix_kernel, radix_kernel_length, "fill_count_matrix", defines);
+        ocl::Kernel prefix_sum(radix_kernel, radix_kernel_length, "prefix_sum", defines);
         radix.compile();
+        sort_workgroup.compile();
+        matrix_transpose.compile();
+        prefix_sum.compile();
+        fill_count_matrix.compile();
 
+        unsigned int workGroupSize = 128;
+        unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        const gpu::WorkSize workSize(workGroupSize, global_work_size);
+
+        gpu::gpu_mem_32u bs_gpu;
+        bs_gpu.resizeN(n);
+
+        const uint K = 1 << NUM_BITS;                          // range of values [0..K - 1]
+        const uint M = (n + workGroupSize - 1) / workGroupSize;// number of work groups
+
+        gpu::gpu_mem_32u matrix_gpu;
+        gpu::gpu_mem_32u temp_matrix_gpu;
+        matrix_gpu.resizeN(K * M);
+        temp_matrix_gpu.resizeN(K * M);
+
+        const gpu::WorkSize prefix_workSize(workGroupSize, (K * M + workGroupSize - 1) / workGroupSize * workGroupSize);
+        const gpu::WorkSize matrix_workSize(TILE_SIZE, TILE_SIZE, K, M);
+
+        constexpr uint numIters = sizeof(uint) * 8 / NUM_BITS;
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
-
-            // TODO
+            for (uint i = 0; i < numIters; i++) {
+                // stable sorting to each workgroup
+                sort_workgroup.exec(workSize, as_gpu, bs_gpu, n, i);
+                std::swap(as_gpu, bs_gpu);
+                // filling out the matrix with counting each value in the array within the work group
+                fill_count_matrix.exec(workSize, as_gpu, matrix_gpu, n, i);
+                // transpose matrix
+                matrix_transpose.exec(matrix_workSize, matrix_gpu, temp_matrix_gpu, M, K);
+                std::swap(temp_matrix_gpu, matrix_gpu);
+                // calculating prefix sum in matrix
+                for (uint i = 1, d = 1; i < n; i <<= 1, ++d) {
+                    prefix_sum.exec(prefix_workSize, matrix_gpu, temp_matrix_gpu, K * M, d);
+                    std::swap(matrix_gpu, temp_matrix_gpu);
+                }
+                // sort (reordering)
+                radix.exec(workSize, as_gpu, matrix_gpu, bs_gpu, n, K, M, i);
+                std::swap(as_gpu, bs_gpu);
+            }
+            t.nextLap();
         }
+        t.stop();
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
 
@@ -76,6 +125,5 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
OpenCL devices:
  Device #0: GPU. Intel(R) Graphics [0x46a3]. Total memory: 12561 Mb
  Device #1: GPU. NVIDIA GeForce MX550. Total memory: 1870 Mb
Using device #1: GPU. NVIDIA GeForce MX550. Total memory: 1870 Mb
Data generated for n=33554432!
CPU: 8.73176+-0.0923836 s
CPU: 3.77931 millions/s
GPU: 0.488617+-0.000593132 s
GPU: 67.5375 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
 OpenCL devices:
  Device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Using device #0: CPU. Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 6932 Mb
Data generated for n=33554432!
CPU: 4.095+-0.000881819 s
CPU: 8.05861 millions/s
GPU: 8.9139+-0.00297135 s
GPU: 3.70208 millions/s
</pre>

</p></details>

## Сравнение с другими сортировками

В 2 раза лучше bitonic sort, но в 2 раза хуже merge sort.
При <strong>n = 32 * 1024 * 1024</strong>
bitonic:  0.903 s
radix:     0.489 s
merge:  0.206 s

p.s. протестил также различные количество рассматриваемых бит (NUM_BITS): для 1,2,4,8 соответственно время составило 1.5с, 0.98с, 0.48с, 0.99с. Разница двукратная - значения от 0 до 4 (num_bits=2) слишком мало (для транспонирования неудобно), а от 0 до 255 велико (?). Но я думал, что разница между 4 и 8 не будет столько значительно.