### PR TITLE
Task07 Илья Асадуллин ITMO

### DIFF
--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -8,6 +8,17 @@
 #define MASK_WIDTH 4
 #define CNT (1 << MASK_WIDTH)
 
+__kernel void fill_zeros(__global uint32_t* as,
+                         const uint32_t N)
+{
+    const uint32_t gid = get_global_id(0);
+
+    if (gid >= N)
+        return;
+
+    as[gid] = 0;
+}
+
 __kernel void local_stable_merge_sort(__global const uint32_t* as,
                                 __global uint32_t* bs,
                                 const uint32_t mask,

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,3 +1,167 @@
-__kernel void radix(__global unsigned int *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include "clion_defines.cl"
+#endif
+
+#line 6
+
+#define uint32_t unsigned int
+#define MASK_WIDTH 4
+#define CNT (1 << MASK_WIDTH)
+
+__kernel void local_stable_merge_sort(__global const uint32_t* as,
+                                __global uint32_t* bs,
+                                const uint32_t mask,
+                                const uint32_t N,
+                                const uint32_t M)
+{
+    const uint32_t gid = get_global_id(0);
+    const uint32_t curr = as[gid];
+    const uint32_t curr_masked = curr & mask;
+
+    uint32_t other;
+    uint32_t other_masked;
+
+    const uint32_t group_id = gid / M;
+    const uint32_t left_bound = group_id * M;
+    const uint32_t right_bound = left_bound + M;
+    const uint32_t local_id = gid - left_bound;
+
+    bool is_right = group_id % 2;
+
+    uint32_t L = is_right ? left_bound - M : right_bound;
+    uint32_t R = is_right ? left_bound : L + M;
+    uint32_t med = 0;
+
+    while (L < R) {
+        med = (L + R) / 2;
+        other = as[med];
+        other_masked = other & mask;
+        if ((!is_right && curr_masked <= other_masked) || curr_masked < other_masked) {
+            R = med;
+        } else {
+            L = med + 1;
+        }
+    }
+
+    const uint32_t index = local_id + R - !is_right * M;
+    if (index < N) {
+        bs[index] = curr;
+    }
+}
+
+__kernel void local_counts(__global const uint32_t* as,
+                           const uint32_t N,
+                           __global uint32_t* matrix_local_cnt,
+                           const uint32_t mask,
+                           const uint32_t mask_offset)
+{
+    const uint32_t gid = get_global_id(0);
+    const uint32_t lid = get_local_id(0);
+
+    const uint32_t group_id = get_group_id(0);
+
+    const uint32_t curr_masked_shifted = (as[gid] & mask) >> mask_offset;
+
+    __local uint32_t local_mem[CNT];
+    if (lid < CNT) {
+        local_mem[lid] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    atomic_add(&local_mem[curr_masked_shifted], 1);
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid < CNT) {
+        matrix_local_cnt[group_id * CNT + lid] = local_mem[lid];
+    }
+}
+
+__kernel void prefix_sum(__global const uint32_t* as,
+                         __global uint32_t* bs,
+                         const uint32_t N,
+                         const uint32_t offset)
+{
+    const uint32_t gid = get_global_id(0);
+    if (gid >= N)
+        return;
+
+    bs[gid] = gid >= offset ? as[gid] + as[gid - offset] : as[gid];
+}
+
+__kernel void shift_right(__global const uint32_t* as,
+                          __global uint32_t* bs,
+                          const uint32_t N)
+{
+    const uint32_t gid = get_global_id(0);
+
+    if (gid + 1 >= N)
+        return;
+
+    bs[gid + 1] = as[gid];
+
+    if (gid == 0)
+        bs[gid] = 0;
+}
+
+#define TILE_SIZE 16
+
+__kernel void matrix_transpose(__global const uint32_t* from,
+                               __global uint32_t* to,
+                               const uint32_t M,
+                               const uint32_t K)
+{
+    const unsigned int i = get_global_id(0);
+    const unsigned int j = get_global_id(1);
+
+    const unsigned int local_i = get_local_id(0);
+    const unsigned int local_j = get_local_id(1);
+
+    const unsigned int gr_i = get_group_id(0);
+    const unsigned int gr_j = get_group_id(1);
+
+    const unsigned int ls_i = get_local_size(0);
+    const unsigned int ls_j = get_local_size(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE * 2];
+
+    if (i < K && j < M) {
+        tile[local_i][local_i + local_j] = from[j * K + i];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const uint32_t ni = ls_j * gr_j + local_i;
+    const uint32_t nj = ls_i * gr_i + local_j;
+
+    if (ni < M && nj < K) {
+        to[M * nj + ni] = tile[local_j][local_i + local_j];
+    }
+}
+
+__kernel void radix(__global const uint32_t* as,
+                    __global uint32_t* bs,
+                    const uint32_t N,
+                    __global const uint32_t* local_prefix_sums,
+                    __global const uint32_t* global_prefix_sums,
+                    const uint32_t wgCnt,
+                    const uint32_t mask,
+                    const uint32_t mask_offset)
+{
+    const uint32_t gid = get_global_id(0);
+    const uint32_t lid = get_local_id(0);
+
+    const uint32_t group_id = get_group_id(0);
+
+    if (gid >= N)
+        return;
+
+    const uint32_t curr = as[gid];
+    const uint32_t curr_masked_offset = (curr & mask) >> mask_offset;
+
+    const uint32_t curr_offset = local_prefix_sums[group_id * CNT + curr_masked_offset] - local_prefix_sums[group_id * CNT];
+    const uint32_t index = global_prefix_sums[wgCnt * curr_masked_offset + group_id] + lid - curr_offset;
+
+    bs[index] = as[gid];
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <vector>
+#include <bitset>
 
 
 template<typename T>
@@ -30,8 +31,8 @@ int main(int argc, char **argv) {
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
-    unsigned int n = 32 * 1024 * 1024;
+    const int benchmarkingIters = 10;
+    const uint32_t n = 32 * 1024 * 1024;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -50,21 +51,120 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32u as_gpu;
     as_gpu.resizeN(n);
 
     {
+        ocl::Kernel local_stable_merge_sort(radix_kernel, radix_kernel_length, "local_stable_merge_sort");
+        local_stable_merge_sort.compile();
+
+        ocl::Kernel local_counts(radix_kernel, radix_kernel_length, "local_counts");
+        local_counts.compile();
+
+        ocl::Kernel prefix_sum(radix_kernel, radix_kernel_length, "prefix_sum");
+        prefix_sum.compile();
+
+        ocl::Kernel shift_right(radix_kernel, radix_kernel_length, "shift_right");
+        shift_right.compile();
+
+        ocl::Kernel matrix_transpose(radix_kernel, radix_kernel_length, "matrix_transpose");
+        matrix_transpose.compile();
+
         ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
         radix.compile();
+
+        const int K_bits = 4;
+        const int cnt = (1 << K_bits);
+
+        gpu::gpu_mem_32u bs_gpu;
+        bs_gpu.resizeN(n);
+
+        const uint32_t workGroupSize = 128;
+        const uint32_t global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+        gpu::WorkSize ws(workGroupSize, global_work_size);
+
+        const uint32_t workGroupCnt = global_work_size / workGroupSize;
+
+        const uint32_t matrix_size = workGroupCnt * cnt;
+
+        const uint32_t matrix_wh_min = workGroupCnt < cnt ? workGroupCnt : cnt;
+
+        gpu::WorkSize ws_matrix(matrix_wh_min, matrix_size);
+        gpu::WorkSize ws_transpose(matrix_wh_min, matrix_wh_min, cnt, workGroupCnt);
+
+        gpu::gpu_mem_32u local_cnt_matrix;
+        local_cnt_matrix.resizeN(matrix_size);
+
+        gpu::gpu_mem_32u local_cnt_matrix_copy;
+        local_cnt_matrix_copy.resizeN(matrix_size);
+
+        gpu::gpu_mem_32u local_prefix_sums;
+        local_prefix_sums.resizeN(matrix_size);
+
+        gpu::gpu_mem_32u global_prefix_sums;
+        global_prefix_sums.resizeN(matrix_size);
+
+        const std::vector<uint32_t> zeroes(matrix_size, 0);
+        std::vector<uint32_t> bar(matrix_size, 0);
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
-
+            bs_gpu.writeN(std::vector<uint32_t>(n, 0).data(), n);
+            int bit_mask = (1 << K_bits) - 1;
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (uint32_t step = 0; step < sizeof(uint32_t) * 8 / K_bits; ++step) {
+                local_cnt_matrix.writeN(zeroes.data(), matrix_size);
+                local_cnt_matrix_copy.writeN(zeroes.data(), matrix_size);
+                local_prefix_sums.writeN(zeroes.data(), matrix_size);
+                global_prefix_sums.writeN(zeroes.data(), matrix_size);
+
+                // 1. Сортируем стабильной сортировкой каждую воркгруппу локально
+                for (uint32_t M = 1; M < workGroupSize; M *= 2) {
+                    local_stable_merge_sort.exec(ws, as_gpu, bs_gpu, bit_mask, n, M);
+                    as_gpu.swap(bs_gpu);
+                }
+
+                // 2. Считаем счетчики для каждой воркгруппы через local_mem и atomic_add,
+                // скопировав эту память потом в глобальную матрицу CNT
+                local_counts.exec(ws, as_gpu, n, local_cnt_matrix, bit_mask, step * K_bits);
+
+                // 3. Считаем по матрице CNT локальные префиксные суммы в каждой воркгруппе
+                local_cnt_matrix.copyToN(local_cnt_matrix_copy, matrix_size);
+                for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
+                    prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, local_prefix_sums, matrix_size, prefix_offset);
+                    local_prefix_sums.swap(local_cnt_matrix_copy);
+                }
+
+                // 3.1 Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
+                shift_right.exec(ws_matrix, local_prefix_sums, local_cnt_matrix_copy, matrix_size);
+                local_prefix_sums.swap(local_cnt_matrix_copy);
+
+                // 4. Транспонируем матрицу CNT
+                matrix_transpose.exec(ws_transpose, local_cnt_matrix, local_cnt_matrix_copy, workGroupCnt, cnt);
+
+                // 5. Считаем префиксные суммы по матрице CNT
+                for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
+                    prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, global_prefix_sums, matrix_size, prefix_offset);
+                    global_prefix_sums.swap(local_cnt_matrix_copy);
+                }
+
+
+                // 5.1 Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
+                shift_right.exec(ws_matrix, global_prefix_sums, local_cnt_matrix_copy, matrix_size);
+                global_prefix_sums.swap(local_cnt_matrix_copy);
+
+                // 6. Записываем исходные числа по новым индексам через магию индексации
+                radix.exec(ws, as_gpu, bs_gpu, n, local_prefix_sums, global_prefix_sums, workGroupCnt, bit_mask, step * K_bits);
+                as_gpu.swap(bs_gpu);
+
+                // 7. Сдвигаем маску влево
+                bit_mask = (bit_mask << K_bits);
+
+                t.nextLap();
+            }
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +176,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -65,6 +65,9 @@ int main(int argc, char **argv) {
         ocl::Kernel local_counts(radix_kernel, radix_kernel_length, "local_counts");
         local_counts.compile();
 
+        ocl::Kernel local_counts_transposed(radix_kernel, radix_kernel_length, "local_counts_transposed");
+        local_counts_transposed.compile();
+
         ocl::Kernel prefix_sum(radix_kernel, radix_kernel_length, "prefix_sum");
         prefix_sum.compile();
 
@@ -77,6 +80,9 @@ int main(int argc, char **argv) {
         ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
         radix.compile();
 
+        ocl::Kernel radix_fast(radix_kernel, radix_kernel_length, "radix_fast");
+        radix_fast.compile();
+
         const int K_bits = 4;
         const int cnt = (1 << K_bits);
 
@@ -88,13 +94,10 @@ int main(int argc, char **argv) {
         gpu::WorkSize ws(workGroupSize, global_work_size);
 
         const uint32_t workGroupCnt = global_work_size / workGroupSize;
-
         const uint32_t matrix_size = workGroupCnt * cnt;
 
-        const uint32_t matrix_wh_min = std::min(workGroupCnt < cnt ? workGroupCnt : cnt, workGroupSize);
-
-        gpu::WorkSize ws_matrix(matrix_wh_min, matrix_size);
-        gpu::WorkSize ws_transpose(matrix_wh_min, matrix_wh_min, cnt, workGroupCnt);
+        gpu::WorkSize ws_matrix(workGroupSize, matrix_size);
+        gpu::WorkSize ws_transpose(16, 16, cnt, workGroupCnt);
 
         gpu::gpu_mem_32u local_cnt_matrix;
         local_cnt_matrix.resizeN(matrix_size);
@@ -111,72 +114,122 @@ int main(int argc, char **argv) {
         const std::vector<uint32_t> zeroes(matrix_size, 0);
         std::vector<uint32_t> bar(matrix_size, 0);
 
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            as_gpu.writeN(as.data(), n);
-            bs_gpu.writeN(std::vector<uint32_t>(n, 0).data(), n);
-            int bit_mask = (1 << K_bits) - 1;
-            t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(std::vector<uint32_t>(n, 0).data(), n);
+                int bit_mask = (1 << K_bits) - 1;
+                // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+                t.restart();
 
-            for (uint32_t step = 0; step < sizeof(uint32_t) * 8 / K_bits; ++step) {
-                fill_zeros.exec(ws, local_cnt_matrix, matrix_size);
-                fill_zeros.exec(ws, local_cnt_matrix_copy, matrix_size);
-                fill_zeros.exec(ws, local_prefix_sums, matrix_size);
-                fill_zeros.exec(ws, global_prefix_sums, matrix_size);
+                for (uint32_t step = 0; step < sizeof(uint32_t) * 8 / K_bits; ++step) {
+                    fill_zeros.exec(ws, local_cnt_matrix, matrix_size);
+                    fill_zeros.exec(ws, local_cnt_matrix_copy, matrix_size);
+                    fill_zeros.exec(ws, local_prefix_sums, matrix_size);
+                    fill_zeros.exec(ws, global_prefix_sums, matrix_size);
 
-                // 1. Сортируем стабильной сортировкой каждую воркгруппу локально
-                for (uint32_t M = 1; M < workGroupSize; M *= 2) {
-                    local_stable_merge_sort.exec(ws, as_gpu, bs_gpu, bit_mask, n, M);
-                    as_gpu.swap(bs_gpu);
-                }
+                    // 1. Сортируем стабильной сортировкой каждую воркгруппу локально
+                    for (uint32_t M = 1; M < workGroupSize; M *= 2) {
+                        local_stable_merge_sort.exec(ws, as_gpu, bs_gpu, bit_mask, n, M);
+                        as_gpu.swap(bs_gpu);
+                    }
 
-                // 2. Считаем счетчики для каждой воркгруппы через local_mem и atomic_add,
-                // скопировав эту память потом в глобальную матрицу CNT
-                local_counts.exec(ws, as_gpu, n, local_cnt_matrix, bit_mask, step * K_bits);
+                    // 2. Считаем счетчики для каждой воркгруппы через local_mem и atomic_add,
+                    // скопировав эту память потом в глобальную матрицу CNT
+                    local_counts.exec(ws, as_gpu, n, local_cnt_matrix, bit_mask, step * K_bits);
 
-                // 3. Считаем по матрице CNT локальные префиксные суммы в каждой воркгруппе
-                local_cnt_matrix.copyToN(local_cnt_matrix_copy, matrix_size);
-                for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
-                    prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, local_prefix_sums, matrix_size, prefix_offset);
+                    // 3. Считаем по матрице CNT локальные префиксные суммы в каждой воркгруппе
+                    local_cnt_matrix.copyToN(local_cnt_matrix_copy, matrix_size);
+                    for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
+                        prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, local_prefix_sums, matrix_size, prefix_offset);
+                        local_prefix_sums.swap(local_cnt_matrix_copy);
+                    }
+
+                    // 4 Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
+                    shift_right.exec(ws_matrix, local_prefix_sums, local_cnt_matrix_copy, matrix_size);
                     local_prefix_sums.swap(local_cnt_matrix_copy);
-                }
 
-                // 3.1 Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
-                shift_right.exec(ws_matrix, local_prefix_sums, local_cnt_matrix_copy, matrix_size);
-                local_prefix_sums.swap(local_cnt_matrix_copy);
+                    // 5. Транспонируем матрицу CNT
+                    matrix_transpose.exec(ws_transpose, local_cnt_matrix, local_cnt_matrix_copy, workGroupCnt, cnt);
 
-                // 4. Транспонируем матрицу CNT
-                matrix_transpose.exec(ws_transpose, local_cnt_matrix, local_cnt_matrix_copy, workGroupCnt, cnt);
+                    // 6. Считаем префиксные суммы по матрице CNT
+                    for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
+                        prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, global_prefix_sums, matrix_size, prefix_offset);
+                        global_prefix_sums.swap(local_cnt_matrix_copy);
+                    }
 
-                // 5. Считаем префиксные суммы по матрице CNT
-                for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
-                    prefix_sum.exec(ws_matrix, local_cnt_matrix_copy, global_prefix_sums, matrix_size, prefix_offset);
+                    // 7. Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
+                    shift_right.exec(ws_matrix, global_prefix_sums, local_cnt_matrix_copy, matrix_size);
                     global_prefix_sums.swap(local_cnt_matrix_copy);
+
+                    // 8. Записываем исходные числа по новым индексам через магию индексации
+                    radix.exec(ws, as_gpu, bs_gpu, n, local_prefix_sums, global_prefix_sums, workGroupCnt, bit_mask, step * K_bits);
+                    as_gpu.swap(bs_gpu);
+
+                    // 9. Сдвигаем маску
+                    bit_mask = (bit_mask << K_bits);
                 }
-
-                // 5.1 Сдвигаем префиксы вправо для удобства индексирования (матрица маленькая, так что будет быстро)
-                shift_right.exec(ws_matrix, global_prefix_sums, local_cnt_matrix_copy, matrix_size);
-                global_prefix_sums.swap(local_cnt_matrix_copy);
-
-                // 6. Записываем исходные числа по новым индексам через магию индексации
-                radix.exec(ws, as_gpu, bs_gpu, n, local_prefix_sums, global_prefix_sums, workGroupCnt, bit_mask, step * K_bits);
-                as_gpu.swap(bs_gpu);
-
-                // 7. Сдвигаем маску влево
-                bit_mask = (bit_mask << K_bits);
+                t.nextLap();
             }
-            t.nextLap();
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(as.data(), n);
+
+            // Проверяем корректность результатов
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
+            }
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
 
-        as_gpu.readN(as.data(), n);
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                bs_gpu.writeN(std::vector<uint32_t>(n, 0).data(), n);
+                int bit_mask = (1 << K_bits) - 1;
+                // Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+                t.restart();
+
+                for (uint32_t step = 0; step < sizeof(uint32_t) * 8 / K_bits; ++step) {
+                    fill_zeros.exec(ws_matrix, local_cnt_matrix, matrix_size);
+                    fill_zeros.exec(ws_matrix, global_prefix_sums, matrix_size);
+
+                    // 1. Считаем счетчики уже транспонировано
+                    local_counts_transposed.exec(ws, as_gpu, n, local_cnt_matrix, bit_mask, step * K_bits);
+
+                    // 2. Считаем глобальные префиксные суммы
+                    for (uint32_t prefix_offset = 1; prefix_offset <= matrix_size; prefix_offset *= 2) {
+                        prefix_sum.exec(ws_matrix, local_cnt_matrix, global_prefix_sums, matrix_size, prefix_offset);
+                        local_cnt_matrix.swap(global_prefix_sums);
+                    }
+
+                    // 3. Сдвигаем префиксные суммы для удобства индексирования
+                    shift_right.exec(ws_matrix, local_cnt_matrix, global_prefix_sums, matrix_size);
+
+                    // 4. Сортируем
+                    radix_fast.exec(ws, as_gpu, bs_gpu, n, global_prefix_sums, workGroupCnt, bit_mask, step * K_bits);
+                    as_gpu.swap(bs_gpu);
+
+                    // 5. Сдвигаем маску
+                    bit_mask = (bit_mask << K_bits);
+                }
+                t.nextLap();
+            }
+            std::cout << "GPU fast: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU fast: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+
+            as_gpu.readN(as.data(), n);
+
+            // Проверяем корректность результатов
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
+            }
+        }
     }
 
-    // Проверяем корректность результатов
-    for (int i = 0; i < n; ++i) {
-        EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
-    }
+
 
     return 0;
 }


### PR DESCRIPTION
Сделал 2 реализации:
- Обычную как обсуждали на лекции с двумя матрицами префиксных сумм (локальных и глобальных)
- Упрощенную, которая локально сама считает оффсет в локальных рабочих группах непосредственно перед помещением элемента по нужному индексу.

Вторая работает намного быстрее.

Префиксные суммы считаю наивно, без дерева. Эта сортировка получилась самой быстрой, но можно ли их сравнивать, если сортировка слиянием и битоническая сортировка работали для float, в то время как эта работает с целыми числами. Конечно ГПУ заточены под работы с float, но возможно все таки операции с float там медленнее, чем с целыми числами (в контексте сортировок это сравнения).

Локальный вывод:
```
OpenCL devices:
  Device #0: GPU. Intel(R) HD Graphics 630. Total memory: 12695 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1070. Total memory: 8113 Mb
Data generated for n=33554432!
CPU: 3.30443+-0.0126146 s
CPU: 9.98661 millions/s
GPU: 0.233268+-0.0024416 s
GPU: 141.468 millions/s
GPU fast: 0.0803962+-0.000955339 s
GPU fast: 410.467 millions/s
```

В ридми которую домашку подряд нет требования указывать вывод из CI (что логично), поэтому его опущу, чтобы не грустить вместе с CPU.

На ширине масок 2 и 8 бит производительность сортировки падает в 2-4 раза.