### PR TITLE
Task09 Антон Суркис ITMO

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,8 +9,8 @@ AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: true
 AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
@@ -64,3 +64,5 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 TabWidth: 4
 UseTab: Never
+BinPackArguments: false
+BinPackParameters: false

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 build
 cmake-build*
 .vs
+.cache
+compile_commands.json

--- a/src/cl/clion_defines.cl
+++ b/src/cl/clion_defines.cl
@@ -9,9 +9,9 @@
 #define __constant
 #define __private
 
-#define half float
+using half = float;
 
-struct float2 { float x;          };
+struct float2 { float x, y;       };
 struct float3 { float x, y, z;    };
 struct float4 { float x, y, z, w; };
 

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -396,6 +396,9 @@ void calculateForce(float x0,
     int stack_size = 0;
     stack[stack_size++] = 0;
 
+    float d_force_x = 0.0f;
+    float d_force_y = 0.0f;
+
     while (stack_size) {
         int i_node = stack[--stack_size];
         __global const struct Node *node = &nodes[i_node];
@@ -433,14 +436,17 @@ void calculateForce(float x0,
                 float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
                 float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
 
-                *force_x += child->mass * fx;
-                *force_y += child->mass * fy;
+                d_force_x += child->mass * fx;
+                d_force_y += child->mass * fy;
             } else {
                 stack[stack_size++] = i_child;
                 if (stack_size >= 2 * NBITS_PER_DIM) { printf("0420392384283\n"); }
             }
         }
     }
+
+    *force_x += d_force_x;
+    *force_y += d_force_y;
 }
 
 __kernel void calculateForces(__global const float *pxs,

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -110,9 +110,10 @@ morton_t zOrder(float fx, float fy, int i) {
         //        return 0;
     }
 
-    // TODO
+    morton_t morton_code = spreadBits(x) | (spreadBits(y) << 1);
 
-    return 0;
+    // augmentation
+    return (morton_code << 32) | i;
 }
 
 __kernel void
@@ -160,11 +161,78 @@ void __kernel merge(__global const morton_t *as,
 }
 
 int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_index) {
-    // TODO
+    // Если биты в начале и в конце совпадают, то этот бит незначащий
+    if (getBit(codes[i_begin], bit_index) == getBit(codes[i_end - 1], bit_index)) { return -1; }
+
+    while (i_begin + 1 < i_end) {
+        int m = i_begin + (i_end - i_begin) / 2;
+        int b = getBit(codes[m], bit_index);
+        if (b) {
+            i_end = m;
+        } else {
+            i_begin = m;
+        }
+    }
+    return i_end;
 }
 
 void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_t *codes, int N, int i_node) {
-    // TODO
+    if (i_node < 1 || i_node > N - 2) { printf("842384298293482\n"); }
+
+    // 1. найдем, какого типа мы граница: левая или правая. Идем от самого старшего бита и паттерн-матчим тройки соседних битов
+    //  если нашли (0, 0, 1), то мы правая граница, если нашли (0, 1, 1), то мы левая
+    // dir: 1 если мы левая граница и -1 если правая
+    int dir = 0;
+    int i_bit = NBITS - 1;
+
+    morton_t ml = codes[i_node - 1];
+    morton_t mc = codes[i_node];
+    morton_t mr = codes[i_node + 1];
+
+    for (; i_bit >= 0; --i_bit) {
+        int bl = (ml >> i_bit) & 1;
+        int bc = (mc >> i_bit) & 1;
+        int br = (mr >> i_bit) & 1;
+        if (bl != br) {
+            // bl = 0
+            // br = 1
+            // 0 <= bc <= 1
+            dir = 2 * bc - 1;
+            break;
+        }
+    }
+
+    if (dir == 0) { printf("8923482374983\n"); }
+
+    // 2. Найдем вторую границу нашей зоны ответственности
+
+    // количество совпадающих бит в префиксе
+    int K = NBITS - i_bit;
+    morton_t pref0 = getBits(codes[i_node], i_bit, K);
+
+    // граница зоны ответственности - момент, когда префикс перестает совпадать
+    int l = i_node;
+    int r = dir > 0 ? N : -1;
+    while (l + dir != r) {
+        int m = l + (r - l) / 2;
+        morton_t bits = getBits(codes[m], i_bit, K);
+        if (bits == pref0) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    int i_node_end = l;
+
+    *bit_index = i_bit - 1;
+
+    if (dir > 0) {
+        *i_begin = i_node;
+        *i_end = i_node_end + 1;
+    } else {
+        *i_begin = i_node_end;
+        *i_end = i_node + 1;
+    }
 }
 
 
@@ -175,7 +243,59 @@ void initLBVHNode(__global struct Node *nodes,
                   __global const float *pxs,
                   __global const float *pys,
                   __global const float *mxs) {
-    // TODO
+    // инициализация ссылок на соседей для нод lbvh
+    // если мы лист, то просто инициализируем минус единицами (нет детей), иначе ищем своб зону ответственности и запускаем на ней findSplit
+    // можно заполнить пропуски в виде тудушек, можно реализовать с чистого листа самостоятельно, если так проще
+
+    __global struct Node *node = &nodes[i_node];
+    clear(&node->bbox);
+    node->mass = 0;
+    node->cmsx = 0;
+    node->cmsy = 0;
+
+    // первые N-1 элементов - внутренние ноды, за ними N листьев
+
+    // инициализируем лист
+    if (i_node >= N - 1) {
+        nodes[i_node].child_left = -1;
+        nodes[i_node].child_right = -1;
+        int i_point = i_node - (N - 1);
+
+        int idx = getIndex(codes[i_point]);
+        float center_mass_x = pxs[idx];
+        float center_mass_y = pys[idx];
+        float mass = mxs[idx];
+
+        growPoint(&node->bbox, center_mass_x, center_mass_y);
+        node->cmsx = center_mass_x;
+        node->cmsy = center_mass_y;
+        node->mass = mass;
+
+        return;
+    }
+
+    // инициализируем внутреннюю ноду
+
+    int i_begin = 0, i_end = N, bit_index = NBITS - 1;
+    // если рассматриваем не корень, то нужно найти зону ответственности ноды и самый старший бит, с которого надо начинать поиск разреза
+    if (i_node) { findRegion(&i_begin, &i_end, &bit_index, codes, N, i_node); }
+
+    bool found = false;
+    for (int i_bit = bit_index; i_bit >= 0; --i_bit) {
+        int split = findSplit(codes, i_begin, i_end, i_bit);
+        if (split < 0) continue;
+        if (split < 1) { printf("043204230042342\n"); }
+        if (split - i_begin < 1) { printf("043204230042342\n"); }
+        if (i_end - split < 1) { printf("043204230042342\n"); }
+
+        nodes[i_node].child_left = split - 1 + (split - i_begin < 2 ? N - 1 : 0);
+        nodes[i_node].child_right = split + (i_end - split < 2 ? N - 1 : 0);
+
+        found = true;
+        break;
+    }
+
+    if (!found) { printf("54356549645\n"); }
 }
 
 __kernel void buidLBVH(__global const float *pxs,
@@ -184,7 +304,10 @@ __kernel void buidLBVH(__global const float *pxs,
                        __global const morton_t *codes,
                        __global struct Node *nodes,
                        int N) {
-    // TODO
+    int tree_size = LBVHSize(N);
+    int i_node = get_global_id(0);
+    if (i_node >= tree_size) return;
+    initLBVHNode(nodes, i_node, codes, N, pxs, pys, mxs);
 }
 
 void initFlag(__global int *flags, int i_node, __global const struct Node *nodes, int level) {
@@ -266,7 +389,58 @@ void calculateForce(float x0,
                     __global const struct Node *nodes,
                     __global float *force_x,
                     __global float *force_y) {
-    // TODO
+    // основная идея ускорения - аггрегировать в узлах дерева веса и центры масс,
+    //   и не спускаться внутрь, если точка запроса не пересекает ноду, а заменить на взаимодействие с ее центром масс
+
+    int stack[2 * NBITS_PER_DIM];
+    int stack_size = 0;
+    stack[stack_size++] = 0;
+
+    while (stack_size) {
+        int i_node = stack[--stack_size];
+        __global const struct Node *node = &nodes[i_node];
+
+        if (isLeaf(node)) continue;
+
+        // если запрос содержится и а левом и в правом ребенке - то они в одном пикселе
+        {
+            __global const struct Node *left = &nodes[node->child_left];
+            __global const struct Node *right = &nodes[node->child_right];
+            if (contains(&left->bbox, x0, y0) && contains(&right->bbox, x0, y0)) {
+                if (!equals(&left->bbox, &right->bbox)) { printf("42357987645432456547\n"); }
+                if (!equalsPoint(&left->bbox, x0, y0)) { printf("5446456456435656\n"); }
+                continue;
+            }
+        }
+
+        int idx_children[] = {node->child_left, node->child_right};
+        for (int ii_child = 0; ii_child < 2; ++ii_child) {
+            int i_child = idx_children[ii_child];
+            __global const struct Node *child = &nodes[i_child];
+            // С точки зрения ббоксов заходить в ребенка, ббокс которого не пересекаем, не нужно (из-за того, что в листьях у нас точки и они не высовываются за свой регион пространства)
+            //   Но, с точки зрения физики, замена гравитационного влияния всех точек в регионе на взаимодействие с суммарной массой в центре масс - это точное решение только в однородном поле (например, на поверхности земли)
+            //   У нас поле неоднородное, и такая замена - лишь приближение. Чтобы оно было достаточно точным, будем спускаться внутрь ноды, пока она не станет похожа на точечное тело (маленький размер ее ббокса относительно нашего расстояния до центра масс ноды)
+            if (!contains(&child->bbox, x0, y0) && barnesHutCondition(x0, y0, child)) {
+                float dx = child->cmsx - x0;
+                float dy = child->cmsy - y0;
+                float dr2 = max(100.0f, dx * dx + dy * dy);
+
+                float dr2_inv = 1.0f / dr2;
+                float dr_inv = sqrt(dr2_inv);
+
+                float ex = dx * dr_inv;
+                float ey = dy * dr_inv;
+                float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
+                float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
+
+                *force_x += child->mass * fx;
+                *force_y += child->mass * fy;
+            } else {
+                stack[stack_size++] = i_child;
+                if (stack_size >= 2 * NBITS_PER_DIM) { printf("0420392384283\n"); }
+            }
+        }
+    }
 }
 
 __kernel void calculateForces(__global const float *pxs,
@@ -279,7 +453,13 @@ __kernel void calculateForces(__global const float *pxs,
                               __global float *dvy2d,
                               int N,
                               int t) {
-    // TODO
+    int i = get_global_id(0);
+    float x0 = pxs[i];
+    float y0 = pys[i];
+    float m0 = mxs[i];
+    __global float *force_x = dvx2d + t * N + i;
+    __global float *force_y = dvy2d + t * N + i;
+    calculateForce(x0, y0, m0, nodes, force_x, force_y);
 }
 
 __kernel void integrate(__global float *pxs,

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -1,5 +1,5 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
@@ -12,65 +12,51 @@
 #define NBITS_PER_DIM 16
 #define NBITS (NBITS_PER_DIM /*x dimension*/ + NBITS_PER_DIM /*y dimension*/ + 32 /*index augmentation*/)
 
-int LBVHSize(int N) {
-    return N + N-1;
-}
+int LBVHSize(int N) { return N + N - 1; }
 
-morton_t getBits(morton_t morton_code, int bit_index, int prefix_size)
-{
+morton_t getBits(morton_t morton_code, int bit_index, int prefix_size) {
     morton_t one = 1;
     return (morton_code >> bit_index) & ((one << prefix_size) - one);
 }
 
-int getBit(morton_t morton_code, int bit_index)
-{
-    return (morton_code >> bit_index) & 1;
-}
+int getBit(morton_t morton_code, int bit_index) { return (morton_code >> bit_index) & 1; }
 
-int getIndex(morton_t morton_code)
-{
+int getIndex(morton_t morton_code) {
     morton_t mask = 1;
     mask = (mask << 32) - 1;
     return morton_code & mask;
 }
 
-int spreadBits(int word){
-    word = (word ^ (word << 8 )) & 0x00ff00ff;
-    word = (word ^ (word << 4 )) & 0x0f0f0f0f;
-    word = (word ^ (word << 2 )) & 0x33333333;
-    word = (word ^ (word << 1 )) & 0x55555555;
+int spreadBits(int word) {
+    word = (word ^ (word << 8)) & 0x00ff00ff;
+    word = (word ^ (word << 4)) & 0x0f0f0f0f;
+    word = (word ^ (word << 2)) & 0x33333333;
+    word = (word ^ (word << 1)) & 0x55555555;
     return word;
 }
 
-struct __attribute__ ((packed)) BBox {
+struct __attribute__((packed)) BBox {
 
     int minx, maxx;
     int miny, maxy;
-
 };
 
-void clear(__global struct BBox *self)
-{
+void clear(__global struct BBox *self) {
     self->minx = INT_MAX;
     self->maxx = INT_MIN;
     self->miny = self->minx;
     self->maxy = self->maxx;
 }
 
-bool contains(__global const struct BBox *self, float fx, float fy)
-{
+bool contains(__global const struct BBox *self, float fx, float fy) {
     int x = fx + 0.5;
     int y = fy + 0.5;
-    return x >= self->minx && x <= self->maxx &&
-           y >= self->miny && y <= self->maxy;
+    return x >= self->minx && x <= self->maxx && y >= self->miny && y <= self->maxy;
 }
 
-bool empty(__global const struct BBox *self)
-{
-    return self->minx > self->maxx;
-}
+bool empty(__global const struct BBox *self) { return self->minx > self->maxx; }
 
-struct __attribute__ ((packed)) Node {
+struct __attribute__((packed)) Node {
 
     int child_left, child_right;
     struct BBox bbox;
@@ -81,48 +67,35 @@ struct __attribute__ ((packed)) Node {
     float cmsy;
 };
 
-bool hasLeftChild(__global const struct Node *self)
-{
-    return self->child_left >= 0;
-}
+bool hasLeftChild(__global const struct Node *self) { return self->child_left >= 0; }
 
-bool hasRightChild(__global const struct Node *self)
-{
-    return self->child_right >= 0;
-}
+bool hasRightChild(__global const struct Node *self) { return self->child_right >= 0; }
 
-bool isLeaf(__global const struct Node *self)
-{
-    return !hasLeftChild(self) && !hasRightChild(self);
-}
+bool isLeaf(__global const struct Node *self) { return !hasLeftChild(self) && !hasRightChild(self); }
 
-void growPoint(__global struct BBox *self, float fx, float fy)
-{
+void growPoint(__global struct BBox *self, float fx, float fy) {
     self->minx = min(self->minx, (int) (fx + 0.5));
     self->maxx = max(self->maxx, (int) (fx + 0.5));
     self->miny = min(self->miny, (int) (fy + 0.5));
     self->maxy = max(self->maxy, (int) (fy + 0.5));
 }
 
-void growBBox(__global struct BBox *self, __global const struct BBox *other)
-{
+void growBBox(__global struct BBox *self, __global const struct BBox *other) {
     growPoint(self, other->minx, other->miny);
     growPoint(self, other->maxx, other->maxy);
 }
 
-bool equals(__global const struct BBox *lhs, __global const struct BBox *rhs)
-{
+bool equals(__global const struct BBox *lhs, __global const struct BBox *rhs) {
     return lhs->minx == rhs->minx && lhs->maxx == rhs->maxx && lhs->miny == rhs->miny && lhs->maxy == rhs->maxy;
 }
 
-bool equalsPoint(__global const struct BBox *lhs, float fx, float fy)
-{
+bool equalsPoint(__global const struct BBox *lhs, float fx, float fy) {
     int x = fx + 0.5;
     int y = fy + 0.5;
     return lhs->minx == x && lhs->maxx == x && lhs->miny == y && lhs->maxy == y;
 }
 
-morton_t zOrder(float fx, float fy, int i){
+morton_t zOrder(float fx, float fy, int i) {
     int x = fx + 0.5;
     int y = fy + 0.5;
 
@@ -130,11 +103,11 @@ morton_t zOrder(float fx, float fy, int i){
 
     if (x < 0 || x >= (1 << NBITS_PER_DIM)) {
         printf("098245490432590890\n");
-//        return 0;
+        //        return 0;
     }
     if (y < 0 || y >= (1 << NBITS_PER_DIM)) {
         printf("432764328764237823\n");
-//        return 0;
+        //        return 0;
     }
 
     // TODO
@@ -142,32 +115,29 @@ morton_t zOrder(float fx, float fy, int i){
     return 0;
 }
 
-__kernel void generateMortonCodes(__global const float *pxs, __global const float *pys,
-                                  __global morton_t *codes,
-                                  int N)
-{
+__kernel void
+generateMortonCodes(__global const float *pxs, __global const float *pys, __global morton_t *codes, int N) {
     int gid = get_global_id(0);
-    if (gid >= N)
-        return;
+    if (gid >= N) return;
 
     codes[gid] = zOrder(pxs[gid], pys[gid], gid);
 }
 
-bool mergePathPredicate(morton_t val_mid, morton_t val_cur, bool is_right)
-{
+bool mergePathPredicate(morton_t val_mid, morton_t val_cur, bool is_right) {
     return is_right ? val_mid <= val_cur : val_mid < val_cur;
 }
 
-void __kernel merge(__global const morton_t *as, __global morton_t *as_sorted, unsigned int n, unsigned int subarray_size)
-{
+void __kernel merge(__global const morton_t *as,
+                    __global morton_t *as_sorted,
+                    unsigned int n,
+                    unsigned int subarray_size) {
     const int gid = get_global_id(0);
-    if (gid >= n)
-        return;
+    if (gid >= n) return;
 
     const int subarray_id = gid / subarray_size;
     const int is_right_subarray = subarray_id & 1;
 
-    const int base_cur = (subarray_id) * subarray_size;
+    const int base_cur = (subarray_id) *subarray_size;
     const int base_other = (subarray_id + 1 - 2 * is_right_subarray) * subarray_size;
 
     const int j = gid - base_cur;
@@ -189,67 +159,63 @@ void __kernel merge(__global const morton_t *as, __global morton_t *as_sorted, u
     as_sorted[idx] = val_cur;
 }
 
-int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_index)
-{
+int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_index) {
     // TODO
 }
 
-void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_t *codes, int N, int i_node)
-{
+void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_t *codes, int N, int i_node) {
     // TODO
 }
 
 
-void initLBVHNode(__global struct Node *nodes, int i_node, __global const morton_t *codes, int N, __global const float *pxs, __global const float *pys, __global const float *mxs)
-{
+void initLBVHNode(__global struct Node *nodes,
+                  int i_node,
+                  __global const morton_t *codes,
+                  int N,
+                  __global const float *pxs,
+                  __global const float *pys,
+                  __global const float *mxs) {
     // TODO
 }
 
-__kernel void buidLBVH(__global const float *pxs, __global const float *pys, __global const float *mxs,
-                       __global const morton_t *codes, __global struct Node *nodes,
-                       int N)
-{
+__kernel void buidLBVH(__global const float *pxs,
+                       __global const float *pys,
+                       __global const float *mxs,
+                       __global const morton_t *codes,
+                       __global struct Node *nodes,
+                       int N) {
     // TODO
 }
 
-void initFlag(__global int *flags, int i_node, __global const struct Node *nodes, int level)
-{
+void initFlag(__global int *flags, int i_node, __global const struct Node *nodes, int level) {
     flags[i_node] = -1;
 
     __global const struct Node *node = &nodes[i_node];
     if (isLeaf(node)) {
         printf("9423584385834\n");
-//        return;
+        //        return;
     }
 
-    if (!empty(&node->bbox)) {
-        return;
-    }
+    if (!empty(&node->bbox)) { return; }
 
     __global const struct BBox *left = &nodes[node->child_left].bbox;
     __global const struct BBox *right = &nodes[node->child_right].bbox;
 
-    if (!empty(left) && !empty(right)) {
-        flags[i_node] = level;
-    }
+    if (!empty(left) && !empty(right)) { flags[i_node] = level; }
 }
 
-__kernel void initFlags(__global int *flags, __global const struct Node *nodes,
-                       int N, int level)
-{
+__kernel void initFlags(__global int *flags, __global const struct Node *nodes, int N, int level) {
     int gid = get_global_id(0);
 
-    if (gid == N-1)
-        flags[gid] = 0; // use last element as a n_updated counter in next kernel
+    if (gid == N - 1) flags[gid] = 0;// use last element as a n_updated counter in next kernel
 
-    if (gid >= N-1) // инициализируем только внутренние ноды
+    if (gid >= N - 1)// инициализируем только внутренние ноды
         return;
 
     initFlag(flags, gid, nodes, level);
 }
 
-void growNode(__global struct Node *root, __global struct Node *nodes)
-{
+void growNode(__global struct Node *root, __global struct Node *nodes) {
     __global const struct Node *left = &nodes[root->child_left];
     __global const struct Node *right = &nodes[root->child_right];
 
@@ -263,73 +229,75 @@ void growNode(__global struct Node *root, __global struct Node *nodes)
 
     if (root->mass <= 1e-8) {
         printf("04230420340322\n");
-//        return;
+        //        return;
     }
 
     root->cmsx = (left->cmsx * m0 + right->cmsx * m1) / root->mass;
     root->cmsy = (left->cmsy * m0 + right->cmsy * m1) / root->mass;
 }
 
-__kernel void growNodes(__global int *flags, __global struct Node *nodes,
-                        int N, int level)
-{
+__kernel void growNodes(__global int *flags, __global struct Node *nodes, int N, int level) {
     int gid = get_global_id(0);
 
-    if (gid >= N-1) // инициализируем только внутренние ноды
+    if (gid >= N - 1)// инициализируем только внутренние ноды
         return;
 
     __global struct Node *node = &nodes[gid];
     if (flags[gid] == level) {
         growNode(node, nodes);
-        atomic_add(&flags[N-1], 1);
+        atomic_add(&flags[N - 1], 1);
     }
 }
 
 // https://en.wikipedia.org/wiki/Barnes%E2%80%93Hut_simulation
-bool barnesHutCondition(float x, float y, __global const struct Node *node)
-{
+bool barnesHutCondition(float x, float y, __global const struct Node *node) {
     float dx = x - node->cmsx;
     float dy = y - node->cmsy;
     float s = max(node->bbox.maxx - node->bbox.minx, node->bbox.maxy - node->bbox.miny);
-    float d2 = dx*dx + dy*dy;
+    float d2 = dx * dx + dy * dy;
     float thresh = 0.5;
 
     return s * s < d2 * thresh * thresh;
 }
 
-void calculateForce(float x0, float y0, float m0, __global const struct Node *nodes, __global float *force_x, __global float *force_y)
-{
+void calculateForce(float x0,
+                    float y0,
+                    float m0,
+                    __global const struct Node *nodes,
+                    __global float *force_x,
+                    __global float *force_y) {
     // TODO
 }
 
-__kernel void calculateForces(
-        __global const float *pxs, __global const float *pys,
-        __global const float *vxs, __global const float *vys,
-        __global const float *mxs,
-        __global const struct Node *nodes,
-        __global float * dvx2d, __global float * dvy2d,
-        int N,
-        int t)
-{
+__kernel void calculateForces(__global const float *pxs,
+                              __global const float *pys,
+                              __global const float *vxs,
+                              __global const float *vys,
+                              __global const float *mxs,
+                              __global const struct Node *nodes,
+                              __global float *dvx2d,
+                              __global float *dvy2d,
+                              int N,
+                              int t) {
     // TODO
 }
 
-__kernel void integrate(
-        __global float * pxs, __global float * pys,
-        __global float *vxs, __global float *vys,
-        __global const float *mxs,
-        __global float * dvx2d, __global float * dvy2d,
-        int N,
-        int t,
-        int coord_shift)
-{
+__kernel void integrate(__global float *pxs,
+                        __global float *pys,
+                        __global float *vxs,
+                        __global float *vys,
+                        __global const float *mxs,
+                        __global float *dvx2d,
+                        __global float *dvy2d,
+                        int N,
+                        int t,
+                        int coord_shift) {
     unsigned int i = get_global_id(0);
 
-    if (i >= N)
-        return;
+    if (i >= N) return;
 
-    __global float * dvx = dvx2d + t * N;
-    __global float * dvy = dvy2d + t * N;
+    __global float *dvx = dvx2d + t * N;
+    __global float *dvy = dvy2d + t * N;
 
     vxs[i] += dvx[i];
     vys[i] += dvy[i];

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -15,19 +15,44 @@ __kernel void nbody_calculate_force_global(__global float *pxs,
                                            __global float *dvy2d,
                                            int N,
                                            int t) {
-    unsigned int i = get_global_id(0);
+    int i = get_global_id(0);
 
-    if (i >= N)
-        return;
+    if (i >= N) return;
 
     __global float *dvx = dvx2d + t * N;
     __global float *dvy = dvy2d + t * N;
 
     float x0 = pxs[i];
     float y0 = pys[i];
-    float m0 = mxs[i];
+    // float m0 = mxs[i];
 
-    // TODO
+    float dvxi = dvx[i];
+    float dvyi = dvx[i];
+
+    for (int j = 0; j < N; ++j) {
+        if (i == j) continue;
+        float x1 = pxs[j];
+        float y1 = pys[j];
+        float m1 = mxs[j];
+
+        float dx = x1 - x0;
+        float dy = y1 - y0;
+        float dr2 = max(100.0f, dx * dx + dy * dy);
+
+        float dr2_inv = 1.0f / dr2;
+        float dr_inv = sqrt(dr2_inv);
+
+        float ex = dx * dr_inv;
+        float ey = dy * dr_inv;
+        float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
+        float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
+
+        dvxi += m1 * fx;
+        dvyi += m1 * fy;
+    }
+
+    dvx[i] = dvxi;
+    dvy[i] = dvyi;
 }
 
 __kernel void nbody_integrate(__global float *pxs,
@@ -39,10 +64,9 @@ __kernel void nbody_integrate(__global float *pxs,
                               __global float *dvy2d,
                               int N,
                               int t) {
-    unsigned int i = get_global_id(0);
+    int i = get_global_id(0);
 
-    if (i >= N)
-        return;
+    if (i >= N) return;
 
     __global float *dvx = dvx2d + t * N;
     __global float *dvy = dvy2d + t * N;

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -1,26 +1,27 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
 #define GRAVITATIONAL_FORCE 0.0001
 
-__kernel void nbody_calculate_force_global(
-    __global float * pxs, __global float * pys,
-    __global float *vxs, __global float *vys,
-    __global const float *mxs,
-    __global float * dvx2d, __global float * dvy2d,
-    int N,
-    int t)
-{
+__kernel void nbody_calculate_force_global(__global float *pxs,
+                                           __global float *pys,
+                                           __global float *vxs,
+                                           __global float *vys,
+                                           __global const float *mxs,
+                                           __global float *dvx2d,
+                                           __global float *dvy2d,
+                                           int N,
+                                           int t) {
     unsigned int i = get_global_id(0);
 
     if (i >= N)
         return;
 
-    __global float * dvx = dvx2d + t * N;
-    __global float * dvy = dvy2d + t * N;
+    __global float *dvx = dvx2d + t * N;
+    __global float *dvy = dvy2d + t * N;
 
     float x0 = pxs[i];
     float y0 = pys[i];
@@ -29,21 +30,22 @@ __kernel void nbody_calculate_force_global(
     // TODO
 }
 
-__kernel void nbody_integrate(
-        __global float * pxs, __global float * pys,
-        __global float *vxs, __global float *vys,
-        __global const float *mxs,
-        __global float * dvx2d, __global float * dvy2d,
-        int N,
-        int t)
-{
+__kernel void nbody_integrate(__global float *pxs,
+                              __global float *pys,
+                              __global float *vxs,
+                              __global float *vys,
+                              __global const float *mxs,
+                              __global float *dvx2d,
+                              __global float *dvy2d,
+                              int N,
+                              int t) {
     unsigned int i = get_global_id(0);
 
     if (i >= N)
         return;
 
-    __global float * dvx = dvx2d + t * N;
-    __global float * dvy = dvy2d + t * N;
+    __global float *dvx = dvx2d + t * N;
+    __global float *dvy = dvy2d + t * N;
 
     vxs[i] += dvx[i];
     vys[i] += dvy[i];

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -26,7 +26,7 @@
 #define EVALUATE_PRECISION 1
 
 // удобно включить при локальном тестировании
-#define ENABLE_GUI 1
+#define ENABLE_GUI 0
 
 // сброс картинок симуляции на диск
 #define SAVE_IMAGES 0

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1884,7 +1884,7 @@ TEST(LBVH, Nbody) {
 
 #if NBODY_INITIAL_STATE_COMPLEXITY < 2
     nbody(false, evaluate_precision, 0);// cpu naive
-    // nbody(false, evaluate_precision, 1); // gpu naive
+    nbody(false, evaluate_precision, 1); // gpu naive
 #endif
     // nbody(false, evaluate_precision, 2); // cpu lbvh
     // nbody(false, evaluate_precision, 3); // gpu lbvh

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -83,7 +83,7 @@ struct State {
     int coord_shift;
 };
 
-bool floatEq(float a, float b) { return std::abs(a - b) < 1e-3f; }
+bool floatEq(float a, float b) { return std::abs(a - b) < 1e-3f * std::max(1.0f, std::max(std::abs(a), std::abs(b))); }
 
 struct Point {
     int x, y;
@@ -1521,9 +1521,6 @@ void checkTreesEqual(const std::vector<Node> &nodes_recursive,
     EXPECT_TRUE(floatEq(root_recursive.mass, root.mass));
     EXPECT_TRUE(floatEq(root_recursive.cmsx, root.cmsx));
     EXPECT_TRUE(floatEq(root_recursive.cmsy, root.cmsy));
-    // EXPECT_EQ(root_recursive.mass, root.mass);
-    // EXPECT_EQ(root_recursive.cmsx, root.cmsx);
-    // EXPECT_EQ(root_recursive.cmsy, root.cmsy);
     EXPECT_EQ(root_recursive.hasLeftChild(), root.hasLeftChild());
     EXPECT_EQ(root_recursive.hasRightChild(), root.hasRightChild());
 
@@ -1927,7 +1924,7 @@ TEST(LBVH, Nbody) {
     nbody(false, evaluate_precision, 1);// gpu naive
 #endif
     nbody(false, evaluate_precision, 2);// cpu lbvh
-    nbody(false, evaluate_precision, 3); // gpu lbvh
+    nbody(false, evaluate_precision, 3);// gpu lbvh
 }
 
 TEST(LBVH, Nbody_meditation) {


### PR DESCRIPTION
Из-за ограничений точности вычислений с плавающей точкой я поменял операторы сравнения на равенство, использующиеся в тестах.

<details>
<summary>Локальный вывод</summary>

```
Running main() from /run/media/asurkis/HDD/Homework/sem11/GPGPUTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (361 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
[       OK ] LBVH.GPU (3089 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
simulated 100 frames, N: 1000, framerate: 148.063 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 3573.73 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 326.626 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 631.8 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (2252 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (5703 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (5703 ms total)
[  PASSED  ] 4 tests.
```

</details>

<details>
<summary>Локальный вывод, N=10000</summary>

```
Running main() from /run/media/asurkis/HDD/Homework/sem11/GPGPUTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (364 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
[       OK ] LBVH.GPU (3081 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
  Device #1: CPU. cpu-AMD Ryzen 5 1500X Quad-Core Processor. AuthenticAMD. Total memory: 21938 Mb
Using device #0: GPU. NVIDIA GeForce GTX 1060 6GB. Total memory: 6069 Mb
simulated 100 frames, N: 10000, framerate: 1.57852 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 10000, framerate: 108.072 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 10000, framerate: 24.4187 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 10000, framerate: 150.616 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (127024 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (130470 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (130470 ms total)
[  PASSED  ] 4 tests.
```

</details>

<details>
<summary>Вывод в CI</summary>

```
Running main() from /home/runner/work/GPGPUTasks2023/GPGPUTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (59 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
[       OK ] LBVH.GPU (4120 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
simulated 100 frames, N: 1000, framerate: 389.443 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 685.204 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 1319.82 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 28.3139 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (4399 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (8578 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (8578 ms total)
[  PASSED  ] 4 tests.
```

</details>

# Вывод

LBVH показывает себя асимптотически лучше наивного решения. Таблица частоты кадров для сравнения:

| Тип решения | Устройство | N = 1000 | N = 10 000 | Соотношение |
|:---|:---|:---|:---|:---|
| Наивное | AMD Ryzen 5 1500X | 153,828 | 1,57852 | 97,4507766768872 |
| Наивное | NVIDIA GeForce GTX 1060 6GB | 3571,68 | 108,072 | 33,049078392183 |
| NBVH | AMD Ryzen 5 1500X | 316,148 | 24,4187 | 12,9469627785263 |
| NBVH | NVIDIA GeForce GTX 1060 6GB | 651,037 | 150,616 | 4,32249561799543 |

При увеличении объёма данных в 10 раз наблюдаем:
- Ожидаемое снижение частоты кадров в наивном решении на процессоре в 100 раз при асимптотике $O(n^2)$
- Снижение частоты кадров на видеокарте в 33 раза, что можно объяснить тем, что 1000 частиц — очень маленький набор данных, и, вероятно, значительное время уходит на синхронизацию
- NBVH на процессоре замедляется только в 13 раз, что соответствует асимптотике $O(n \log n)$
- NBVH на видеокарте замедляется только в 4 раза, аналогично, значительное время на 1000 частиц может уходить на синхронизацию

Алгоритмы NBVH на процессоре и видеокарте идентичны с точностью до замены `std::vector<T>&` на `__global struct T*`.

При этом, несмотря на более выгодную асимптотику, у LBVH значительно больше константа, поэтому на малых данных на видеокарте он проигрывает наивному решению.