### PR TITLE
Task09 Артем Каширин SPbU

### DIFF
--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -1,5 +1,5 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+#include "clion_defines.cl"
 #endif
 
 #line 6
@@ -7,7 +7,7 @@
 
 #define GRAVITATIONAL_FORCE 0.0001
 
-#define morton_t ulong
+#define morton_t unsigned long
 
 #define NBITS_PER_DIM 16
 #define NBITS (NBITS_PER_DIM /*x dimension*/ + NBITS_PER_DIM /*y dimension*/ + 32 /*index augmentation*/)
@@ -137,9 +137,9 @@ morton_t zOrder(float fx, float fy, int i){
 //        return 0;
     }
 
-    // TODO
+	morton_t morton_code = (spreadBits(y) << 1) | spreadBits(x);
 
-    return 0;
+	return (morton_code << 32) | i;
 }
 
 __kernel void generateMortonCodes(__global const float *pxs, __global const float *pys,

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -29,7 +29,7 @@ float q_rsqrt(float number)
 	i  = 0x5f3759df - ( i >> 1 );               // what the fuck?
 	y  = * ( float * ) &i;
 	y  = y * ( threehalfs - ( x2 * y * y ) );   // 1st iteration
-//	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
+	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
 
 	return y;
 }

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -477,10 +477,10 @@ void calculateForce(float x0, float y0, float m0, __global const struct Node *no
 				float dy = child->cmsy - y0;
 				float dr2 = max(100.f, dx * dx + dy * dy);
 
-//                float dr2_inv = 1.f / dr2;
-//                float dr_inv = std::sqrt(dr2_inv);
-				float dr_inv = q_rsqrt(dr2);
-				float dr2_inv = dr_inv * dr_inv;
+                float dr2_inv = 1.f / dr2;
+                float dr_inv = sqrt(dr2_inv);
+//				float dr_inv = q_rsqrt(dr2);
+//				float dr2_inv = dr_inv * dr_inv;
 
 				float ex = dx * dr_inv;
 				float ey = dy * dr_inv;

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -19,7 +19,7 @@ float q_rsqrt(float number)
 	i  = 0x5f3759df - ( i >> 1 );               // what the fuck?
 	y  = * ( float * ) &i;
 	y  = y * ( threehalfs - ( x2 * y * y ) );   // 1st iteration
-//	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
+	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
 
 	return y;
 }

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -56,8 +56,10 @@ __kernel void nbody_calculate_force_global(
 		float dy = y1 - y0;
 		float dr2 = max(100.f, dx * dx + dy * dy);
 
-		float dr_inv = q_rsqrt(dr2);
-		float dr2_inv = dr_inv * dr_inv;
+		float dr2_inv = 1.f / dr2;
+		float dr_inv = sqrt(dr2_inv);
+//		float dr_inv = q_rsqrt(dr2);
+//		float dr2_inv = dr_inv * dr_inv;
 
 		float ex = dx * dr_inv;
 		float ey = dy * dr_inv;

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -441,10 +441,10 @@ void calculateForce(float x0, float y0, float m0, const std::vector<Node> &nodes
 				float dy = child.cmsy - y0;
 				float dr2 = std::max(100.f, dx * dx + dy * dy);
 
-//                float dr2_inv = 1.f / dr2;
-//                float dr_inv = std::sqrt(dr2_inv);
-				float dr_inv = q_rsqrt(dr2);
-				float dr2_inv = dr_inv * dr_inv;
+                float dr2_inv = 1.f / dr2;
+                float dr_inv = std::sqrt(dr2_inv);
+//				float dr_inv = q_rsqrt(dr2);
+//				float dr2_inv = dr_inv * dr_inv;
 
 				float ex = dx * dr_inv;
 				float ey = dy * dr_inv;
@@ -604,10 +604,10 @@ void nbody_cpu(DeltaState &delta_state, State &initial_state, int N, int NT, con
                 float dy = y1 - y0;
                 float dr2 = std::max(100.f, dx * dx + dy * dy);
 
-//                float dr2_inv = 1.f / dr2;
-//                float dr_inv = std::sqrt(dr2_inv);
-				float dr_inv = q_rsqrt(dr2);
-				float dr2_inv = dr_inv * dr_inv;
+                float dr2_inv = 1.f / dr2;
+                float dr_inv = std::sqrt(dr2_inv);
+//				float dr_inv = q_rsqrt(dr2);
+//				float dr2_inv = dr_inv * dr_inv;
 
                 float ex = dx * dr_inv;
                 float ey = dy * dr_inv;

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -340,7 +340,7 @@ float q_rsqrt(float number)
 	i  = 0x5f3759df - ( i >> 1 );               // what the fuck?
 	y  = * ( float * ) &i;
 	y  = y * ( threehalfs - ( x2 * y * y ) );   // 1st iteration
-//	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
+	y  = y * ( threehalfs - ( x2 * y * y ) );   // 2nd iteration, this can be removed
 
 	return y;
 }


### PR DESCRIPTION
Я попытался сделать немного быстрее с использованием q_rsqrt(), но это привело к неточностям в данных, пришлось оставить как есть.

<details><summary>Вывод Github CI</summary><p>
<pre>
Run ./lbvh
Running main() from /home/runner/work/GPGPUTasks2023/GPGPUTasks2023/libs/3rdparty/libgtest/googletest/src/gtest_main.cc
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (7 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
[       OK ] LBVH.GPU (4193 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
simulated 100 frames, N: 1000, framerate: 400.122 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 691.501 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 1288.23 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 27.7688 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (4468 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (8668 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (8668 ms total)
[  PASSED  ] 4 tests.
</pre>
</p></details>