### PR TITLE
Task09 Овчинников Егор ITMO

### DIFF
--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -137,9 +137,11 @@ morton_t zOrder(float fx, float fy, int i){
 //        return 0;
     }
 
-    // TODO
+//  TODO
+    morton_t morton_code = spreadBits(x) | spreadBits(y) * 2;
 
-    return 0;
+    //    augmentation
+    return (morton_code << 32) | i;
 }
 
 __kernel void generateMortonCodes(__global const float *pxs, __global const float *pys,
@@ -192,24 +194,184 @@ void __kernel merge(__global const morton_t *as, __global morton_t *as_sorted, u
 int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_index)
 {
     // TODO
+        // Если биты в начале и в конце совпадают, то этот бит незначащий
+    if (getBit(codes[i_begin], bit_index) == getBit(codes[i_end-1], bit_index)) {
+        return -1;
+    }
+
+    // TODO бинпоиск для нахождения разбиения области ответственности ноды
+    int l = i_begin, r = i_end;
+    while (l + 1 < r) {
+        int m = (l + r) / 2;
+        int lb = getBit(codes[l], bit_index);
+        int mb = getBit(codes[m], bit_index);
+        if (lb == mb) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
+    if (getBit(codes[l], bit_index) < getBit(codes[r], bit_index)) {
+        return r;
+    }
+
+    // избыточно, так как на входе в функцию проверили, что ответ существует, но приятно иметь sanity-check на случай если набагали
+    printf("451932492039458209485");
 }
 
 void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_t *codes, int N, int i_node)
 {
     // TODO
+    if (i_node < 1 || i_node > N - 2) {
+        printf("85142384298293482");
+    }
+
+    // 1. найдем, какого типа мы граница: левая или правая. Идем от самого старшего бита и паттерн-матчим тройки соседних битов
+    //  если нашли (0, 0, 1), то мы правая граница, если нашли (0, 1, 1), то мы левая
+    // dir: 1 если мы левая граница и -1 если правая
+    int dir = 0;
+    int i_bit = NBITS-1;
+    morton_t lmorton = codes[i_node - 1];
+    morton_t mmorton = codes[i_node];
+    morton_t rmorton = codes[i_node + 1];
+    const int right = 1, left = 3;
+    for (; i_bit >= 0; --i_bit) {
+        // TODO найти dir и значащий бит
+        int m = (!!getBit(lmorton, i_bit) << 2) |
+                (!!getBit(mmorton, i_bit) << 1) |
+                !!getBit(rmorton, i_bit);
+        if (m == left) {
+            dir = 1;
+            break;
+        }
+        if (m == right) {
+            dir = -1;
+            break;
+        }
+    }
+
+    if (dir == 0) {
+        printf("628923482374983");
+    }
+
+    // 2. Найдем вторую границу нашей зоны ответственности
+
+    // количество совпадающих бит в префиксе
+    int K = NBITS - i_bit;
+    morton_t pref0 = getBits(codes[i_node], i_bit, K);
+
+    // граница зоны ответственности - момент, когда префикс перестает совпадать
+    // TODO бинпоиск зоны ответственности
+
+    int l, r;
+    if (dir > 0) {
+        l = i_node;
+        r = N;
+    } else {
+        l = -1;
+        r = i_node;
+    }
+    while (l + 1 < r) {
+        int m = (l + r) / 2;
+        if (getBits(codes[m], i_bit, K) == pref0) {
+            if (dir > 0) {
+                l = m;
+            } else {
+                r = m;
+            }
+        } else {
+            if (dir > 0) {
+                r = m;
+            } else {
+                l = m;
+            }
+        }
+    }
+    *bit_index = i_bit - 1;
+
+    if (dir > 0) {
+        *i_begin = i_node;
+        *i_end = r;
+    } else {
+        *i_begin = l + 1;
+        *i_end = i_node + 1;
+    }
 }
 
 
 void initLBVHNode(__global struct Node *nodes, int i_node, __global const morton_t *codes, int N, __global const float *pxs, __global const float *pys, __global const float *mxs)
 {
-    // TODO
+    // инициализация ссылок на соседей для нод lbvh
+    // если мы лист, то просто инициализируем минус единицами (нет детей), иначе ищем своб зону ответственности и запускаем на ней findSplit
+    // можно заполнить пропуски в виде тудушек, можно реализовать с чистого листа самостоятельно, если так проще
+
+    clear(&nodes[i_node].bbox);
+    nodes[i_node].mass = 0;
+    nodes[i_node].cmsx = 0;
+    nodes[i_node].cmsy = 0;
+
+    // первые N-1 элементов - внутренние ноды, за ними N листьев
+
+    // инициализируем лист
+    if (i_node >= N-1) {
+        nodes[i_node].child_left = -1;
+        nodes[i_node].child_right = -1;
+        int i_point = i_node - (N-1);
+
+        const int index = getIndex(codes[i_point]);
+        float center_mass_x = pxs[index];
+        float center_mass_y = pys[index];
+        float mass = mxs[index];
+
+        growPoint(&nodes[i_node].bbox, center_mass_x, center_mass_y);
+        nodes[i_node].cmsx = center_mass_x;
+        nodes[i_node].cmsy = center_mass_y;
+        nodes[i_node].mass = mass;
+
+        return;
+    }
+
+    // инициализируем внутреннюю ноду
+
+    int i_begin = 0, i_end = N, bit_index = NBITS-1;
+    // если рассматриваем не корень, то нужно найти зону ответственности ноды и самый старший бит, с которого надо начинать поиск разреза
+    if (i_node) {
+        // TODO
+        findRegion(&i_begin, &i_end, &bit_index, codes, N, i_node);
+    }
+
+    bool found = false;
+    for (int i_bit = bit_index; i_bit >= 0; --i_bit) {
+        int split = findSplit(codes, i_begin, i_end, i_bit);
+        if (split < 0) continue;
+
+        if (split < 1) {
+            printf("15043204230042342");
+        }
+        // TODO проинициализировать nodes[i_node].child_left, nodes[i_node].child_right на основе i_begin, i_end, split
+        //   не забудьте на N-1 сдвинуть индексы, указывающие на листья
+        nodes[i_node].child_left = split - 1 + ((split - i_begin == 1) ? N -1 : 0);
+        nodes[i_node].child_right = split + ((i_end - split == 1) ? N -1 : 0);
+
+        found = true;
+        break;
+    }
+
+    if (!found) {
+        printf("5154356549645");
+    }
 }
 
 __kernel void buidLBVH(__global const float *pxs, __global const float *pys, __global const float *mxs,
                        __global const morton_t *codes, __global struct Node *nodes,
                        int N)
 {
-    // TODO
+    const int i_node = get_global_id(0);
+    const int tree_size = LBVHSize(N);
+
+    if (i_node >= tree_size) return;
+
+    initLBVHNode(nodes, i_node, codes, N, pxs, pys, mxs);
 }
 
 void initFlag(__global int *flags, int i_node, __global const struct Node *nodes, int level)
@@ -300,6 +462,73 @@ bool barnesHutCondition(float x, float y, __global const struct Node *node)
 void calculateForce(float x0, float y0, float m0, __global const struct Node *nodes, __global float *force_x, __global float *force_y)
 {
     // TODO
+    // основная идея ускорения - аггрегировать в узлах дерева веса и центры масс,
+    //   и не спускаться внутрь, если точка запроса не пересекает ноду, а заменить на взаимодействие с ее центром масс
+
+    int stack[2 * NBITS_PER_DIM];
+    int stack_size = 0;
+    // TODO кладем корень на стек
+    stack[stack_size++] = 0;
+    while (stack_size) {
+        // TODO берем ноду со стека
+        __global const struct Node* node = &nodes[stack[--stack_size]];
+
+        if (isLeaf(node)) {
+            continue;
+        }
+
+        // если запрос содержится и а левом и в правом ребенке - то они в одном пикселе
+        {
+            __global const struct Node* left = &nodes[node->child_left];
+            __global const struct Node* right = &nodes[node->child_right];
+            if (contains(&left->bbox, x0, y0) && contains(&right->bbox, x0, y0)) {
+                if (!equals(&left->bbox, &right->bbox)) {
+                    printf("142357987645432456547");
+                }
+                if (!equalsPoint(&left->bbox, x0, y0)) {
+                    printf("51446456456435656");
+                }
+                continue;
+            }
+        }
+        const int SIZE = 2;
+        int indexes[SIZE]; 
+        indexes[0] = node->child_left;
+        indexes[1] = node->child_right;
+        for (int i = 0; i < SIZE; i++) {
+            int i_child = indexes[i];
+            __global const struct Node* child = &nodes[i_child];
+            // С точки зрения ббоксов заходить в ребенка, ббокс которого не пересекаем, не нужно (из-за того, что в листьях у нас точки и они не высовываются за свой регион пространства)
+            //   Но, с точки зрения физики, замена гравитационного влияния всех точек в регионе на взаимодействие с суммарной массой в центре масс - это точное решение только в однородном поле (например, на поверхности земли)
+            //   У нас поле неоднородное, и такая замена - лишь приближение. Чтобы оно было достаточно точным, будем спускаться внутрь ноды, пока она не станет похожа на точечное тело (маленький размер ее ббокса относительно нашего расстояния до центра масс ноды)
+            if (!contains(&child->bbox, x0, y0) && barnesHutCondition(x0, y0, child)) {
+                // TODO посчитать взаимодействие точки с центром масс ноды
+                float x1 = child->cmsx;
+                float y1 = child->cmsy;
+                float m1 = child->mass;
+
+                float dx = x1 - x0;
+                float dy = y1 - y0;
+
+                float dr2 = max(100.f, dx * dx + dy * dy);
+
+                float dr2_inv = 1.f / dr2;
+                float dr_inv = sqrt(dr2_inv);
+
+                float ex = dx * dr_inv;
+                float ey = dy * dr_inv;
+
+                *force_x += m1 * ex * dr2_inv * GRAVITATIONAL_FORCE;
+                *force_y += m1 * ey * dr2_inv * GRAVITATIONAL_FORCE;
+            } else {
+                // TODO кладем ребенка на стек
+                stack[stack_size++] = i_child;
+                if (stack_size >= 2 * NBITS_PER_DIM) {
+                    printf("10420392384283");
+                }
+            }
+        }
+    }
 }
 
 __kernel void calculateForces(
@@ -312,6 +541,17 @@ __kernel void calculateForces(
         int t)
 {
     // TODO
+    int gid = get_global_id(0);
+    if (gid >= N) return;
+
+    __global float * dvx = &dvx2d[t * N];
+    __global float * dvy = &dvy2d[t * N];
+
+    float x0 = pxs[gid];
+    float y0 = pys[gid];
+    float m0 = mxs[gid];
+
+    calculateForce(x0, y0, m0, nodes, &dvx[gid], &dvy[gid]);
 }
 
 __kernel void integrate(

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -362,7 +362,7 @@ void initLBVHNode(__global struct Node *nodes, int i_node, __global const morton
     }
 }
 
-__kernel void buidLBVH(__global const float *pxs, __global const float *pys, __global const float *mxs,
+__kernel void buildLBVH(__global const float *pxs, __global const float *pys, __global const float *mxs,
                        __global const morton_t *codes, __global struct Node *nodes,
                        int N)
 {

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -194,7 +194,7 @@ void __kernel merge(__global const morton_t *as, __global morton_t *as_sorted, u
 int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_index)
 {
     // TODO
-        // Если биты в начале и в конце совпадают, то этот бит незначащий
+    // Если биты в начале и в конце совпадают, то этот бит незначащий
     if (getBit(codes[i_begin], bit_index) == getBit(codes[i_end-1], bit_index)) {
         return -1;
     }
@@ -229,18 +229,12 @@ void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_
     morton_t lmorton = codes[i_node - 1];
     morton_t mmorton = codes[i_node];
     morton_t rmorton = codes[i_node + 1];
-    const int right = 1, left = 3;
     for (; i_bit >= 0; --i_bit) {
         // TODO найти dir и значащий бит
-        int m = (!!getBit(lmorton, i_bit) << 2) |
-                (!!getBit(mmorton, i_bit) << 1) |
-                !!getBit(rmorton, i_bit);
-        if (m == left) {
-            dir = 1;
-            break;
-        }
-        if (m == right) {
-            dir = -1;
+        int lb = getBit(lmorton, i_bit);
+        int rb = getBit(rmorton, i_bit);
+        if (lb != rb) {
+            dir = getBit(mmorton, i_bit) * 2 - 1;
             break;
         }
     }

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -211,12 +211,7 @@ int findSplit(__global const morton_t *codes, int i_begin, int i_end, int bit_in
             r = m;
         }
     }
-    if (getBit(codes[l], bit_index) < getBit(codes[r], bit_index)) {
-        return r;
-    }
-
-    // избыточно, так как на входе в функцию проверили, что ответ существует, но приятно иметь sanity-check на случай если набагали
-    printf("451932492039458209485");
+    return r;
 }
 
 void findRegion(int *i_begin, int *i_end, int *bit_index, __global const morton_t *codes, int N, int i_node)

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -1,49 +1,62 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
 #define GRAVITATIONAL_FORCE 0.0001
 
-__kernel void nbody_calculate_force_global(
-    __global float * pxs, __global float * pys,
-    __global float *vxs, __global float *vys,
-    __global const float *mxs,
-    __global float * dvx2d, __global float * dvy2d,
-    int N,
-    int t)
-{
+__kernel void nbody_calculate_force_global(__global float *pxs, __global float *pys, __global float *vxs,
+                                           __global float *vys, __global const float *mxs, __global float *dvx2d,
+                                           __global float *dvy2d, int N, int t) {
     unsigned int i = get_global_id(0);
 
     if (i >= N)
         return;
 
-    __global float * dvx = dvx2d + t * N;
-    __global float * dvy = dvy2d + t * N;
+    __global float *dvx = dvx2d + t * N;
+    __global float *dvy = dvy2d + t * N;
 
     float x0 = pxs[i];
     float y0 = pys[i];
     float m0 = mxs[i];
 
-    // TODO
+    for (int j = 0; j < N; ++j) {
+        if (j == i) {
+            continue;
+        }
+
+        float x1 = pxs[j];
+        float y1 = pys[j];
+        float m1 = mxs[j];
+
+        float dx = x1 - x0;
+        float dy = y1 - y0;
+        float dr2 = max(100.f, dx * dx + dy * dy);
+
+        float dr2_inv = 1.f / dr2;
+        float dr_inv = sqrt(dr2_inv);
+
+        float ex = dx * dr_inv;
+        float ey = dy * dr_inv;
+
+        float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
+        float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
+
+        dvx[i] += m1 * fx;
+        dvy[i] += m1 * fy;
+    }
 }
 
-__kernel void nbody_integrate(
-        __global float * pxs, __global float * pys,
-        __global float *vxs, __global float *vys,
-        __global const float *mxs,
-        __global float * dvx2d, __global float * dvy2d,
-        int N,
-        int t)
-{
+__kernel void nbody_integrate(__global float *pxs, __global float *pys, __global float *vxs, __global float *vys,
+                              __global const float *mxs, __global float *dvx2d, __global float *dvy2d, int N, int t) {
     unsigned int i = get_global_id(0);
 
     if (i >= N)
         return;
 
-    __global float * dvx = dvx2d + t * N;
-    __global float * dvy = dvy2d + t * N;
+    __global float *dvx = dvx2d + t * N;
+    __global float *dvy = dvy2d + t * N;
 
     vxs[i] += dvx[i];
     vys[i] += dvy[i];

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -20,7 +20,7 @@
 #define OPENCL_DEVICE_INDEX 0
 
 // TODO включить чтобы начали запускаться тесты
-#define ENABLE_TESTING 0
+#define ENABLE_TESTING 1
 
 // имеет смысл отключать при оффлайн симуляции больших N, но в итоговом решении стоит оставить
 #define EVALUATE_PRECISION 1
@@ -195,7 +195,6 @@ morton_t zOrder(const Point &coord, int i){
     int x = coord.x;
     int y = coord.y;
 
-    throw std::runtime_error("not implemented");
 //  TODO
     morton_t morton_code = spreadBits(coord.x) * 2 | spreadBits(coord.y);
 
@@ -1703,279 +1702,279 @@ TEST (LBVH, CPU)
     }
 }
 
-TEST (LBVH, GPU)
-{
-    if (!ENABLE_TESTING)
-        return;
+// TEST (LBVH, GPU)
+// {
+//     if (!ENABLE_TESTING)
+//         return;
 
-    gpu::Device device = gpu::chooseGPUDevice(OPENCL_DEVICE_INDEX);
-    gpu::Context context;
-    context.init(device.device_id_opencl);
-    context.activate();
+//     gpu::Device device = gpu::chooseGPUDevice(OPENCL_DEVICE_INDEX);
+//     gpu::Context context;
+//     context.init(device.device_id_opencl);
+//     context.activate();
 
-    std::srand(1);
+//     std::srand(1);
 
-    int N = 100000;
-    std::vector<float> pxs(N);
-    std::vector<float> pys(N);
-    std::vector<float> mxs(N);
-    std::vector<morton_t> codes(N);
-    for (int i = 0; i < N; ++i) {
-        pxs[i] = std::rand() % (1 << NBITS_PER_DIM);
-        pys[i] = std::rand() % (1 << NBITS_PER_DIM);
-        mxs[i] = 100;
-    }
+//     int N = 100000;
+//     std::vector<float> pxs(N);
+//     std::vector<float> pys(N);
+//     std::vector<float> mxs(N);
+//     std::vector<morton_t> codes(N);
+//     for (int i = 0; i < N; ++i) {
+//         pxs[i] = std::rand() % (1 << NBITS_PER_DIM);
+//         pys[i] = std::rand() % (1 << NBITS_PER_DIM);
+//         mxs[i] = 100;
+//     }
 
-    const points_mass_functor points_mass_array = [&](int i) { return std::make_tuple(pxs[i], pys[i], mxs[i]); };
+//     const points_mass_functor points_mass_array = [&](int i) { return std::make_tuple(pxs[i], pys[i], mxs[i]); };
 
-    unsigned int workGroupSize = 128;
-    unsigned int global_work_size_points = (N + workGroupSize - 1) / workGroupSize * workGroupSize;
-    unsigned int global_work_size_nodes = (LBVHSize(N) + workGroupSize - 1) / workGroupSize * workGroupSize;
-    ocl::Kernel kernel_generate_morton_codes(lbvh_kernel, lbvh_kernel_length, "generateMortonCodes");
-    kernel_generate_morton_codes.compile();
-    gpu::gpu_mem_32f pxs_gpu, pys_gpu, mxs_gpu;
-    gpu::shared_device_buffer_typed<morton_t> codes_gpu;
+//     unsigned int workGroupSize = 128;
+//     unsigned int global_work_size_points = (N + workGroupSize - 1) / workGroupSize * workGroupSize;
+//     unsigned int global_work_size_nodes = (LBVHSize(N) + workGroupSize - 1) / workGroupSize * workGroupSize;
+//     ocl::Kernel kernel_generate_morton_codes(lbvh_kernel, lbvh_kernel_length, "generateMortonCodes");
+//     kernel_generate_morton_codes.compile();
+//     gpu::gpu_mem_32f pxs_gpu, pys_gpu, mxs_gpu;
+//     gpu::shared_device_buffer_typed<morton_t> codes_gpu;
 
-    pxs_gpu.resizeN(N);
-    pys_gpu.resizeN(N);
-    mxs_gpu.resizeN(N);
-    codes_gpu.resizeN(N);
+//     pxs_gpu.resizeN(N);
+//     pys_gpu.resizeN(N);
+//     mxs_gpu.resizeN(N);
+//     codes_gpu.resizeN(N);
 
-    pxs_gpu.writeN(pxs.data(), N);
-    pys_gpu.writeN(pys.data(), N);
-    mxs_gpu.writeN(mxs.data(), N);
-
-
-    // GENERATE MORTON CODES
-
-    kernel_generate_morton_codes.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
-                                      pxs_gpu, pys_gpu,
-                                      codes_gpu,
-                                      N);
-
-    codes_gpu.readN(codes.data(), N);
-
-    for (int i = 0; i < N; ++i) {
-        EXPECT_EQ(codes[i], zOrder(makePoint(pxs[i], pys[i]), i));
-    }
+//     pxs_gpu.writeN(pxs.data(), N);
+//     pys_gpu.writeN(pys.data(), N);
+//     mxs_gpu.writeN(mxs.data(), N);
 
 
-    // SORT MORTON CODES
+//     // GENERATE MORTON CODES
 
-    ocl::Kernel kernel_merge(lbvh_kernel, lbvh_kernel_length, "merge");
-    kernel_merge.compile();
+//     kernel_generate_morton_codes.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
+//                                       pxs_gpu, pys_gpu,
+//                                       codes_gpu,
+//                                       N);
 
-    gpu::gpu_mem_64f codes_gpu_buf;
-    codes_gpu_buf.resizeN(N);
-    for (unsigned int subn = 1; subn < N; subn *= 2) {
-        kernel_merge.exec(gpu::WorkSize(workGroupSize, global_work_size_points), codes_gpu, codes_gpu_buf, N, subn);
-        codes_gpu.swap(codes_gpu_buf);
-    }
-    std::vector<morton_t> codes_tmp = codes;
-    codes_gpu.readN(codes.data(), N);
-    {
-        std::sort(codes_tmp.begin(), codes_tmp.end());
-        for (int i = 1; i < N; ++i) {
-            EXPECT_LE(codes_tmp[i-1], codes_tmp[i]);
-        }
-        for (int i = 1; i < N; ++i) {
-            EXPECT_LE(codes[i-1], codes[i]);
-        }
-        for (int i = 0; i < N; ++i) {
-            EXPECT_EQ(codes_tmp[i], codes[i]);
-        }
-    }
+//     codes_gpu.readN(codes.data(), N);
+
+//     for (int i = 0; i < N; ++i) {
+//         EXPECT_EQ(codes[i], zOrder(makePoint(pxs[i], pys[i]), i));
+//     }
 
 
-    // BUILD LBVH
+//     // SORT MORTON CODES
 
-    const int tree_size = LBVHSize(N);
+//     ocl::Kernel kernel_merge(lbvh_kernel, lbvh_kernel_length, "merge");
+//     kernel_merge.compile();
 
-    std::vector<Node> nodes(tree_size);
-    // init with something just for test
-    for (int i = 0; i < tree_size; ++i) {
-        Node &n = nodes[i];
-        n.mass = std::rand();
-        n.cmsx = std::rand();
-        n.cmsy = std::rand();
-        n.child_right = std::rand();
-        n.child_left = std::rand();
-        n.bbox.grow(makePoint(std::rand(), std::rand()));
-    }
-    std::vector<Node> nodes_cpu = nodes;
-
-    gpu::gpu_mem_any nodes_gpu;
-    nodes_gpu.resize(tree_size * sizeof(Node));
-
-    {
-        nodes_gpu.write(nodes.data(), tree_size * sizeof(Node));
-        std::vector<Node> tmp(tree_size);
-        nodes_gpu.read(tmp.data(), tree_size * sizeof(Node));
-
-        for (int i = 0; i < tree_size; ++i) {
-            EXPECT_EQ(tmp[i], nodes[i]);
-        }
-    }
-
-    ocl::Kernel kernel_build_lbvh(lbvh_kernel, lbvh_kernel_length, "buidLBVH");
-    kernel_build_lbvh.compile();
-
-    kernel_build_lbvh.exec(gpu::WorkSize(workGroupSize, global_work_size_nodes),
-                           pxs_gpu, pys_gpu, mxs_gpu,
-                           codes_gpu, nodes_gpu,
-                           N);
+//     gpu::gpu_mem_64f codes_gpu_buf;
+//     codes_gpu_buf.resizeN(N);
+//     for (unsigned int subn = 1; subn < N; subn *= 2) {
+//         kernel_merge.exec(gpu::WorkSize(workGroupSize, global_work_size_points), codes_gpu, codes_gpu_buf, N, subn);
+//         codes_gpu.swap(codes_gpu_buf);
+//     }
+//     std::vector<morton_t> codes_tmp = codes;
+//     codes_gpu.readN(codes.data(), N);
+//     {
+//         std::sort(codes_tmp.begin(), codes_tmp.end());
+//         for (int i = 1; i < N; ++i) {
+//             EXPECT_LE(codes_tmp[i-1], codes_tmp[i]);
+//         }
+//         for (int i = 1; i < N; ++i) {
+//             EXPECT_LE(codes[i-1], codes[i]);
+//         }
+//         for (int i = 0; i < N; ++i) {
+//             EXPECT_EQ(codes_tmp[i], codes[i]);
+//         }
+//     }
 
 
-    nodes_gpu.read(nodes.data(), tree_size * sizeof(Node));
+//     // BUILD LBVH
 
-    for (int i = 0; i < tree_size; ++i) {
-        initLBVHNode(nodes_cpu, i, codes, points_mass_array);
-    }
+//     const int tree_size = LBVHSize(N);
 
-    for (int i = 0; i < tree_size; ++i) {
-        EXPECT_EQ(nodes[i], nodes_cpu[i]);
-    }
+//     std::vector<Node> nodes(tree_size);
+//     // init with something just for test
+//     for (int i = 0; i < tree_size; ++i) {
+//         Node &n = nodes[i];
+//         n.mass = std::rand();
+//         n.cmsx = std::rand();
+//         n.cmsy = std::rand();
+//         n.child_right = std::rand();
+//         n.child_left = std::rand();
+//         n.bbox.grow(makePoint(std::rand(), std::rand()));
+//     }
+//     std::vector<Node> nodes_cpu = nodes;
+
+//     gpu::gpu_mem_any nodes_gpu;
+//     nodes_gpu.resize(tree_size * sizeof(Node));
+
+//     {
+//         nodes_gpu.write(nodes.data(), tree_size * sizeof(Node));
+//         std::vector<Node> tmp(tree_size);
+//         nodes_gpu.read(tmp.data(), tree_size * sizeof(Node));
+
+//         for (int i = 0; i < tree_size; ++i) {
+//             EXPECT_EQ(tmp[i], nodes[i]);
+//         }
+//     }
+
+//     ocl::Kernel kernel_build_lbvh(lbvh_kernel, lbvh_kernel_length, "buidLBVH");
+//     kernel_build_lbvh.compile();
+
+//     kernel_build_lbvh.exec(gpu::WorkSize(workGroupSize, global_work_size_nodes),
+//                            pxs_gpu, pys_gpu, mxs_gpu,
+//                            codes_gpu, nodes_gpu,
+//                            N);
 
 
-    // BUILD BBOXES AND AGGREGATE MASS INFO
+//     nodes_gpu.read(nodes.data(), tree_size * sizeof(Node));
 
-    // аналог buildBBoxes
-    {
-        gpu::gpu_mem_32i flags_gpu;
-        flags_gpu.resizeN(N);
+//     for (int i = 0; i < tree_size; ++i) {
+//         initLBVHNode(nodes_cpu, i, codes, points_mass_array);
+//     }
 
-        ocl::Kernel kernel_init_flags(lbvh_kernel, lbvh_kernel_length, "initFlags");
-        ocl::Kernel kernel_grow_nodes(lbvh_kernel, lbvh_kernel_length, "growNodes");
+//     for (int i = 0; i < tree_size; ++i) {
+//         EXPECT_EQ(nodes[i], nodes_cpu[i]);
+//     }
 
-        kernel_init_flags.compile();
-        kernel_grow_nodes.compile();
 
-        for (int level = 0; level < NBITS; ++level) {
+//     // BUILD BBOXES AND AGGREGATE MASS INFO
 
-            kernel_init_flags.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
-                                   flags_gpu, nodes_gpu,
-                                   N, level);
+//     // аналог buildBBoxes
+//     {
+//         gpu::gpu_mem_32i flags_gpu;
+//         flags_gpu.resizeN(N);
 
-            kernel_grow_nodes.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
-                                   flags_gpu, nodes_gpu,
-                                   N, level);
+//         ocl::Kernel kernel_init_flags(lbvh_kernel, lbvh_kernel_length, "initFlags");
+//         ocl::Kernel kernel_grow_nodes(lbvh_kernel, lbvh_kernel_length, "growNodes");
 
-            int n_updated;
-            flags_gpu.readN(&n_updated, 1, N-1);
+//         kernel_init_flags.compile();
+//         kernel_grow_nodes.compile();
 
-            //            std::cout << "n updated: " << n_updated << std::endl;
+//         for (int level = 0; level < NBITS; ++level) {
 
-            if (!n_updated)
-                break;
-        }
+//             kernel_init_flags.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
+//                                    flags_gpu, nodes_gpu,
+//                                    N, level);
 
-        nodes_gpu.read(nodes.data(), tree_size * sizeof(Node));
+//             kernel_grow_nodes.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
+//                                    flags_gpu, nodes_gpu,
+//                                    N, level);
 
-        std::vector<int> flags;
-        buildBBoxes(nodes_cpu, flags, N);
+//             int n_updated;
+//             flags_gpu.readN(&n_updated, 1, N-1);
 
-        for (int i = 0; i < tree_size; ++i) {
-            EXPECT_EQ(nodes[i], nodes_cpu[i]);
-        }
-    }
+//             //            std::cout << "n updated: " << n_updated << std::endl;
 
-    std::vector<float> vxs(N);
-    std::vector<float> vys(N);
-    std::vector<float> dvx(N);
-    std::vector<float> dvy(N);
+//             if (!n_updated)
+//                 break;
+//         }
 
-    gpu::gpu_mem_32f vxs_gpu, vys_gpu;
-    gpu::gpu_mem_32f dvx_gpu, dvy_gpu;
+//         nodes_gpu.read(nodes.data(), tree_size * sizeof(Node));
 
-    vxs_gpu.resizeN(N);
-    vys_gpu.resizeN(N);
-    dvx_gpu.resizeN(N);
-    dvy_gpu.resizeN(N);
+//         std::vector<int> flags;
+//         buildBBoxes(nodes_cpu, flags, N);
 
-    vxs_gpu.writeN(vxs.data(), N);
-    vys_gpu.writeN(vys.data(), N);
-    dvx_gpu.writeN(dvx.data(), N);
-    dvy_gpu.writeN(dvy.data(), N);
+//         for (int i = 0; i < tree_size; ++i) {
+//             EXPECT_EQ(nodes[i], nodes_cpu[i]);
+//         }
+//     }
 
-    std::vector<float> pxs_cpu = pxs;
-    std::vector<float> pys_cpu = pys;
-    std::vector<float> vxs_cpu = vxs;
-    std::vector<float> vys_cpu = vys;
-    std::vector<float> dvx_cpu = dvx;
-    std::vector<float> dvy_cpu = dvy;
+//     std::vector<float> vxs(N);
+//     std::vector<float> vys(N);
+//     std::vector<float> dvx(N);
+//     std::vector<float> dvy(N);
 
-    {
-        ocl::Kernel kernel_calculate_forces(lbvh_kernel, lbvh_kernel_length, "calculateForces");
-        ocl::Kernel kernel_integrate(lbvh_kernel, lbvh_kernel_length, "integrate");
+//     gpu::gpu_mem_32f vxs_gpu, vys_gpu;
+//     gpu::gpu_mem_32f dvx_gpu, dvy_gpu;
 
-        kernel_calculate_forces.compile();
-        kernel_integrate.compile();
+//     vxs_gpu.resizeN(N);
+//     vys_gpu.resizeN(N);
+//     dvx_gpu.resizeN(N);
+//     dvy_gpu.resizeN(N);
 
-        int t = 0;
-        int coord_shift = 0;
+//     vxs_gpu.writeN(vxs.data(), N);
+//     vys_gpu.writeN(vys.data(), N);
+//     dvx_gpu.writeN(dvx.data(), N);
+//     dvy_gpu.writeN(dvy.data(), N);
 
-        kernel_calculate_forces.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
-                                     pxs_gpu, pys_gpu, vxs_gpu, vys_gpu,
-                                     mxs_gpu, nodes_gpu,
-                                     dvx_gpu, dvy_gpu,
-                                     N, t);
+//     std::vector<float> pxs_cpu = pxs;
+//     std::vector<float> pys_cpu = pys;
+//     std::vector<float> vxs_cpu = vxs;
+//     std::vector<float> vys_cpu = vys;
+//     std::vector<float> dvx_cpu = dvx;
+//     std::vector<float> dvy_cpu = dvy;
 
-        kernel_integrate.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
-                              pxs_gpu, pys_gpu, vxs_gpu, vys_gpu,
-                              mxs_gpu,
-                              dvx_gpu, dvy_gpu,
-                              N, t, coord_shift);
+//     {
+//         ocl::Kernel kernel_calculate_forces(lbvh_kernel, lbvh_kernel_length, "calculateForces");
+//         ocl::Kernel kernel_integrate(lbvh_kernel, lbvh_kernel_length, "integrate");
 
-        pxs_gpu.readN(pxs.data(), N);
-        pys_gpu.readN(pys.data(), N);
-        vxs_gpu.readN(vxs.data(), N);
-        vys_gpu.readN(vys.data(), N);
-        dvx_gpu.readN(dvx.data(), N);
-        dvy_gpu.readN(dvy.data(), N);
-    }
+//         kernel_calculate_forces.compile();
+//         kernel_integrate.compile();
 
-    {
-        for (int i = 0; i < N; ++i) {
-            float x0 = pxs_cpu[i];
-            float y0 = pys_cpu[i];
-            float m0 = mxs[i];
-            calculateForce(x0, y0, m0, nodes_cpu, &dvx_cpu[i], &dvy_cpu[i]);
-        }
+//         int t = 0;
+//         int coord_shift = 0;
 
-        int n_super_good_pxs = 0;
-        int n_super_good_pys = 0;
-        int n_super_good_vxs = 0;
-        int n_super_good_vys = 0;
-        int n_super_good_dvx = 0;
-        int n_super_good_dvy = 0;
-        for (int i = 0; i < N; ++i) {
-            integrate(i, pxs_cpu, pys_cpu, vxs_cpu, vys_cpu, dvx_cpu.data(), dvy_cpu.data(), 0);
+//         kernel_calculate_forces.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
+//                                      pxs_gpu, pys_gpu, vxs_gpu, vys_gpu,
+//                                      mxs_gpu, nodes_gpu,
+//                                      dvx_gpu, dvy_gpu,
+//                                      N, t);
 
-            double rel_eps_super_good = 1e-3;
-            if (std::abs(pxs[i] - pxs_cpu[i]) < rel_eps_super_good * std::abs(pxs_cpu[i])) n_super_good_pxs++;
-            if (std::abs(pys[i] - pys_cpu[i]) < rel_eps_super_good * std::abs(pys_cpu[i])) n_super_good_pys++;
-            if (std::abs(vxs[i] - vxs_cpu[i]) < rel_eps_super_good * std::abs(vxs_cpu[i])) n_super_good_vxs++;
-            if (std::abs(vys[i] - vys_cpu[i]) < rel_eps_super_good * std::abs(vys_cpu[i])) n_super_good_vys++;
-            if (std::abs(dvx[i] - dvx_cpu[i]) < rel_eps_super_good * std::abs(dvx_cpu[i])) n_super_good_dvx++;
-            if (std::abs(dvy[i] - dvy_cpu[i]) < rel_eps_super_good * std::abs(dvy_cpu[i])) n_super_good_dvy++;
+//         kernel_integrate.exec(gpu::WorkSize(workGroupSize, global_work_size_points),
+//                               pxs_gpu, pys_gpu, vxs_gpu, vys_gpu,
+//                               mxs_gpu,
+//                               dvx_gpu, dvy_gpu,
+//                               N, t, coord_shift);
 
-            double rel_eps = 0.5;
-            EXPECT_NEAR(pxs[i], pxs_cpu[i], rel_eps * std::abs(pxs_cpu[i]));
-            EXPECT_NEAR(pys[i], pys_cpu[i], rel_eps * std::abs(pys_cpu[i]));
-            EXPECT_NEAR(vxs[i], vxs_cpu[i], rel_eps * std::abs(vxs_cpu[i]));
-            EXPECT_NEAR(vys[i], vys_cpu[i], rel_eps * std::abs(vys_cpu[i]));
-            EXPECT_NEAR(dvx[i], dvx_cpu[i], rel_eps * std::abs(dvx_cpu[i]));
-            EXPECT_NEAR(dvy[i], dvy_cpu[i], rel_eps * std::abs(dvy_cpu[i]));
-        }
+//         pxs_gpu.readN(pxs.data(), N);
+//         pys_gpu.readN(pys.data(), N);
+//         vxs_gpu.readN(vxs.data(), N);
+//         vys_gpu.readN(vys.data(), N);
+//         dvx_gpu.readN(dvx.data(), N);
+//         dvy_gpu.readN(dvy.data(), N);
+//     }
 
-        EXPECT_GE(n_super_good_pxs, 0.99 * N);
-        EXPECT_GE(n_super_good_pys, 0.99 * N);
-        EXPECT_GE(n_super_good_vxs, 0.99 * N);
-        EXPECT_GE(n_super_good_vys, 0.99 * N);
-        EXPECT_GE(n_super_good_dvx, 0.99 * N);
-        EXPECT_GE(n_super_good_dvy, 0.99 * N);
-    }
-}
+//     {
+//         for (int i = 0; i < N; ++i) {
+//             float x0 = pxs_cpu[i];
+//             float y0 = pys_cpu[i];
+//             float m0 = mxs[i];
+//             calculateForce(x0, y0, m0, nodes_cpu, &dvx_cpu[i], &dvy_cpu[i]);
+//         }
+
+//         int n_super_good_pxs = 0;
+//         int n_super_good_pys = 0;
+//         int n_super_good_vxs = 0;
+//         int n_super_good_vys = 0;
+//         int n_super_good_dvx = 0;
+//         int n_super_good_dvy = 0;
+//         for (int i = 0; i < N; ++i) {
+//             integrate(i, pxs_cpu, pys_cpu, vxs_cpu, vys_cpu, dvx_cpu.data(), dvy_cpu.data(), 0);
+
+//             double rel_eps_super_good = 1e-3;
+//             if (std::abs(pxs[i] - pxs_cpu[i]) < rel_eps_super_good * std::abs(pxs_cpu[i])) n_super_good_pxs++;
+//             if (std::abs(pys[i] - pys_cpu[i]) < rel_eps_super_good * std::abs(pys_cpu[i])) n_super_good_pys++;
+//             if (std::abs(vxs[i] - vxs_cpu[i]) < rel_eps_super_good * std::abs(vxs_cpu[i])) n_super_good_vxs++;
+//             if (std::abs(vys[i] - vys_cpu[i]) < rel_eps_super_good * std::abs(vys_cpu[i])) n_super_good_vys++;
+//             if (std::abs(dvx[i] - dvx_cpu[i]) < rel_eps_super_good * std::abs(dvx_cpu[i])) n_super_good_dvx++;
+//             if (std::abs(dvy[i] - dvy_cpu[i]) < rel_eps_super_good * std::abs(dvy_cpu[i])) n_super_good_dvy++;
+
+//             double rel_eps = 0.5;
+//             EXPECT_NEAR(pxs[i], pxs_cpu[i], rel_eps * std::abs(pxs_cpu[i]));
+//             EXPECT_NEAR(pys[i], pys_cpu[i], rel_eps * std::abs(pys_cpu[i]));
+//             EXPECT_NEAR(vxs[i], vxs_cpu[i], rel_eps * std::abs(vxs_cpu[i]));
+//             EXPECT_NEAR(vys[i], vys_cpu[i], rel_eps * std::abs(vys_cpu[i]));
+//             EXPECT_NEAR(dvx[i], dvx_cpu[i], rel_eps * std::abs(dvx_cpu[i]));
+//             EXPECT_NEAR(dvy[i], dvy_cpu[i], rel_eps * std::abs(dvy_cpu[i]));
+//         }
+
+//         EXPECT_GE(n_super_good_pxs, 0.99 * N);
+//         EXPECT_GE(n_super_good_pys, 0.99 * N);
+//         EXPECT_GE(n_super_good_vxs, 0.99 * N);
+//         EXPECT_GE(n_super_good_vys, 0.99 * N);
+//         EXPECT_GE(n_super_good_dvx, 0.99 * N);
+//         EXPECT_GE(n_super_good_dvy, 0.99 * N);
+//     }
+// }
 
 TEST (LBVH, Nbody)
 {
@@ -1994,21 +1993,21 @@ TEST (LBVH, Nbody)
     nbody(false, evaluate_precision, 1); // gpu naive
 #endif
     nbody(false, evaluate_precision, 2); // cpu lbvh
-    nbody(false, evaluate_precision, 3); // gpu lbvh
+    // nbody(false, evaluate_precision, 3); // gpu lbvh
 }
 
-TEST (LBVH, Nbody_meditation)
-{
-    if (!ENABLE_TESTING)
-        return;
+// TEST (LBVH, Nbody_meditation)
+// {
+//     if (!ENABLE_TESTING)
+//         return;
 
-    if (!ENABLE_GUI)
-        return;
+//     if (!ENABLE_GUI)
+//         return;
 
-    gpu::Device device = gpu::chooseGPUDevice(OPENCL_DEVICE_INDEX);
-    gpu::Context context;
-    context.init(device.device_id_opencl);
-    context.activate();
+//     gpu::Device device = gpu::chooseGPUDevice(OPENCL_DEVICE_INDEX);
+//     gpu::Context context;
+//     context.init(device.device_id_opencl);
+//     context.activate();
 
-    nbody(true, false, 3); // gpu lbvh
-}
+//     nbody(true, false, 3); // gpu lbvh
+// }

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1002,7 +1002,17 @@ int findSplit(const std::vector<morton_t> &codes, int i_begin, int i_end, int bi
     //    }
 
     // TODO бинпоиск для нахождения разбиения области ответственности ноды
-    throw std::runtime_error("not implemented");
+    int l = i_begin, r = i_end - 1;
+    while (l + 1 < r) {
+        int m = (l + r) / 2;
+        int a = getBit(codes[l], bit_index);
+        int b = getBit(codes[m], bit_index);
+        if (a == b) {
+            l = m;
+        } else {
+            r = m;
+        }
+    }
 
     // избыточно, так как на входе в функцию проверили, что ответ существует, но приятно иметь sanity-check на случай если набагали
     throw std::runtime_error("4932492039458209485");

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -17,7 +17,7 @@
 
 
 // может понадобиться поменять индекс локально чтобы выбрать GPU если у вас более одного девайса
-#define OPENCL_DEVICE_INDEX 1
+#define OPENCL_DEVICE_INDEX 0
 
 // TODO включить чтобы начали запускаться тесты
 #define ENABLE_TESTING 1
@@ -26,7 +26,7 @@
 #define EVALUATE_PRECISION 1
 
 // удобно включить при локальном тестировании
-#define ENABLE_GUI 1
+#define ENABLE_GUI 0
 
 // сброс картинок симуляции на диск
 #define SAVE_IMAGES 0
@@ -1003,12 +1003,7 @@ int findSplit(const std::vector<morton_t> &codes, int i_begin, int i_end, int bi
             r = m;
         }
     }
-    if (getBit(codes[l], bit_index) < getBit(codes[r], bit_index)) {
-        return r;
-    }
-
-    // избыточно, так как на входе в функцию проверили, что ответ существует, но приятно иметь sanity-check на случай если набагали
-    throw std::runtime_error("4932492039458209485");
+    return r;
 }
 
 void buildLBVHRecursive(std::vector<Node> &nodes, const std::vector<morton_t> &codes, const std::vector<Point> &points, int i_begin, int i_end, int bit_index)

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1785,7 +1785,7 @@ TEST (LBVH, CPU)
 //         }
 //     }
 
-//     ocl::Kernel kernel_build_lbvh(lbvh_kernel, lbvh_kernel_length, "buidLBVH");
+//     ocl::Kernel kernel_build_lbvh(lbvh_kernel, lbvh_kernel_length, "buildLBVH");
 //     kernel_build_lbvh.compile();
 
 //     kernel_build_lbvh.exec(gpu::WorkSize(workGroupSize, global_work_size_nodes),
@@ -1797,7 +1797,7 @@ TEST (LBVH, CPU)
 //     nodes_gpu.read(nodes.data(), tree_size * sizeof(Node));
 
 //     for (int i = 0; i < tree_size; ++i) {
-//         initLBVHNode(nodes_cpu, i, codes, points_mass_array);
+        // initLBVHNode(nodes_cpu, i, codes, points_mass_array);
 //     }
 
 //     for (int i = 0; i < tree_size; ++i) {

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -196,10 +196,11 @@ morton_t zOrder(const Point &coord, int i){
     int y = coord.y;
 
     throw std::runtime_error("not implemented");
-//    morton_t morton_code = TODO
-//
-//    // augmentation
-//    return (morton_code << 32) | i;
+//  TODO
+    morton_t morton_code = spreadBits(coord.x) * 2 | spreadBits(coord.y);
+
+    //    augmentation
+    return (morton_code << 32) | i;
 }
 
 #pragma pack (push, 1)
@@ -379,10 +380,10 @@ void calculateForce(float x0, float y0, float m0, const std::vector<Node> &nodes
     int stack[2 * NBITS_PER_DIM];
     int stack_size = 0;
     // TODO кладем корень на стек
-    throw std::runtime_error("not implemented");
-   /* while (stack_size) {
+    stack[stack_size++] = 0;
+    while (stack_size) {
         // TODO берем ноду со стека
-        throw std::runtime_error("not implemented");
+        Node node = nodes[stack[--stack_size]];
 
         if (node.isLeaf()) {
             continue;
@@ -410,16 +411,32 @@ void calculateForce(float x0, float y0, float m0, const std::vector<Node> &nodes
             //   У нас поле неоднородное, и такая замена - лишь приближение. Чтобы оно было достаточно точным, будем спускаться внутрь ноды, пока она не станет похожа на точечное тело (маленький размер ее ббокса относительно нашего расстояния до центра масс ноды)
             if (!child.bbox.contains(x0, y0) && barnesHutCondition(x0, y0, child)) {
                 // TODO посчитать взаимодействие точки с центром масс ноды
-                throw std::runtime_error("not implemented");
+                float x1 = node.cmsx;
+                float y1 = node.cmsy;
+                float m1 = node.mass;
+
+                float dx = x1 - x0;
+                float dy = y1 - y0;
+
+                float dr2 = std::max(100.f, dx * dx + dy * dy);
+
+                float dr2_inv = 1.f / dr2;
+                float dr_inv = std::sqrt(dr2_inv);
+
+                float ex = dx * dr_inv;
+                float ey = dy * dr_inv;
+
+                *force_x += ex * dr2_inv * GRAVITATIONAL_FORCE;
+                *force_y += ey * dr2_inv * GRAVITATIONAL_FORCE;
             } else {
                 // TODO кладем ребенка на стек
-                throw std::runtime_error("not implemented");
+                stack[stack_size++] = i_child;
                 if (stack_size >= 2 * NBITS_PER_DIM) {
                     throw std::runtime_error("0420392384283");
                 }
             }
         }
-    }*/
+    }
 }
 
 void integrate(int i, std::vector<float> &pxs, std::vector<float> &pys, std::vector<float> &vxs, std::vector<float> &vys, float *dvx, float *dvy, int coord_shift)

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1055,18 +1055,12 @@ void findRegion(int *i_begin, int *i_end, int *bit_index, const std::vector<mort
     morton_t lmorton = codes[i_node - 1];
     morton_t mmorton = codes[i_node];
     morton_t rmorton = codes[i_node + 1];
-    const int right = 1, left = 3;
     for (; i_bit >= 0; --i_bit) {
         // TODO найти dir и значащий бит
-        int m = (!!getBit(lmorton, i_bit) << 2) |
-                (!!getBit(mmorton, i_bit) << 1) |
-                !!getBit(rmorton, i_bit);
-        if (m == left) {
-            dir = 1;
-            break;
-        }
-        if (m == right) {
-            dir = -1;
+        int lb = getBit(lmorton, i_bit);
+        int rb = getBit(rmorton, i_bit);
+        if (lb != rb) {
+            dir = getBit(mmorton, i_bit) * 2 - 1;
             break;
         }
     }

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1090,7 +1090,8 @@ void findRegion(int *i_begin, int *i_end, int *bit_index, const std::vector<mort
     // TODO бинпоиск зоны ответственности
 
     int l, r;
-    if (dir > 0) {
+    bool cmp2 = dir > 0;
+    if (cmp2) {
         l = i_node;
         r = N;
     } else {
@@ -1099,10 +1100,12 @@ void findRegion(int *i_begin, int *i_end, int *bit_index, const std::vector<mort
     }
     while (l + 1 < r) {
         int m = (l + r) / 2;
-        if (getBits(codes[m], i_bit, K) == pref0) {
-            ((dir > 0) ? l : r) = m;
-        } else {
-            ((dir > 0) ? r : l) = m;
+        bool cmp1 = getBits(codes[m], i_bit, K) == pref0;
+        if (cmp1 && cmp2 || !cmp1 && !cmp2) {
+            l = m;
+        }
+        if (cmp1 && !cmp2 || !cmp1 && cmp2) {
+            r = m;
         }
     }
     *bit_index = i_bit - 1;

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1087,46 +1087,31 @@ void findRegion(int *i_begin, int *i_end, int *bit_index, const std::vector<mort
     morton_t pref0 = getBits(codes[i_node], i_bit, K);
 
     // граница зоны ответственности - момент, когда префикс перестает совпадать
-    // int i_node_end = (dir > 0) ? N - 2 : i_node;
-    int i_node_end = -1;
-    // наивная версия, линейный поиск, можно использовать для отладки бинпоиска
-       for (int i = i_node; i >= 0 && i < int(codes.size()); i += dir) {
-           if (getBits(codes[i], i_bit, K) == pref0) {
-               i_node_end = i;
-           } else {
-               break;
-           }
-       }
-    // if (i_node_end == -1) {
-    //     throw std::runtime_error("47248457284332098");
-    // }
-
     // TODO бинпоиск зоны ответственности
 
-    // int i_node_end = (dir > 0) ? N - 2 : i_node;
-    // int l, r;
-    // if (dir > 0) {
-    //     l = i_node;
-    //     r = N - 1;
-    // } else {
-    //     l = 0;
-    //     r = i_node;
-    // }
-    // while (l + 1 < r) {
-    //     int m = (l + r) / 2;
-    //     if (getBits(codes[m], i_bit, K) == pref0) {
-    //         ((dir > 0) ? l : r) = m;
-    //     } else {
-    //         ((dir > 0) ? r : l) = m;
-    //     }
-    // }
+    int l, r;
+    if (dir > 0) {
+        l = i_node;
+        r = N;
+    } else {
+        l = -1;
+        r = i_node;
+    }
+    while (l + 1 < r) {
+        int m = (l + r) / 2;
+        if (getBits(codes[m], i_bit, K) == pref0) {
+            ((dir > 0) ? l : r) = m;
+        } else {
+            ((dir > 0) ? r : l) = m;
+        }
+    }
     *bit_index = i_bit - 1;
 
     if (dir > 0) {
         *i_begin = i_node;
-        *i_end = i_node_end + 1;
+        *i_end = r;
     } else {
-        *i_begin = i_node_end;
+        *i_begin = l + 1;
         *i_end = i_node + 1;
     }
 }

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -1185,22 +1185,16 @@ void initLBVHNode(std::vector<Node> &nodes, int i_node, const std::vector<morton
 
     bool found = false;
     for (int i_bit = bit_index; i_bit >= 0; --i_bit) {
-        /*
-        int split = TODO
+        int split = findSplit(codes, i_begin, i_end, i_bit);
         if (split < 0) continue;
 
         if (split < 1) {
             throw std::runtime_error("043204230042342");
         }
-         */
-        throw std::runtime_error("not implemented");
-
-
         // TODO проинициализировать nodes[i_node].child_left, nodes[i_node].child_right на основе i_begin, i_end, split
         //   не забудьте на N-1 сдвинуть индексы, указывающие на листья
-
-        throw std::runtime_error("not implemented");
-
+        nodes[i_node].child_left = split - 1 + (split - 1 == i_begin) ? N -1 : 0;
+        nodes[i_node].child_right = split + (split == i_end) ? N -1 : 0;
 
         found = true;
         break;
@@ -1311,10 +1305,19 @@ void buildBBoxes(std::vector<Node> &nodes, std::vector<int> &flags, int N, bool 
 #pragma omp parallel for if(use_omp) reduction(+:n_updated)
         for (int i_node = 0; i_node < N-1; ++i_node) {
             // TODO если находимся на нужном уровне (нужный flag), проинициализируем ббокс и центр масс ноды
-//            if (TODO) {
-//                  TODO
-//                ++n_updated;
-//            }
+           if (flags[i_node] == level) {
+                //  TODO
+                BBox bbox;
+                Node& node_left = nodes[nodes[i_node].child_left];
+                Node& node_right = nodes[nodes[i_node].child_right];
+                bbox.grow(node_left.bbox);
+                bbox.grow(node_right.bbox);
+                nodes[i_node].bbox = bbox;
+                nodes[i_node].cmsx = (node_left.cmsx + node_right.cmsx) / 2.;
+                nodes[i_node].cmsy = (node_left.cmsy + node_right.cmsy) / 2.;
+                nodes[i_node].mass = node_left.mass + node_right.mass;
+                ++n_updated;
+           }
 
         }
 


### PR DESCRIPTION
Результаты `CI`:
```
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (64 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
[       OK ] LBVH.GPU (4379 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
simulated 100 frames, N: 1000, framerate: 405.029 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 704.667 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 1210.01 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 26.2065 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (4675 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (9118 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (9118 ms total)
[  PASSED  ] 4 tests.
```
Результаты локально (`NBODY_INITIAL_STATE_COMPLEXITY 1`):
```
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (5211 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
[       OK ] LBVH.GPU (3697 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
simulated 100 frames, N: 10000, framerate: 1.40237 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 10000, framerate: 52.6138 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 10000, framerate: 20.6948 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 10000, framerate: 204.477 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (166083 ms)
[ RUN      ] LBVH.Nbody_meditation
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
simulated 100 frames, N: 10000, framerate: 13.1688 fps, method: nbody_gpu_lbvh
simulated 200 frames, N: 10000, framerate: 12.7493 fps, method: nbody_gpu_lbvh
simulated 300 frames, N: 10000, framerate: 12.6913 fps, method: nbody_gpu_lbvh
simulated 400 frames, N: 10000, framerate: 12.391 fps, method: nbody_gpu_lbvh
simulated 500 frames, N: 10000, framerate: 12.077 fps, method: nbody_gpu_lbvh
simulated 600 frames, N: 10000, framerate: 11.4305 fps, method: nbody_gpu_lbvh
simulated 700 frames, N: 10000, framerate: 11.5096 fps, method: nbody_gpu_lbvh
simulated 800 frames, N: 10000, framerate: 11.686 fps, method: nbody_gpu_lbvh
simulated 900 frames, N: 10000, framerate: 11.1752 fps, method: nbody_gpu_lbvh
simulated 1000 frames, N: 10000, framerate: 11.4184 fps, method: nbody_gpu_lbvh
simulated 1100 frames, N: 10000, framerate: 11.2993 fps, method: nbody_gpu_lbvh
simulated 1200 frames, N: 10000, framerate: 12.1223 fps, method: nbody_gpu_lbvh
simulated 1300 frames, N: 10000, framerate: 11.8753 fps, method: nbody_gpu_lbvh
simulated 1400 frames, N: 10000, framerate: 11.1351 fps, method: nbody_gpu_lbvh
simulated 1500 frames, N: 10000, framerate: 11.8612 fps, method: nbody_gpu_lbvh
simulated 1500 frames, N: 10000, framerate: 25779.4 fps, method: nbody_gpu_lbvh
[       OK ] LBVH.Nbody_meditation (127207 ms)
[----------] 4 tests from LBVH (302198 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (302198 ms total)
[  PASSED  ] 4 tests.
```
Результаты локально (`NBODY_INITIAL_STATE_COMPLEXITY 2`):
```
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (5177 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
[       OK ] LBVH.GPU (3555 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
simulated 100 frames, N: 100000, framerate: 1.48471 fps, method: nbody_cpu_lbvh
skipped precision evaluation
simulated 100 frames, N: 100000, framerate: 20.6572 fps, method: nbody_gpu_lbvh
skipped precision evaluation
[       OK ] LBVH.Nbody (234379 ms)
[ RUN      ] LBVH.Nbody_meditation
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 13841 Mb
  Device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
  Device #2: CPU. pthread-AMD Ryzen 5 3550H with Radeon Vega Mobile Gfx. AuthenticAMD. Total memory: 11793 Mb
Using device #1: GPU. NVIDIA GeForce GTX 1650. Total memory: 3903 Mb
simulated 100 frames, N: 100000, framerate: 3.13945 fps, method: nbody_gpu_lbvh
simulated 200 frames, N: 100000, framerate: 3.16353 fps, method: nbody_gpu_lbvh
simulated 300 frames, N: 100000, framerate: 3.15902 fps, method: nbody_gpu_lbvh
simulated 400 frames, N: 100000, framerate: 3.18047 fps, method: nbody_gpu_lbvh
simulated 500 frames, N: 100000, framerate: 3.1925 fps, method: nbody_gpu_lbvh
simulated 600 frames, N: 100000, framerate: 3.18639 fps, method: nbody_gpu_lbvh
simulated 700 frames, N: 100000, framerate: 3.15492 fps, method: nbody_gpu_lbvh
simulated 800 frames, N: 100000, framerate: 3.07151 fps, method: nbody_gpu_lbvh
simulated 900 frames, N: 100000, framerate: 3.03225 fps, method: nbody_gpu_lbvh
simulated 1000 frames, N: 100000, framerate: 2.98647 fps, method: nbody_gpu_lbvh
simulated 1100 frames, N: 100000, framerate: 2.91525 fps, method: nbody_gpu_lbvh
simulated 1200 frames, N: 100000, framerate: 2.89894 fps, method: nbody_gpu_lbvh
simulated 1300 frames, N: 100000, framerate: 2.79977 fps, method: nbody_gpu_lbvh
simulated 1400 frames, N: 100000, framerate: 2.74394 fps, method: nbody_gpu_lbvh
simulated 1500 frames, N: 100000, framerate: 2.74406 fps, method: nbody_gpu_lbvh
simulated 1500 frames, N: 100000, framerate: 17041.8 fps, method: nbody_gpu_lbvh
[       OK ] LBVH.Nbody_meditation (558680 ms)
[----------] 4 tests from LBVH (801792 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (801792 ms total)
[  PASSED  ] 4 tests.
```