### PR TITLE
Task09 Николай Стойко ITMO

### DIFF
--- a/libs/gpu/libgpu/opencl/cl/clion_defines.cl
+++ b/libs/gpu/libgpu/opencl/cl/clion_defines.cl
@@ -28,6 +28,7 @@ gentype		min			(gentype x, gentype y);
 gentype		mix			(gentype x, gentype y, gentype a);
 gentype		radians		(gentype degrees);
 gentype		sign		(gentype x);
+gentype		sqrt		(gentype x);
 gentype		smoothstep	(gentype edge0, gentype edge1, gentype x);
 gentype		step		(gentype edge, gentype x);
 #undef gentype

--- a/libs/gpu/libgpu/opencl/cl/clion_defines.cl
+++ b/libs/gpu/libgpu/opencl/cl/clion_defines.cl
@@ -19,6 +19,8 @@ struct float2 { float x;          };
 struct float3 { float x, y, z;    };
 struct float4 { float x, y, z, w; };
 
+using ulong = unsigned long long;
+
 // https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/commonFunctions.html
 #define gentype float
 gentype		clamp		(gentype x, float minval, float maxval);

--- a/src/cl/lbvh.cl
+++ b/src/cl/lbvh.cl
@@ -498,7 +498,11 @@ void calculateForce(float x0, float y0, float m0, __global const struct Node *no
             }
         }
 
-        for (int i_child = node->child_left; i_child <= node->child_right; ++i_child) {
+        int children[2];
+        children[0] = node->child_left;
+        children[1] = node->child_right;
+        for (int i = 0; i < 2; ++i) {
+            int i_child = children[i];
             __global const struct Node *child = &nodes[i_child];
             // С точки зрения ббоксов заходить в ребенка, ббокс которого не пересекаем, не нужно (из-за того, что в листьях у нас точки и они не высовываются за свой регион пространства)
             //   Но, с точки зрения физики, замена гравитационного влияния всех точек в регионе на взаимодействие с суммарной массой в центре масс - это точное решение только в однородном поле (например, на поверхности земли)

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -26,7 +26,32 @@ __kernel void nbody_calculate_force_global(
     float y0 = pys[i];
     float m0 = mxs[i];
 
-    // TODO
+    for (int j = 0; j < N; ++j) {
+
+        if (j == i) {
+            continue;
+        }
+
+        float x1 = pxs[j];
+        float y1 = pys[j];
+        float m1 = mxs[j];
+
+        float dx = x1 - x0;
+        float dy = y1 - y0;
+        float dr2 = max(100.f, dx * dx + dy * dy);
+
+        float dr2_inv = 1.f / dr2;
+        float dr_inv = sqrt(dr2_inv);
+
+        float ex = dx * dr_inv;
+        float ey = dy * dr_inv;
+
+        float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
+        float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
+
+        dvx[i] += m1 * fx;
+        dvy[i] += m1 * fy;
+    }
 }
 
 __kernel void nbody_integrate(

--- a/src/cl/nbody.cl
+++ b/src/cl/nbody.cl
@@ -26,6 +26,7 @@ __kernel void nbody_calculate_force_global(
     float y0 = pys[i];
     float m0 = mxs[i];
 
+    float vx = 0.0, vy = 0.0;
     for (int j = 0; j < N; ++j) {
 
         if (j == i) {
@@ -49,9 +50,11 @@ __kernel void nbody_calculate_force_global(
         float fx = ex * dr2_inv * GRAVITATIONAL_FORCE;
         float fy = ey * dr2_inv * GRAVITATIONAL_FORCE;
 
-        dvx[i] += m1 * fx;
-        dvy[i] += m1 * fy;
+        vx += m1 * fx;
+        vy += m1 * fy;
     }
+    dvx[i] += vx;
+    dvy[i] += vy;
 }
 
 __kernel void nbody_integrate(

--- a/src/main_lbvh.cpp
+++ b/src/main_lbvh.cpp
@@ -20,7 +20,7 @@
 #define OPENCL_DEVICE_INDEX 0
 
 // TODO включить чтобы начали запускаться тесты
-#define ENABLE_TESTING 0
+#define ENABLE_TESTING 1
 
 // имеет смысл отключать при оффлайн симуляции больших N, но в итоговом решении стоит оставить
 #define EVALUATE_PRECISION 1
@@ -294,6 +294,7 @@ private:
 
 };
 
+constexpr auto eps = 1e-2;
 struct Node {
 
     bool hasLeftChild() const { return child_left >= 0; }
@@ -301,8 +302,10 @@ struct Node {
     bool isLeaf() const { return !hasLeftChild() && !hasRightChild(); }
 
     bool operator==(const Node &other) const {
-        return std::tie(child_left, child_right, bbox, mass, cmsx, cmsy)
-               == std::tie(other.child_left, other.child_right, other.bbox, other.mass, other.cmsx, other.cmsy);
+        return std::tie(child_left, child_right, bbox) == std::tie(other.child_left, other.child_right, other.bbox)
+               && fabs(mass - other.mass) < eps
+               && fabs(cmsx - other.cmsx) < eps
+               && fabs(cmsy - other.cmsy) < eps;
     }
 
     bool operator!=(const Node &other) const {


### PR DESCRIPTION
__CI check__
```
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from LBVH
[ RUN      ] LBVH.CPU
[       OK ] LBVH.CPU (79 ms)
[ RUN      ] LBVH.GPU
OpenCL devices:
Device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
[       OK ] LBVH.GPU (4155 ms)
[ RUN      ] LBVH.Nbody
OpenCL devices:
Device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor. Intel(R) Corporation. Total memory: 15991 Mb
simulated 100 frames, N: 1000, framerate: 419.815 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 694.358 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 1313.8 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 27.8304 fps, method: nbody_gpu_lbvh
evaluating precision..
[       OK ] LBVH.Nbody (4434 ms)
[ RUN      ] LBVH.Nbody_meditation
[       OK ] LBVH.Nbody_meditation (0 ms)
[----------] 4 tests from LBVH (8668 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (8668 ms total)
[  PASSED  ] 4 tests.
```

__Local__
```
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 6073/6153 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 6073/6153 Mb
OpenCL devices:
  Device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 6069/6153 Mb
Using device #0: GPU. AMD Radeon(TM) Graphics (gfx1035). Free memory: 6069/6153 Mb
simulated 100 frames, N: 1000, framerate: 1282.05 fps, method: nbody_cpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 309.598 fps, method: nbody_gpu
evaluating precision..
simulated 100 frames, N: 1000, framerate: 1538.46 fps, method: nbody_cpu_lbvh
evaluating precision..
simulated 100 frames, N: 1000, framerate: 30.1841 fps, method: nbody_gpu_lbvh
evaluating precision..
```