### PR TITLE
Task04 Иван Кузнецов SPbU

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,76 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+#define TILE_SIZE 16
+#define WPT 4
+#define RTS TILE_SIZE / WPT
+
+__kernel void matrix_multiplication_naive(const __global float* as, const __global float* bs, __global float* cs, const uint m, const uint k, const uint n) {
+    const uint gi = get_global_id(0);
+    const uint gj = get_global_id(1);
+
+    float res = 0;
+    for (int i = 0; i < k; ++i) {
+        res += as[gj * k + i] * bs[i * n + gi];
+    }
+
+    cs[gj * n + gi] = res;
+}
+
+__kernel void matrix_multiplication_local(__global const float* as, __global const float* bs, __global float* cs, const uint m, const uint k, const uint n) {
+    const uint gi = get_global_id(0);
+    const uint gj = get_global_id(1);
+
+    const uint li = get_local_id(0);
+    const uint lj = get_local_id(1);
+
+    __local float as_tile[TILE_SIZE][TILE_SIZE];
+    __local float bs_tile[TILE_SIZE][TILE_SIZE];
+
+    float res = 0;
+    for (uint step = 0; step * TILE_SIZE < k; ++step) {
+        as_tile[lj][li] = as[gj * k + (li + step * TILE_SIZE)];
+        bs_tile[lj][li] = bs[(lj + step * TILE_SIZE) * n + gi];
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (uint idx = 0; idx < TILE_SIZE; ++idx) {
+            res += as_tile[lj][idx] * bs_tile[idx][li];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    
+    cs[gj * n + gi] = res;
+}
+
+__kernel void matrix_multiplication_local_bigger(__global const float* as, __global const float* bs, __global float* cs, const uint m, const uint k, const uint n) {
+    const uint li = get_local_id(0);
+    const uint lj = get_local_id(1);
+
+    const uint gi = TILE_SIZE * get_group_id(0) + li;
+    const uint gj = TILE_SIZE * get_group_id(1) + lj;
+
+    __local float as_tile[TILE_SIZE][TILE_SIZE];
+    __local float bs_tile[TILE_SIZE][TILE_SIZE];
+
+    float res[WPT];
+    for (uint i = 0; i < WPT; ++i) {
+        res[i] = 0.0;
+    }
+
+    for (uint step = 0; step * TILE_SIZE < k; ++step) {
+        for (uint i = 0; i < WPT; ++i) {
+            const uint idx = lj + i * RTS;
+            as_tile[idx][li] = as[(gj + i * RTS) * k + (step * TILE_SIZE + li)];
+            bs_tile[idx][li] = bs[(step * TILE_SIZE + idx) * n + gi];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (uint s = 0; s < TILE_SIZE; ++s) {
+            for (uint i = 0; i < WPT; ++i) {
+                res[i] += as_tile[lj + i * RTS][s] * bs_tile[s][li];
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (uint i = 0; i < WPT; ++i) {
+        cs[(i * RTS + gj) * n + gi] = res[i];
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,17 @@
-__kernel void matrix_transpose(...)
-{
-    // TODO
+#define M 16
+#define K 16
+
+__kernel void matrix_transpose(__global float* as, __global float* as_t, const uint m, const uint k) {
+    const uint gi = get_global_id(0);
+    const uint gj = get_global_id(1);
+    const uint li = get_local_id(0);
+    const uint lj = get_local_id(1);
+
+    __local float tile[M * K];
+    tile[lj * M + li] = as[gj * m + gi];
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const uint gi_t = gi - li + lj;
+    const uint gj_t = gj - lj + li;
+    as_t[gi_t * m + gj_t] = tile[li * K + lj];
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -7,6 +7,7 @@
 #include "cl/matrix_multiplication_cl.h"
 
 #include <vector>
+#include <string>
 #include <iostream>
 #include <stdexcept>
 
@@ -28,6 +29,7 @@ int main(int argc, char **argv)
     std::vector<float> as(M*K, 0);
     std::vector<float> bs(K*N, 0);
     std::vector<float> cs(M*N, 0);
+    std::vector<float> cs_zeros(M*N, 0);
 
     FastRandom r(M+K+N);
     for (unsigned int i = 0; i < as.size(); ++i) {
@@ -54,11 +56,11 @@ int main(int argc, char **argv)
         }
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
+        std::cout << std::endl;
     }
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
@@ -67,42 +69,53 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_naive");
     matrix_multiplication_kernel.compile();
+    ocl::Kernel matrix_multiplication_local_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_local");
+    matrix_multiplication_local_kernel.compile();
+    ocl::Kernel matrix_multiplication_local_bigger_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication_local_bigger");
+    matrix_multiplication_local_bigger_kernel.compile();
 
-    {
+    ocl::Kernel kernels[3] = {matrix_multiplication_kernel, matrix_multiplication_local_kernel, matrix_multiplication_local_bigger_kernel};
+    std::string kernelNames[] = {"(naive)", "(local mem)", "(local mem, bigger)"};
+    gpu::WorkSize ws[] = {
+        gpu::WorkSize(16, 16, M, N),
+        gpu::WorkSize(16, 16, M, N),
+        gpu::WorkSize(16, 16 / 4, M, N / 4)
+    };
+
+    for (uint idx = 0; idx < 3; ++idx) {
+        std::cout <<  kernelNames[idx] << std::endl;
+        cs_gpu.writeN(cs_zeros.data(), M*N);
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
-
+            kernels[idx].exec(ws[idx], as_gpu, bs_gpu, cs_gpu, M, K, N);
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
+    
+        cs_gpu.readN(cs.data(), M*N);
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
-
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        // Проверяем корректность результатов
+        double diff_sum = 0;
+        for (int i = 0; i < M * N; ++i) {
+            double a = cs[i];
+            double b = cs_cpu_reference[i];
+            if (a != 0.0 || b != 0.0) {
+                double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+                diff_sum += diff;
+            }
         }
-    }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+        double diff_avg = diff_sum / (M * N);
+        std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+        if (diff_avg > 0.01) {
+            std::cerr << "Too big difference!" << std::endl;
+            return 1;
+        }
+
+        std::cout << std::endl;
     }
 
     return 0;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -45,15 +44,13 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            gpu::WorkSize ws = gpu::WorkSize(16, 16, M, K);
+            matrix_transpose_kernel.exec(ws, as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -74,7 +71,6 @@ int main(int argc, char **argv)
             }
         }
     }
-    */
 
     return 0;
 }


### PR DESCRIPTION
## Задание 4.1. Транспонирование матрицы
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz. Intel(R) Corporation. Total memory: 23703 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Data generated for M=1024, K=1024
GPU: 4.05e-05+-5e-07 s
GPU: 25890.8 millions/s
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024
GPU: 0.001011+-0.000100177 s
GPU: 1037.17 millions/s
</pre>

</p></details>

## Задание 4.2. Умножение матриц
<details><summary>Локальный вывод</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. 11th Gen Intel(R) Core(TM) i5-11300H @ 3.10GHz. Intel(R) Corporation. Total memory: 23703 Mb
  Device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Using device #1: GPU. NVIDIA GeForce RTX 3060 Laptop GPU. Total memory: 5937 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 9.1685+-0.689484 s
CPU: 0.218138 GFlops

(naive)
GPU: 0.00341067+-8.05536e-06 s
GPU: 586.396 GFlops
Average difference: 0.000149043%

(local mem)
GPU: 0.00253917+-1.5763e-05 s
GPU: 787.66 GFlops
Average difference: 0.000149043%

(local mem, bigger)
GPU: 0.001367+-1.52753e-06 s
GPU: 1463.06 GFlops
Average difference: 0.000149043%
</pre>
</p></details>

<details><summary>Вывод Github CI</summary><p>
<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.49102+-0.000678925 s
CPU: 0.364231 GFlops

(naive)
GPU: 0.267206+-0.0038939 s
GPU: 7.48485 GFlops
Average difference: 0.000149043%

(local mem)
GPU: 0.0911805+-0.000216669 s
GPU: 21.9345 GFlops
Average difference: 0.000149043%

(local mem, bigger)
GPU: 0.0745482+-0.000158177 s
GPU: 26.8283 GFlops
Average difference: 0.000149043%
</pre>
</p></details>

В 4.2.2 ради интереса попробовал ставить разные WPT+TILE_SIZE
* TILE_SIZE=16: WPT=4/8, разница 1463.06/1043.3 GFlops соответственно;
* TILE_SIZE=32: WPT=4/8, разница 1825.65/1196.17 GFlops соответственно.