### PR TITLE
Task03 Денис Порсев HSE

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,10 +4,45 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float* res,
+                         const unsigned int width, const unsigned int height,
+                         const float fromX, const float fromY,
+                         const float sizeX, const float sizeY,
+                         const unsigned int iters, const int smoothing)
 {
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+
+    int id_x = get_global_id(0) % width, id_y = get_global_id(0) / width;
+
+    if (id_x >= width || id_y >= height)
+        return;
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (id_x + 0.5f) * sizeX;
+    float y0 = fromY + (id_y + 0.5f) * sizeY;
+    
+    float x = x0, y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float new_x = x * x - y * y + x0;
+        float new_y = 2.0f * x * y + y0;
+        x = new_x;
+        y = new_y;
+        if (x * x + y * y > threshold2)
+            break;
+    }
+
+    float result = iter;
+    
+    if (smoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y))) / log(threshold) / log(2.0f);
+    }
+    
+    res[id_y * width + id_x] = 1.0f * result / iters;
 }

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -15,7 +15,7 @@ __kernel void mandelbrot(__global float* res,
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
     // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
 
-    int id_x = get_global_id(0) % width, id_y = get_global_id(0) / width;
+    int id_x = get_global_id(0), id_y = get_global_id(1);
 
     if (id_x >= width || id_y >= height)
         return;
@@ -23,8 +23,8 @@ __kernel void mandelbrot(__global float* res,
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
 
-    float x0 = fromX + (id_x + 0.5f) * sizeX;
-    float y0 = fromY + (id_y + 0.5f) * sizeY;
+    float x0 = fromX + (id_x + 0.5f) * sizeX / width;
+    float y0 = fromY + (id_y + 0.5f) * sizeY / height;
     
     float x = x0, y = y0;
 

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,103 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define WORKITEM_VALUES 128
+#define WORKGROUP_SIZE 256
+
+__kernel void sum_global_atomic_add(__global const unsigned *arr,
+                                    int len,
+                                    __global unsigned* res)
+{
+    const unsigned index = get_global_id(0);
+
+    if (index >= len)
+        return;
+
+    atomic_add(res, arr[index]);
+}
+
+__kernel void sum_noncoalesced_loop(__global const unsigned int* arr,
+                                    int len,
+                                    __global unsigned* res)
+{
+    unsigned sum = 0;
+
+    for (int i = 0; i < WORKITEM_VALUES; ++i) {
+        int index = get_global_id(0) * WORKITEM_VALUES + i;
+        if (index >= len)
+            break;
+        sum += arr[index];
+    }
+    atomic_add(res, sum);
+}
+
+__kernel void sum_coalesced_loop(__global const unsigned int* arr,
+                                 int len,
+                                 __global unsigned* res)
+{
+    unsigned sum = 0;
+    unsigned localId = get_local_id(0);
+    unsigned workgroupId = get_group_id(0);
+    unsigned localSize = get_local_size(0);
+
+    for (int i = 0; i < WORKITEM_VALUES; ++i) {
+        int index = workgroupId * localSize * WORKITEM_VALUES + localId + i * localSize;
+        if (index >= len)
+            break;
+        sum += arr[index];
+    }
+    atomic_add(res, sum);
+}
+
+__kernel void sum_local(__global const unsigned int* arr,
+                        int len,
+                        __global unsigned* res)
+{
+    unsigned localId = get_local_id(0);
+    unsigned globalId = get_global_id(0);
+    unsigned group_res = 0;
+    __local unsigned buffer[WORKGROUP_SIZE];
+
+    if (globalId < len)
+        buffer[localId] = arr[globalId];
+    else
+        buffer[localId] = 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (localId == 0) {
+        for (int i = 0; i < WORKGROUP_SIZE; ++i)
+            group_res += buffer[i];
+        atomic_add(res, group_res);
+    }
+}
+
+__kernel void sum_tree(__global const unsigned int* arr,
+                        int len,
+                        __global unsigned* res)
+{
+    unsigned group_res = 0;
+    unsigned globalId = get_global_id(0);
+    unsigned localId = get_local_id(0);
+    __local unsigned buffer[WORKGROUP_SIZE];
+
+    if (globalId < len)
+        buffer[localId] = arr[globalId];
+    else
+        buffer[localId] = 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int numVals = WORKGROUP_SIZE;
+    for (; numVals > 1; numVals >>= 1) {
+        if (2 * localId < numVals)
+            buffer[localId] += buffer[localId + (numVals >> 1)];
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (localId == 0)
+        atomic_add(res, buffer[0]);
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,24 +1,20 @@
 #include <cmath>
 
-#include <libutils/misc.h>
-#include <libutils/timer.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
 #include <libimages/images.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+void mandelbrotCPU(float *results, unsigned int width, unsigned int height, float fromX, float fromY, float sizeX,
+                   float sizeY, unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -47,13 +43,12 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     unsigned int benchmarkingIters = 10;
@@ -66,10 +61,10 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    //    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    //    float centralX = -0.5f;
+    //    float centralY = 0.0f;
+    //    float sizeX = 2.0f;
 
     images::Image<float> cpu_results(width, height, 1);
     images::Image<float> gpu_results(width, height, 1);
@@ -80,16 +75,13 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int i = 0; i < benchmarkingIters; ++i) {
-            mandelbrotCPU(cpu_results.ptr(),
-                          width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, false);
+            mandelbrotCPU(cpu_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX,
+                          sizeY, iterationsLimit, false);
             t.nextLap();
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
@@ -99,59 +91,59 @@ int main(int argc, char **argv)
                 realIterationsFraction += cpu_results.ptr()[j * width + i];
             }
         }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
 
         renderToColor(cpu_results.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    //    // Раскомментируйте это:
+    //
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+    //    bool useGPU = false;
+    //    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -174,16 +166,11 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
     do {
         if (!useGPU) {
-            mandelbrotCPU(results.ptr(), width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
+            mandelbrotCPU(results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY,
                           iterationsLimit, true);
         } else {
-            kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
+            kernel.exec(gpu::WorkSize(16, 16, width, height), results_vram, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);
@@ -194,7 +181,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();
@@ -218,9 +205,12 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z) : x(x), y(y), z(z) {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +237,8 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +247,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -85,10 +85,8 @@ int main(int argc, char **argv) {
             bool printLog = false;
             kernel.compile(printLog);
 
-            unsigned workItemVals = 1;
             unsigned workGroupSize = 256;
-            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
-            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+            unsigned workSizeGlobal = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
             timer t;
             for (int i = 0; i < benchmarkingIters; ++i) {
@@ -160,10 +158,8 @@ int main(int argc, char **argv) {
             bool printLog = false;
             kernel.compile(printLog);
 
-            unsigned workItemVals = 1;
             unsigned workGroupSize = 256;
-            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
-            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+            unsigned workSizeGlobal = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
             timer t;
             for (int i = 0; i < benchmarkingIters; ++i) {
@@ -185,10 +181,8 @@ int main(int argc, char **argv) {
             bool printLog = false;
             kernel.compile(printLog);
 
-            unsigned workItemVals = 1;
             unsigned workGroupSize = 256;
-            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
-            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+            unsigned workSizeGlobal = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
 
             timer t;
             for (int i = 0; i < benchmarkingIters; ++i) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,14 @@
+#include "cl/sum_cl.h"
+
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,12 +18,11 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     int benchmarkingIters = 10;
 
     unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
@@ -39,14 +41,14 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
@@ -54,11 +56,151 @@ int main(int argc, char **argv)
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
+
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
     {
         // TODO: implement on OpenCL
         // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+
+        gpu::gpu_mem_32u array_gpu;
+        array_gpu.resizeN(n);
+        array_gpu.writeN(as.data(), n);
+
+        gpu::gpu_mem_32u sum_gpu;
+        sum_gpu.resizeN(1);
+
+        unsigned sum;
+        const unsigned zero = 0;
+
+        // с глобальным атомарным добавлением
+        {
+            std::string kernelName = "sum_global_atomic_add";
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            unsigned workItemVals = 1;
+            unsigned workGroupSize = 256;
+            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
+            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                sum_gpu.writeN(&zero, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, workSizeGlobal), array_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernelName + " result should be consistent!");
+                t.nextLap();
+            }
+
+            std::cout << "GPU (" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (" << kernelName << "): " << (n / 1e6) / t.lapAvg() << " millions/s\n" << std::endl;
+        }
+
+        // с циклом
+        {
+            std::string kernelName = "sum_noncoalesced_loop";
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            unsigned workItemVals = 128;
+            unsigned workGroupSize = 256;
+            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
+            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                sum_gpu.writeN(&zero, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, workSizeGlobal), array_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernelName + " result should be consistent!");
+                t.nextLap();
+            }
+
+            std::cout << "GPU (" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (" << kernelName << "): " << (n / 1e6) / t.lapAvg() << " millions/s\n" << std::endl;
+        }
+
+        // с циклом и coalesced доступом
+        {
+            std::string kernelName = "sum_coalesced_loop";
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            unsigned workItemVals = 128;
+            unsigned workGroupSize = 256;
+            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
+            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                sum_gpu.writeN(&zero, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, workSizeGlobal), array_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernelName + " result should be consistent!");
+                t.nextLap();
+            }
+
+            std::cout << "GPU (" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (" << kernelName << "): " << (n / 1e6) / t.lapAvg() << " millions/s\n" << std::endl;
+        }
+
+        // с локальной памятью и главным потоком
+        {
+            std::string kernelName = "sum_local";
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            unsigned workItemVals = 1;
+            unsigned workGroupSize = 256;
+            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
+            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                sum_gpu.writeN(&zero, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, workSizeGlobal), array_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernelName + " result should be consistent!");
+                t.nextLap();
+            }
+
+            std::cout << "GPU (" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (" << kernelName << "): " << (n / 1e6) / t.lapAvg() << " millions/s\n" << std::endl;
+        }
+
+        // с деревом
+        {
+            std::string kernelName = "sum_tree";
+            ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernelName);
+            bool printLog = false;
+            kernel.compile(printLog);
+
+            unsigned workItemVals = 1;
+            unsigned workGroupSize = 256;
+            unsigned workitemsNum = (n + workItemVals - 1) / workItemVals;
+            unsigned workSizeGlobal = (workitemsNum + workGroupSize - 1) / workGroupSize * workGroupSize;
+
+            timer t;
+            for (int i = 0; i < benchmarkingIters; ++i) {
+                sum_gpu.writeN(&zero, 1);
+                kernel.exec(gpu::WorkSize(workGroupSize, workSizeGlobal), array_gpu, n, sum_gpu);
+                sum_gpu.readN(&sum, 1);
+                EXPECT_THE_SAME(reference_sum, sum, "GPU " + kernelName + " result should be consistent!");
+                t.nextLap();
+            }
+
+            std::cout << "GPU (" << kernelName << "): " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU (" << kernelName << "): " << (n / 1e6) / t.lapAvg() << " millions/s" << std::endl;
+        }
     }
 }


### PR DESCRIPTION
### Mandelbrot

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./mandelbrot 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15800 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 12640 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
CPU: 0.694783+-0.0240566 s
CPU: 14.393 GFlops
    Real iterations fraction: 56.2638%
NVIDIA GeForce GTX 1650 with Max-Q Design: 0.00821017+-2.91071e-06 s
NVIDIA GeForce GTX 1650 with Max-Q Design: 1307.82 GFlops
    Real iterations fraction: 56.0794%
GPU vs CPU average results difference: 1.10491%
</pre>

</p></details>


<details><summary>Вывод Github CI</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.602098+-0.00217883 s
CPU: 16.6086 GFlops
    Real iterations fraction: 56.2638%
AMD EPYC 7763 64-Core Processor                : 0.165561+-2.33339e-05 s
AMD EPYC 7763 64-Core Processor                : 64.8547 GFlops
    Real iterations fraction: 56.08%
GPU vs CPU average results difference: 1.14416%
</pre>

</p></details>


### Sum

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./sum 2
CPU:     0.22073+-0.00115631 s
CPU:     453.041 millions/s
CPU OMP: 0.0691067+-0.00144462 s
CPU OMP: 1447.04 millions/s
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15800 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 12640 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
GPU (sum_global_atomic_add): 0.00643333+-0.000504711 s
GPU (sum_global_atomic_add): 15544 millions/s

GPU (sum_noncoalesced_loop): 0.0712368+-0.000249214 s
GPU (sum_noncoalesced_loop): 1403.77 millions/s

GPU (sum_coalesced_loop): 0.00335833+-3.14466e-06 s
GPU (sum_coalesced_loop): 29776.7 millions/s

GPU (sum_local): 0.00987267+-4.12863e-05 s
GPU (sum_local): 10129 millions/s

GPU (sum_tree): 0.00896767+-1.8418e-05 s
GPU (sum_tree): 11151.2 millions/s
</pre>

</p></details>


<details><summary>Вывод Github CI</summary><p>

<pre>
CPU:     0.0320947+-5.3705e-05 s
CPU:     3115.78 millions/s
CPU OMP: 0.0176777+-0.00026484 s
CPU OMP: 5656.86 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU (sum_global_atomic_add): 1.51599+-0.000889557 s
GPU (sum_global_atomic_add): 65.9635 millions/s

GPU (sum_noncoalesced_loop): 0.0527868+-0.000257343 s
GPU (sum_noncoalesced_loop): 1894.41 millions/s

GPU (sum_coalesced_loop): 0.0251407+-0.000156854 s
GPU (sum_coalesced_loop): 3977.62 millions/s

GPU (sum_local): 0.0373848+-8.12966e-05 s
GPU (sum_local): 2674.88 millions/s

GPU (sum_tree): 0.186381+-0.000180366 s
GPU (sum_tree): 536.536 millions/s
</pre>

</p></details>