### PR TITLE
Task04 Александр Софрыгин ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -19,7 +19,6 @@ __kernel void matrix_multiplication_basic(__global const float *a, __global cons
     c[j * N + i] = sum;
 }
 
-#define TILE_SIZE 16
 __kernel void matrix_multiplication_local(__global const float *a, __global const float *b, __global float *c,
                                           unsigned int M, unsigned int K, unsigned int N)
 {
@@ -33,14 +32,15 @@ __kernel void matrix_multiplication_local(__global const float *a, __global cons
     float sum = 0.0f;
     for (size_t tileK = 0; tileK * TILE_SIZE < K; tileK++)
     {
+        const size_t offset = tileK * TILE_SIZE;
         if (j < M && (tileK * TILE_SIZE + local_i) < K)
         {
-            tileA[local_j][local_i] = a[j * K + tileK * TILE_SIZE + local_i];
+            tileA[local_j][local_i] = a[j * K + offset + local_i];
         }
 
         if (i < N && tileK * TILE_SIZE + local_j < K)
         {
-            tileB[local_j][local_i] = b[(tileK * TILE_SIZE + local_j) * N + i];
+            tileB[local_j][local_i] = b[(offset + local_j) * N + i];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
@@ -56,7 +56,6 @@ __kernel void matrix_multiplication_local(__global const float *a, __global cons
     }
 }
 
-#define THREAD_WORK 4
 __kernel void matrix_multiplication_local_work(__global const float *a, __global const float *b, __global float *c,
                                                unsigned int M, unsigned int K, unsigned int N)
 {

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -26,8 +26,8 @@ __kernel void matrix_multiplication_local(__global const float *a, __global cons
     size_t j = get_global_id(1);
     size_t local_i = get_local_id(0);
     size_t local_j = get_local_id(1);
-    __local float tileA[TILE_SIZE][TILE_SIZE];
-    __local float tileB[TILE_SIZE][TILE_SIZE];
+    __local float tileA[TILE_SIZE][TILE_SIZE + 1];
+    __local float tileB[TILE_SIZE][TILE_SIZE + 1];
 
     float sum = 0.0f;
     for (size_t tileK = 0; tileK * TILE_SIZE < K; tileK++)
@@ -64,8 +64,8 @@ __kernel void matrix_multiplication_local_work(__global const float *a, __global
     size_t i = get_global_id(0);
     size_t j = get_group_id(1) * TILE_SIZE + local_j;
 
-    __local float tileA[TILE_SIZE][TILE_SIZE];
-    __local float tileB[TILE_SIZE][TILE_SIZE];
+    __local float tileA[TILE_SIZE][TILE_SIZE + 1];
+    __local float tileB[TILE_SIZE][TILE_SIZE + 1];
     const size_t WORK_STEP = TILE_SIZE / THREAD_WORK;
 
     float sum[THREAD_WORK] = { 0 };

--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,115 @@
-__kernel void matrix_multiplication(...)
+#line 2
+
+__kernel void matrix_multiplication_basic(__global const float *a, __global const float *b, __global float *c,
+                                          unsigned int M, unsigned int K, unsigned int N)
 {
-    // TODO
+    size_t i = get_global_id(0);
+    size_t j = get_global_id(1);
+
+    if (i >= N || j >= M)
+    {
+        return;
+    }
+
+    float sum = 0.0;
+    for (size_t it = 0; it < K; it++)
+    {
+        sum += a[j * K + it] * b[it * N + i];
+    }
+    c[j * N + i] = sum;
+}
+
+#define TILE_SIZE 16
+__kernel void matrix_multiplication_local(__global const float *a, __global const float *b, __global float *c,
+                                          unsigned int M, unsigned int K, unsigned int N)
+{
+    size_t i = get_global_id(0);
+    size_t j = get_global_id(1);
+    size_t local_i = get_local_id(0);
+    size_t local_j = get_local_id(1);
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+
+    float sum = 0.0f;
+    for (size_t tileK = 0; tileK * TILE_SIZE < K; tileK++)
+    {
+        if (j < M && (tileK * TILE_SIZE + local_i) < K)
+        {
+            tileA[local_j][local_i] = a[j * K + tileK * TILE_SIZE + local_i];
+        }
+
+        if (i < N && tileK * TILE_SIZE + local_j < K)
+        {
+            tileB[local_j][local_i] = b[(tileK * TILE_SIZE + local_j) * N + i];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        for (size_t k = 0; k < TILE_SIZE; k++)
+        {
+            sum += tileA[local_j][k] * tileB[k][local_i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (j < M && i < N)
+    {
+        c[j * N + i] = sum;
+    }
+}
+
+#define THREAD_WORK 4
+__kernel void matrix_multiplication_local_work(__global const float *a, __global const float *b, __global float *c,
+                                               unsigned int M, unsigned int K, unsigned int N)
+{
+    size_t local_i = get_local_id(0);
+    size_t local_j = get_local_id(1);
+    size_t i = get_global_id(0);
+    size_t j = get_group_id(1) * TILE_SIZE + local_j;
+
+    __local float tileA[TILE_SIZE][TILE_SIZE];
+    __local float tileB[TILE_SIZE][TILE_SIZE];
+    const size_t WORK_STEP = TILE_SIZE / THREAD_WORK;
+
+    float sum[THREAD_WORK] = { 0 };
+
+    for (size_t tileK = 0; tileK * TILE_SIZE < K; tileK++)
+    {
+        const size_t offset = tileK * TILE_SIZE;
+        for (size_t w = 0; w * WORK_STEP < TILE_SIZE; w++)
+        {
+            const size_t work_offset = w * WORK_STEP;
+            if (j + work_offset < M && offset + local_i < K)
+            {
+                tileA[local_j + work_offset][local_i] = a[(j + work_offset) * K + offset + local_i];
+            }
+
+            if (i < N && offset + local_j + work_offset < K)
+            {
+                tileB[local_j + work_offset][local_i] = b[(offset + local_j + work_offset) * N + i];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        const size_t end = (TILE_SIZE < (K - offset)) ? TILE_SIZE : (K - offset);
+        for (size_t k = 0; k < end; k++)
+        {
+            const float elem_b = tileB[k][local_i];
+            for (size_t w = 0; w < THREAD_WORK; w++)
+            {
+                if (i < N && j + w * WORK_STEP < M)
+                {
+                    sum[w] += elem_b * tileA[local_j + w * WORK_STEP][k];
+                }
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (size_t w = 0; w < THREAD_WORK; w++)
+    {
+        if (i < N && j + WORK_STEP * w < M)
+        {
+            c[(j + WORK_STEP * w) * N + i] = sum[w];
+        }
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,25 @@
-__kernel void matrix_transpose(...)
+#line 2
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose(__global const float *as, __global float *ast, unsigned int M, unsigned int K)
 {
-    // TODO
+    int i = get_global_id(0);
+    int j = get_global_id(1);
+
+    __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    if (i < M && j < K)
+    {
+        tile[local_i][local_j] = as[j * K + i];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    float tmp = tile[local_i][local_j];
+    tile[local_i][local_j] = tile[local_j][local_i];
+    tile[local_j][local_i] = tmp;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    ast[i * M + j] = tile[local_i][local_j];
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,7 +1,7 @@
 #line 2
 
 #define TILE_SIZE 16
-__kernel void matrix_transpose(__global const float *as, __global float *ast, unsigned int M, unsigned int K)
+__kernel void matrix_transpose(__global const float *as, __global float *ast, unsigned int K, unsigned int M)
 {
     int i = get_global_id(0);
     int j = get_global_id(1);
@@ -10,13 +10,13 @@ __kernel void matrix_transpose(__global const float *as, __global float *ast, un
     int local_i = get_local_id(0);
     int local_j = get_local_id(1);
 
-    if (i < M && j < K)
+    if (i < K && j < M)
     {
         tile[local_j][local_i] = as[j * K + i];
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    if (i < M && j < K)
+    if (i < K && j < M)
     {
         ast[i * M + j] = tile[local_j][local_i];
     }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,12 +1,33 @@
 #line 2
 
 #define TILE_SIZE 16
-__kernel void matrix_transpose(__global const float *as, __global float *ast, unsigned int K, unsigned int M)
+__kernel void matrix_transpose(__global const float *as, __global float *ast, unsigned int M, unsigned int K)
 {
-    int i = get_global_id(0);
-    int j = get_global_id(1);
+    int i = get_global_id(0);  // 0 to K
+    int j = get_global_id(1);  // 0 to M
 
     __local float tile[TILE_SIZE][TILE_SIZE];
+    int local_i = get_local_id(0);
+    int local_j = get_local_id(1);
+
+    if (i < K && j < M)
+    {
+        tile[local_j][local_i] = as[j * K + i];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (i < K && j < M)
+    {
+        ast[i * M + j] = tile[local_j][local_i];
+    }
+}
+
+__kernel void matrix_transpose_banks(__global const float *as, __global float *ast, unsigned int M, unsigned int K)
+{
+    int i = get_global_id(0);  // 0 to K
+    int j = get_global_id(1);  // 0 to M
+
+    __local float tile[TILE_SIZE][TILE_SIZE + 1];
     int local_i = get_local_id(0);
     int local_j = get_local_id(1);
 

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -12,7 +12,7 @@ __kernel void matrix_transpose(__global const float *as, __global float *ast, un
 
     if (i < M && j < K)
     {
-        tile[local_i][local_j] = as[j * K + i];
+        tile[local_j][local_i] = as[j * K + i];
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
@@ -21,5 +21,8 @@ __kernel void matrix_transpose(__global const float *as, __global float *ast, un
     tile[local_j][local_i] = tmp;
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    ast[i * M + j] = tile[local_i][local_j];
+    if (i < M && j < K)
+    {
+        ast[i * M + j] = tile[local_i][local_j];
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -16,13 +16,8 @@ __kernel void matrix_transpose(__global const float *as, __global float *ast, un
     }
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    float tmp = tile[local_i][local_j];
-    tile[local_i][local_j] = tile[local_j][local_i];
-    tile[local_j][local_i] = tmp;
-    barrier(CLK_LOCAL_MEM_FENCE);
-
     if (i < M && j < K)
     {
-        ast[i * M + j] = tile[local_i][local_j];
+        ast[i * M + j] = tile[local_j][local_i];
     }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -58,58 +58,75 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    
-    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
-
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
-
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
-                                             "matrix_multiplication_local_work");
-    matrix_multiplication_kernel.compile();
-
+    struct KernelConfig
     {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 16;
-            unsigned int thread_work_size = 4;
-            gpu::WorkSize ws
-            (
-                work_group_size,
-                work_group_size / thread_work_size,
-                M, gpu::divup(N, thread_work_size)
-            );
-            matrix_multiplication_kernel.exec(ws, as_gpu, bs_gpu, cs_gpu, M, K, N);
+        std::string name;
+        size_t thread_work;
+    };
 
-            t.nextLap();
+    std::vector<KernelConfig> kernels =
+    {
+        { "matrix_multiplication_basic", 1 },
+        { "matrix_multiplication_local", 1 },
+        { "matrix_multiplication_local_work", 4 }
+    };
+
+    for (const KernelConfig& config : kernels)
+    {
+        gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
+        as_gpu.resizeN(M* K);
+        bs_gpu.resizeN(K* N);
+        cs_gpu.resizeN(M* N);
+
+        as_gpu.writeN(as.data(), M* K);
+        bs_gpu.writeN(bs.data(), K* N);
+
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                 config.name);
+        matrix_multiplication_kernel.compile();
+
+        {
+            timer t;
+            const unsigned int work_group_size = 16;
+            const unsigned int thread_work_size = config.thread_work;
+            for (int iter = 0; iter < benchmarkingIters; ++iter)
+            {
+                gpu::WorkSize ws
+                (
+                    work_group_size,
+                    work_group_size / thread_work_size,
+                    M, gpu::divup(N, thread_work_size)
+                );
+                matrix_multiplication_kernel.exec(ws, as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+                t.nextLap();
+            }
+            std::cout << "GPU " << config.name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU " << config.name << ": " << gflops / t.lapAvg() << " GFlops" << std::endl;
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
 
-    cs_gpu.readN(cs.data(), M*N);
-    
+        cs_gpu.readN(cs.data(), M * N);
 
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        // Проверяем корректность результатов
+        double diff_sum = 0;
+        for (int i = 0; i < M * N; ++i)
+        {
+            double a = cs[i];
+            double b = cs_cpu_reference[i];
+            if (a != 0.0 || b != 0.0)
+            {
+                double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+                diff_sum += diff;
+            }
         }
-    }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+        double diff_avg = diff_sum / (M * N);
+        std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+        if (diff_avg > 0.01)
+        {
+            std::cerr << "Too big difference!" << std::endl;
+            return 1;
+        }
     }
 
     return 0;

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -58,7 +58,7 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
+    
     gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
     as_gpu.resizeN(M*K);
     bs_gpu.resizeN(K*N);
@@ -67,16 +67,23 @@ int main(int argc, char **argv)
     as_gpu.writeN(as.data(), M*K);
     bs_gpu.writeN(bs.data(), K*N);
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
+    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                             "matrix_multiplication_local_work");
     matrix_multiplication_kernel.compile();
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+            unsigned int work_group_size = 16;
+            unsigned int thread_work_size = 4;
+            gpu::WorkSize ws
+            (
+                work_group_size,
+                work_group_size / thread_work_size,
+                M, gpu::divup(N, thread_work_size)
+            );
+            matrix_multiplication_kernel.exec(ws, as_gpu, bs_gpu, cs_gpu, M, K, N);
 
             t.nextLap();
         }
@@ -85,7 +92,7 @@ int main(int argc, char **argv)
     }
 
     cs_gpu.readN(cs.data(), M*N);
-    */
+    
 
     // Проверяем корректность результатов
     double diff_sum = 0;

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, M, K), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, K, M), as_gpu, as_t_gpu, K, M);
 
             t.nextLap();
         }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
@@ -45,15 +44,16 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            std::cout << "Iteration " << iter << std::endl;
             // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
+            unsigned int work_group_size = 16;
+            unsigned int global_work_size = M * K;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
             // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
             // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, M, K), as_gpu, as_t_gpu, M, K);
 
             t.nextLap();
         }
@@ -63,18 +63,38 @@ int main(int argc, char **argv)
 
     as_t_gpu.readN(as_t.data(), M*K);
 
-    // Проверяем корректность результатов
-    for (int j = 0; j < M; ++j) {
-        for (int i = 0; i < K; ++i) {
-            float a = as[j * K + i];
-            float b = as_t[i * M + j];
-            if (a != b) {
-                std::cerr << "Not the same!" << std::endl;
-                return 1;
-            }
-        }
-    }
-    */
+     //Проверяем корректность результатов
+    //for (int j = 0; j < M; ++j)
+    //{
+    //    for (int i = 0; i < K; ++i)
+    //    {
+    //        std::cout << as[j * K + i] << ' ';
+    //    }
+    //    std::cout << std::endl;
+    //}
+    //std::cout << std::endl;
 
+    //for (int j = 0; j < M; ++j)
+    //{
+    //    for (int i = 0; i < K; ++i)
+    //    {
+    //        std::cout << as_t[i * M + j] << ' ';
+    //    }
+    //    std::cout << std::endl;
+    //}
+    //std::cout << std::endl;
+
+    //for (int j = 0; j < M; ++j) {
+    //    for (int i = 0; i < K; ++i) {
+    //        float a = as[j * K + i];
+    //        float b = as_t[i * M + j];
+    //        if (abs(a - b) > 1e-6) {
+    //            std::cerr << "Not the same!" << std::endl;
+    //            return 1;
+    //        }
+    //    }
+    //}
+
+    std::cout << "Ok" << std::endl;
     return 0;
 }

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -44,10 +44,8 @@ int main(int argc, char **argv)
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            std::cout << "Iteration " << iter << std::endl;
             // TODO
             unsigned int work_group_size = 16;
-            unsigned int global_work_size = M * K;
             // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
             // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
             // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
@@ -64,36 +62,16 @@ int main(int argc, char **argv)
     as_t_gpu.readN(as_t.data(), M*K);
 
      //Проверяем корректность результатов
-    //for (int j = 0; j < M; ++j)
-    //{
-    //    for (int i = 0; i < K; ++i)
-    //    {
-    //        std::cout << as[j * K + i] << ' ';
-    //    }
-    //    std::cout << std::endl;
-    //}
-    //std::cout << std::endl;
-
-    //for (int j = 0; j < M; ++j)
-    //{
-    //    for (int i = 0; i < K; ++i)
-    //    {
-    //        std::cout << as_t[i * M + j] << ' ';
-    //    }
-    //    std::cout << std::endl;
-    //}
-    //std::cout << std::endl;
-
-    //for (int j = 0; j < M; ++j) {
-    //    for (int i = 0; i < K; ++i) {
-    //        float a = as[j * K + i];
-    //        float b = as_t[i * M + j];
-    //        if (abs(a - b) > 1e-6) {
-    //            std::cerr << "Not the same!" << std::endl;
-    //            return 1;
-    //        }
-    //    }
-    //}
+    for (int j = 0; j < M; ++j) {
+        for (int i = 0; i < K; ++i) {
+            float a = as[j * K + i];
+            float b = as_t[i * M + j];
+            if (abs(a - b) > 1e-6) {
+                std::cerr << "Not the same!" << std::endl;
+                return 1;
+            }
+        }
+    }
 
     std::cout << "Ok" << std::endl;
     return 0;


### PR DESCRIPTION
<details><summary>Локальный вывод (Matrix transpose)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Data generated for M=1024, K=1024
GPU matrix_transpose: 0.001+-0.00057735 s
GPU matrix_transpose: 1048.58 millions/s
GPU matrix_transpose_banks: 0.000666667+-0.000471405 s
GPU matrix_transpose_banks: 1572.86 millions/s
Ok
</pre>

</p></details>

<details><summary>Вывод Github CI (Matrix transpose)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024
GPU matrix_transpose: 0.00149717+-1.49378e-05 s
GPU matrix_transpose: 700.374 millions/s
GPU matrix_transpose_banks: 0.00158317+-2.74312e-05 s
GPU matrix_transpose_banks: 662.328 millions/s
Ok
</pre>

</p></details>

<details><summary>Локальный вывод (Matrix multiplication)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 9.4275+-0.032735 s
CPU: 0.212145 GFlops
GPU matrix_multiplication_basic, thread_work_size = 1: 0.0435+-0.00189297 s
GPU matrix_multiplication_basic, thread_work_size = 1: 45.977 GFlops
Average difference: 0%
GPU matrix_multiplication_local, thread_work_size = 1: 0.0276667+-0.000471405 s
GPU matrix_multiplication_local, thread_work_size = 1: 72.2892 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 2: 0.0311667+-0.00177169 s
GPU matrix_multiplication_local_work, thread_work_size = 2: 64.1711 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 4: 0.0288333+-0.00134371 s
GPU matrix_multiplication_local_work, thread_work_size = 4: 69.3642 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 8: 0.0568333+-0.00338707 s
GPU matrix_multiplication_local_work, thread_work_size = 8: 35.1906 GFlops
Average difference: 0%
</pre>

</p></details>

<details><summary>Вывод Github CI (Matrix multiplication)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.63976+-0.00197859 s
CPU: 0.354625 GFlops
GPU matrix_multiplication_basic, thread_work_size = 1: 0.26923+-0.00461804 s
GPU matrix_multiplication_basic, thread_work_size = 1: 7.42861 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local, thread_work_size = 1: 0.0916177+-0.000248199 s
GPU matrix_multiplication_local, thread_work_size = 1: 21.8299 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 2: 0.192144+-0.00102349 s
GPU matrix_multiplication_local_work, thread_work_size = 2: 10.4089 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 4: 0.259803+-0.00165932 s
GPU matrix_multiplication_local_work, thread_work_size = 4: 7.69814 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 8: 0.177403+-0.000823387 s
GPU matrix_multiplication_local_work, thread_work_size = 8: 11.2737 GFlops
Average difference: 0.000149043%
</pre>

</p></details>

На моей локальной конфигурации в деле перемножения матриц выигрывает версия с локальной памятью, но без увеличения количества работы, хотя версия с 4 элементами на поток при размере рабочей группы 16х16 достаточно близка.
Хотя в приведённых результатах этого и не видно, но версия без дополнительной работы показывает более стабильные результаты: всегда в районе 72-74 ГФлопс (т.е. размах 2 ГФлопс), в то время как версии с дополнительной работой между запусками могут измениться на 5 ГФлопс