### PR TITLE
Task03 Александр Софрыгин ITMO

### DIFF
--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,8 +4,36 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+__kernel void mandelbrot(__global float *results, unsigned int width, unsigned int height,
+                         float fromX, float fromY, float sizeX, float sizeY, unsigned int iters)
 {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    unsigned int i = get_global_id(0);
+    unsigned int j = get_global_id(1);
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter)
+    {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) 
+        {
+            break;
+        }
+    }
+
+    float result = iter;
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
     // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
     // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,120 @@
-// TODO
+#line 2
+
+__kernel void sum_atomic(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+    {
+        return;
+    }
+    atomic_add(sum, arr[i]);
+}
+
+#define VALUES_PER_WORKITEM 64
+__kernel void sum_atomic_cycle(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    size_t gid = get_global_id(0);
+    unsigned int temp_sum = 0;
+    for (size_t i = 0; i < VALUES_PER_WORKITEM; i++)
+    {
+        size_t pos = gid * VALUES_PER_WORKITEM + i;
+        if (pos < n)
+        {
+            temp_sum += arr[pos];
+        }
+    }
+    atomic_add(sum, temp_sum);
+}
+
+__kernel void sum_atomic_cycle_coalesced(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    size_t lid = get_local_id(0);
+    size_t wid = get_group_id(0);
+    size_t local_size = get_local_size(0);
+
+    unsigned int temp_sum = 0;
+    for (size_t i = 0; i < VALUES_PER_WORKITEM; i++)
+    {
+        size_t pos = wid * local_size * VALUES_PER_WORKITEM + i * local_size + lid;
+        if (pos < n)
+        {
+            temp_sum += arr[pos];
+        }
+    }
+    atomic_add(sum, temp_sum);
+}
+
+#define WORKGROUP_SIZE 64
+__kernel void sum_local(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    size_t gid = get_global_id(0);
+    size_t lid = get_local_id(0);
+
+    __local unsigned int local_buf[WORKGROUP_SIZE];
+    local_buf[lid] = arr[gid];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (lid == 0)
+    {
+        unsigned int temp_sum = 0;
+        for (size_t i = 0; i < WORKGROUP_SIZE; i++)
+        {
+            temp_sum += local_buf[i];
+        }
+        atomic_add(sum, temp_sum);
+    }
+}
+
+__kernel void sum_tree_atomic(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    size_t gid = get_global_id(0);
+    size_t lid = get_local_id(0);
+
+    __local unsigned int local_buf[WORKGROUP_SIZE];
+    local_buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (size_t nvalues = WORKGROUP_SIZE; nvalues > 1; nvalues /= 2)
+    {
+        if (2 * lid < nvalues)
+        {
+            unsigned int a = local_buf[lid];
+            unsigned int b = local_buf[lid + nvalues / 2];
+            local_buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0)
+    {
+        atomic_add(sum, local_buf[0]);
+    }
+}
+
+__kernel void sum_tree_array(__global const unsigned int *arr, __global unsigned int *sum, unsigned int n)
+{
+    size_t gid = get_global_id(0);
+    size_t lid = get_local_id(0);
+    size_t wid = get_group_id(0);
+
+    __local unsigned int local_buf[WORKGROUP_SIZE];
+    local_buf[lid] = gid < n ? arr[gid] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    for (size_t nvalues = WORKGROUP_SIZE; nvalues > 1; nvalues /= 2)
+    {
+        if (2 * lid < nvalues)
+        {
+            unsigned int a = local_buf[lid];
+            unsigned int b = local_buf[lid + nvalues / 2];
+            local_buf[lid] = a + b;
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (lid == 0)
+    {
+        sum[wid] = local_buf[0];
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -51,7 +51,7 @@ __kernel void sum_local(__global const unsigned int *arr, __global unsigned int 
     size_t lid = get_local_id(0);
 
     __local unsigned int local_buf[WORKGROUP_SIZE];
-    local_buf[lid] = arr[gid];
+    local_buf[lid] = gid < n ? arr[gid] : 0;
 
     barrier(CLK_LOCAL_MEM_FENCE);
 

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,46 +106,78 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего, в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
+        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+        gpu::gpu_mem_32f result;
+        result.resizeN(width * height);
+
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i)
+        {
+            kernel.exec(gpu::WorkSize(16, 16, width, height), result.clmem(),
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY, iterationsLimit);
+            t.nextLap();
+        }
+        result.readN(gpu_results.ptr(), width * height);
+
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j)
+        {
+            for (int i = 0; i < width; ++i)
+            {
+                realIterationsFraction += gpu_results.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+        renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс
     // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+    //bool useGPU = false;
+    //renderInWindow(centralX, centralY, iterationsLimit, useGPU);
 
     return 0;
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -2,6 +2,11 @@
 #include <libutils/timer.h>
 #include <libutils/fast_random.h>
 
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+
+#include "cl/sum_cl.h"
+#include <numeric>
 
 template<typename T>
 void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
@@ -57,8 +62,77 @@ int main(int argc, char **argv)
         std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
+#define WORKGROUP_SIZE 64
     {
         // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+         gpu::Context context;
+         context.init(device.device_id_opencl);
+         context.activate();
+         std::vector<std::string> kernel_names =
+         {
+             "sum_atomic",
+             "sum_atomic_cycle",
+             "sum_atomic_cycle_coalesced",
+             "sum_local",
+             "sum_tree_atomic",
+             //"sum_tree_array"  <-- здесь в конце нужен массив, потому вместе со всеми не получится
+         };
+         gpu::gpu_mem_32u as_gpu;
+         as_gpu.resizeN(n);
+         as_gpu.writeN(as.data(), n);
+         gpu::gpu_mem_32u result;
+         result.resizeN(1);
+
+         for (const std::string& kernel_name : kernel_names)
+         {
+             ocl::Kernel kernel(sum_kernel, sum_kernel_length, kernel_name);
+             bool printLog = false;
+             kernel.compile(printLog);
+
+             timer t;
+             for (int iter = 0; iter < benchmarkingIters; iter++)
+             {
+                 unsigned int sum = 0;
+                 result.writeN(&sum, 1);
+                 kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, n), as_gpu, result, n);
+                 result.readN(&sum, 1);
+                 EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent: " + kernel_name);
+                 t.nextLap();
+             }
+             std::cout << "GPU " << kernel_name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+             std::cout << "GPU " << kernel_name << ": " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+         }
+
+         ocl::Kernel kernel(sum_kernel, sum_kernel_length, "sum_tree_array");
+         bool printLog = false;
+         kernel.compile(printLog);
+
+         gpu::gpu_mem_32u result_arr;
+         size_t n_groups = gpu::divup(n, WORKGROUP_SIZE);
+         std::vector<unsigned int> vec(n_groups, 0);
+         result_arr.resizeN(n_groups);
+
+         timer t;
+         for (int iter = 0; iter < benchmarkingIters; iter++)
+         {
+             t.stop();
+             unsigned int sum = 0;
+             vec.assign(n_groups, 0);
+             result_arr.writeN(vec.data(), n_groups);
+
+             t.start();
+             kernel.exec(gpu::WorkSize(WORKGROUP_SIZE, n), as_gpu, result_arr, n);
+             t.stop();
+
+             result_arr.readN(vec.data(), n_groups);
+             sum = std::accumulate(vec.begin(), vec.end(), 0U);
+             EXPECT_THE_SAME(reference_sum, sum, "GPU result should be consistent!");
+             t.nextLap();
+         }
+         std::cout << "GPU sum_tree_array: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+         std::cout << "GPU sum_tree_array: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
+
+    return 0;
 }


### PR DESCRIPTION
| CPU | GPU |
| ------------- | ------------- |
| ![mandelbrot_cpu](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/58438883/4df1cc1c-7bc3-47e7-ad4e-fdfc337419ca) | ![mandelbrot_gpu](https://github.com/GPGPUCourse/GPGPUTasks2023/assets/58438883/97b9fa2b-3fc3-4e04-9337-71477c931489) |

<details><summary>Локальный вывод (mandelbrot)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
CPU: 0.796+-0.00447214 s
CPU: 12.5628 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0225+-0.0005 s
GPU: 444.444 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0%
</pre>

</p></details>

<details><summary>Вывод Github CI (mandelbrot)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
CPU: 0.601955+-4.3478e-05 s
CPU: 16.6125 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.152959+-0.000121266 s
GPU: 65.3771 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.943129%
</pre>

</p></details>

На каком-то сайте нашёл, что для моей карты максимум при работе с флотами -- 1126 ГФлопс. То есть удалось достичь примерно 40% от теоретического максимума. 

<details><summary>Локальный вывод (sum)</summary><p>

<pre>
CPU:     0.414333+-0.00694422 s
CPU:     241.352 millions/s
CPU OMP: 0.121667+-0.00179505 s
CPU OMP: 821.918 millions/s
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
GPU sum_atomic: 0.126167+-0.00474049 s
GPU sum_atomic: 792.602 millions/s
GPU sum_atomic_cycle: 0.05+-0.00057735 s
GPU sum_atomic_cycle: 2000 millions/s
GPU sum_atomic_cycle_coalesced: 0.0128333+-0.000372678 s
GPU sum_atomic_cycle_coalesced: 7792.21 millions/s
GPU sum_local: 0.068+-0.00141421 s
GPU sum_local: 1470.59 millions/s
GPU sum_tree_atomic: 0.0245+-0.000763763 s
GPU sum_tree_atomic: 4081.63 millions/s
GPU sum_tree_array: 0.034+-0 s
GPU sum_tree_array: 2941.18 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI (sum)</summary><p>

<pre>
CPU:     0.0321405+-4.59193e-05 s
CPU:     3111.34 millions/s
CPU OMP: 0.019538+-0.0035356 s
CPU OMP: 5118.23 millions/s
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
GPU sum_atomic: 1.47512+-0.000548329 s
GPU sum_atomic: 67.7909 millions/s
GPU sum_atomic_cycle: 0.0267782+-1.30947e-05 s
GPU sum_atomic_cycle: 3734.39 millions/s
GPU sum_atomic_cycle_coalesced: 0.0277688+-5.04328e-05 s
GPU sum_atomic_cycle_coalesced: 3601.16 millions/s
GPU sum_local: 0.0387655+-4.47837e-05 s
GPU sum_local: 2579.61 millions/s
GPU sum_tree_atomic: 0.214503+-0.000194644 s
GPU sum_tree_atomic: 466.194 millions/s
GPU sum_tree_array: 0.197417+-0.000380628 s
GPU sum_tree_array: 506.543 millions/s
</pre>

</p></details>

Поначалу циклы с atomic локально показывали себя не лучшим образом, но потом я допёр, что в их случаях количество групп нужно менять соразмерно размеру группы, и `atomic_cycle_coalesced` вышел на первое место. Дерево с атомарным прибавлением идёт на втором месте, хотя, может быть, если покрутить ещё константы, то можно будет найти набор параметров, при котором дерево с массивом будет выигрывать.