### PR TITLE
Task06 Александр Софрыгин ITMO

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,27 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#line 2
+
+__kernel void bitonic(__global float *as, unsigned int n, unsigned int block_size, unsigned int gap) {
+    unsigned int lower_i = get_global_id(0);
+    unsigned int higher_i = lower_i ^ gap;
+    if (higher_i > lower_i)
+    {
+        float lower = as[lower_i];
+        float higher = as[higher_i];
+        if (lower_i & block_size)
+        {
+            if (lower < higher)
+            {
+                as[lower_i] = higher;
+                as[higher_i] = lower;
+            }
+        }
+        else
+        {
+            if (lower > higher)
+            {
+                as[lower_i] = higher;
+                as[higher_i] = lower;
+            }
+        }
+    }
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,22 @@
-// TODO
+#line 2
+
+__kernel void prefix_sum(__global const unsigned int *as, __global unsigned int *result, unsigned int n, unsigned int take_id)
+{
+    unsigned int i = get_global_id(0);
+    if (i < n && i & take_id)
+    {
+        result[i] += as[i / take_id - 1];
+    }
+}
+
+__kernel void reduce(__global const unsigned int *as, __global unsigned int *bs, unsigned int n)
+{
+    unsigned int i = get_global_id(0);
+    if (i >= n)
+    {
+        return;
+    }
+    unsigned int x = (2 * i >= n) ? 0 : as[2 * i];
+    unsigned int y = (2 * i + 1 >= n) ? 0 : as[2 * i + 1];
+    bs[i] = x + y;
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+    
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -59,15 +59,23 @@ int main(int argc, char **argv) {
         bitonic.compile();
 
         timer t;
+        const size_t WS_SIZE = 256;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (unsigned int i = 2; i <= n; i <<= 1)
+            {
+                for (unsigned int j = (i >> 1); j > 0; j >>= 1)
+                {
+                    bitonic.exec(gpu::WorkSize(WS_SIZE, n), as_gpu, n, i, j);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "GPU: " << (n / 1000. / 1000.) / t.lapAvg() << " millions/s" << std::endl;
 
         as_gpu.readN(as.data(), n);
     }
@@ -76,6 +84,7 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
+    std::cout << "Ok!" << std::endl;
     return 0;
 }

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -65,11 +65,11 @@ int main(int argc, char **argv) {
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            for (unsigned int i = 2; i <= n; i <<= 1)
+            for (unsigned int block_size = 2; block_size <= n; block_size <<= 1)
             {
-                for (unsigned int j = (i >> 1); j > 0; j >>= 1)
+                for (unsigned int gap = (block_size >> 1); gap > 0; gap >>= 1)
                 {
-                    bitonic.exec(gpu::WorkSize(WS_SIZE, n), as_gpu, n, i, j);
+                    bitonic.exec(gpu::WorkSize(WS_SIZE, n), as_gpu, n, block_size, gap);
                 }
             }
             t.nextLap();


### PR DESCRIPTION
<details><summary>Локальный вывод (bitonic sort)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Data generated for n=33554432!
CPU: 23.2778+-0.0581791 s
CPU: 1.41766 millions/s
GPU: 2.91633+-0.0273476 s
GPU: 11.5057 millions/s
Ok!
</pre>

</p></details>

<details><summary>Вывод Github CI (bitonic sort)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 3.79654+-0.00669544 s
CPU: 8.69213 millions/s
GPU: 6.69019+-0.0180778 s
GPU: 5.01547 millions/s
Ok!
</pre>

</p></details>

<details><summary>Локальный вывод (prefix sums) </summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 6074 Mb
  Device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
Using device #1: GPU. AMD Radeon(TM) Vega 8 Graphics (gfx902). Free memory: 4053/4133 Mb
______________________________________________
n=4096 values in range: [0; 1023]
Start measuring
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.003+-4.1159e-11 s
GPU: 1.36533 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
Start measuring
CPU: 0.000166667+-0.000372678 s
CPU: 98.304 millions/s
GPU: 0.0035+-0.0005 s
GPU: 4.68114 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
Start measuring
CPU: 0.00133333+-0.000471405 s
CPU: 49.152 millions/s
GPU: 0.00416667+-0.000372678 s
GPU: 15.7286 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
Start measuring
CPU: 0.00433333+-0.000471405 s
CPU: 60.4948 millions/s
GPU: 0.006+-8.23181e-11 s
GPU: 43.6907 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
Start measuring
CPU: 0.0176667+-0.000471405 s
CPU: 59.3534 millions/s
GPU: 0.0105+-0.0005 s
GPU: 99.8644 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
Start measuring
CPU: 0.0698333+-0.00267187 s
CPU: 60.0616 millions/s
GPU: 0.028+-0 s
GPU: 149.797 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
Start measuring
CPU: 0.287833+-0.00636178 s
CPU: 58.288 millions/s
GPU: 0.1+-0.002 s
GPU: 167.772 millions/s
Ok!
</pre>

</p></details>

<details><summary>Вывод Github CI (prefix sums)</summary><p>

<pre>
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
Start measuring
CPU: 5e-06+-5.68434e-14 s
CPU: 819.2 millions/s
GPU: 0.0003525+-3.04781e-05 s
GPU: 11.6199 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
Start measuring
CPU: 1.2e-05+-0 s
CPU: 1365.33 millions/s
GPU: 0.000513667+-1.62549e-05 s
GPU: 31.8962 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
Start measuring
CPU: 4.55e-05+-5e-07 s
CPU: 1440.35 millions/s
GPU: 0.00110417+-2.28358e-05 s
GPU: 59.3534 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
Start measuring
CPU: 0.000187167+-4.25898e-06 s
CPU: 1400.59 millions/s
GPU: 0.00323483+-5.06768e-05 s
GPU: 81.0379 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
Start measuring
CPU: 0.0007315+-3.31197e-05 s
CPU: 1433.46 millions/s
GPU: 0.0117447+-0.000536288 s
GPU: 89.281 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
Start measuring
CPU: 0.00296617+-3.90914e-05 s
CPU: 1414.05 millions/s
GPU: 0.0479925+-0.00074838 s
GPU: 87.395 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
Start measuring
CPU: 0.0430492+-0.000194681 s
CPU: 389.722 millions/s
GPU: 0.239795+-0.00375588 s
GPU: 69.9648 millions/s
Ok!
</pre>

</p></details>