### PR TITLE
Task06 Денис Порсев HSE

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,3 +1,26 @@
-__kernel void bitonic(__global float *as) {
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define max(x, y) x > y ? x : y
+#define min(x, y) x < y ? x : y
+
+__kernel void bitonic(__global float *as, unsigned int chunk, unsigned int stride, unsigned int n) {
+    unsigned idx = get_global_id(0);
+    unsigned id2x = idx << 1;
+
+    if (id2x >= n) return;
+    
+    unsigned s = id2x / chunk;
+    idx = s * chunk
+        + (idx - idx / stride * stride) 
+        + (id2x - s * chunk ) / (stride << 1) * (stride << 1);
+
+    float max = max(as[idx], as[idx + stride]);
+    float min = min(as[idx], as[idx + stride]);
+
+    as[idx] = (s & 1) ? max : min;
+    as[idx + stride] = (s & 1) ? min : max;
 }

--- a/src/cl/prefix_sum.cl
+++ b/src/cl/prefix_sum.cl
@@ -1,1 +1,23 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+__kernel void reduce(__global const unsigned int *bs,
+                     __global unsigned int *as,
+                     const unsigned int n) {
+    int idx = get_global_id(0);
+    if (idx < n)
+        as[idx] = bs[idx * 2] + bs[idx * 2 + 1];
+}
+
+__kernel void prefix_sum(__global const unsigned int *as,
+                         __global unsigned int *res,
+                         unsigned int stride, 
+                         const unsigned int n) {
+    int idx = get_global_id(0);
+    
+    if (idx < n && ++idx & stride)
+        res[idx - 1] += as[idx / stride - 1];
+}

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-    /*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
@@ -58,13 +58,20 @@ int main(int argc, char **argv) {
         ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
         bitonic.compile();
 
+        const size_t workGroupSize = 128;
+
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             as_gpu.writeN(as.data(), n);
 
             t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
 
-            // TODO
+            for (unsigned stride = 2; stride <= n; stride <<= 1) {
+                for (unsigned gap = stride / 2; gap > 0; gap >>= 1) {
+                    bitonic.exec(gpu::WorkSize(workGroupSize, n / 2), as_gpu, stride, gap, n);
+                }
+            }
+            t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
@@ -76,6 +83,6 @@ int main(int argc, char **argv) {
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
+
     return 0;
 }

--- a/src/main_prefix_sum.cpp
+++ b/src/main_prefix_sum.cpp
@@ -1,83 +1,123 @@
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
 // Этот файл будет сгенерирован автоматически в момент сборки - см. convertIntoHeader в CMakeLists.txt:18
 #include "cl/prefix_sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
-	if (a != b) {
-		std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
-		throw std::runtime_error(message);
-	}
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
+    if (a != b) {
+        std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
+        throw std::runtime_error(message);
+    }
 }
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
-	int benchmarkingIters = 10;
-	unsigned int max_n = (1 << 24);
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
-	for (unsigned int n = 4096; n <= max_n; n *= 4) {
-		std::cout << "______________________________________________" << std::endl;
-		unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
-		std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
-		std::vector<unsigned int> as(n, 0);
-		FastRandom r(n);
-		for (int i = 0; i < n; ++i) {
-			as[i] = r.next(0, values_range);
-		}
+    int benchmarkingIters = 10;
+    unsigned int max_n = (1 << 24);
 
-		std::vector<unsigned int> bs(n, 0);
-		{
-			for (int i = 0; i < n; ++i) {
-				bs[i] = as[i];
-				if (i) {
-					bs[i] += bs[i-1];
-				}
-			}
-		}
-		const std::vector<unsigned int> reference_result = bs;
+    for (unsigned int n = 4096; n <= max_n; n *= 4) {
+        std::cout << "______________________________________________" << std::endl;
+        unsigned int values_range = std::min<unsigned int>(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << 0 << "; " << values_range << "]" << std::endl;
 
-		{
-			{
-				std::vector<unsigned int> result(n);
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				for (int i = 0; i < n; ++i) {
-					EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
-				}
-			}
+        std::vector<unsigned int> as(n, 0);
+        FastRandom r(n);
+        for (int i = 0; i < n; ++i) {
+            as[i] = r.next(0, values_range);
+        }
 
-			std::vector<unsigned int> result(n);
-			timer t;
-			for (int iter = 0; iter < benchmarkingIters; ++iter) {
-				for (int i = 0; i < n; ++i) {
-					result[i] = as[i];
-					if (i) {
-						result[i] += result[i-1];
-					}
-				}
-				t.nextLap();
-			}
-			std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-			std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
-		}
+        std::vector<unsigned int> bs(n, 0);
+        {
+            for (int i = 0; i < n; ++i) {
+                bs[i] = as[i];
+                if (i) {
+                    bs[i] += bs[i - 1];
+                }
+            }
+        }
+        const std::vector<unsigned int> reference_result = bs;
 
-		{
-			// TODO: implement on OpenCL
-		}
-	}
+        {
+            {
+                std::vector<unsigned int> result(n);
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                for (int i = 0; i < n; ++i) {
+                    EXPECT_THE_SAME(reference_result[i], result[i], "CPU result should be consistent!");
+                }
+            }
+
+            std::vector<unsigned int> result(n);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                for (int i = 0; i < n; ++i) {
+                    result[i] = as[i];
+                    if (i) {
+                        result[i] += result[i - 1];
+                    }
+                }
+                t.nextLap();
+            }
+            std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "CPU: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        }
+
+        gpu::gpu_mem_32u as_gpu, bs_gpu, cs_gpu;
+        as_gpu.resizeN(n);
+        bs_gpu.resizeN(n);
+        cs_gpu.resizeN(n);
+        {
+            ocl::Kernel reduce(prefix_sum_kernel, prefix_sum_kernel_length, "reduce");
+            reduce.compile();
+            ocl::Kernel prefix_sum(prefix_sum_kernel, prefix_sum_kernel_length, "prefix_sum");
+            prefix_sum.compile();
+            std::vector<unsigned int> cs(n, 0);
+
+            const size_t workGroupSize = 128;
+
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                as_gpu.writeN(as.data(), n);
+                cs_gpu.writeN(cs.data(), n);
+
+                t.restart();// Запускаем секундомер после прогрузки данных, чтобы замерять время работы кернела, а не трансфер данных
+
+                prefix_sum.exec(gpu::WorkSize(workGroupSize, n), as_gpu, cs_gpu, 1, n);
+                for (unsigned int stride = 2; stride <= n; stride *= 2) {
+                    std::swap(as_gpu, bs_gpu);
+                    reduce.exec(gpu::WorkSize(workGroupSize, n / stride), bs_gpu, as_gpu, n / stride);
+                    prefix_sum.exec(gpu::WorkSize(workGroupSize, n), as_gpu, cs_gpu, stride, n);
+                }
+                t.nextLap();
+            }
+
+            std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU: " << (n / 1000 / 1000) / t.lapAvg() << " millions/s" << std::endl;
+
+            cs_gpu.readN(cs.data(), n);
+
+            // Проверяем корректность результатов
+            for (int i = 0; i < n; ++i) {
+                EXPECT_THE_SAME(cs[i], reference_result[i], "GPU results should be equal to CPU results!");
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Bitonic sort

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./bitonic 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15799 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 12639 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
Data generated for n=33554432!
CPU: 14.3332+-0.163189 s
CPU: 2.30235 millions/s
GPU: 0.626897+-0.000295265 s
GPU: 52.6403 millions/s

Process finished with exit code 0
</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./bitonic
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for n=33554432!
CPU: 3.69753+-0.00102169 s
CPU: 8.92489 millions/s
GPU: 15.2721+-0.00544629 s
GPU: 2.1608 millions/s
</pre>

</p></details>

### Prefix sum

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./prefix_sum 2
OpenCL devices:
  Device #0: CPU. Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz. Intel(R) Corporation. Total memory: 15799 Mb
  Device #1: GPU. Intel(R) UHD Graphics. Total memory: 12639 Mb
  Device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
Using device #2: GPU. NVIDIA GeForce GTX 1650 with Max-Q Design. Total memory: 3903 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.6e-05+-0 s
CPU: 157.538 millions/s
GPU: 0.0003185+-4.99166e-06 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 0.0001995+-1.68201e-05 s
CPU: 82.1253 millions/s
GPU: 0.000403333+-7.80313e-06 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 0.000815667+-4.76748e-05 s
CPU: 80.3465 millions/s
GPU: 0.000471833+-4.05233e-05 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.00272267+-0.000225666 s
CPU: 96.2821 millions/s
GPU: 0.000789333+-3.10036e-05 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.00972767+-0.0010738 s
CPU: 107.793 millions/s
GPU: 0.00191367+-3.40082e-05 s
GPU: 522.557 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.055353+-0.00111008 s
CPU: 75.7737 millions/s
GPU: 0.00684117+-0.000104818 s
GPU: 584.696 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.209433+-0.00328157 s
CPU: 80.1077 millions/s
GPU: 0.0213735+-0.00258054 s
GPU: 748.591 millions/s

Process finished with exit code 0
</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./prefix_sum
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
______________________________________________
n=4096 values in range: [0; 1023]
CPU: 2.66667e-06+-4.71405e-07 s
CPU: 1536 millions/s
GPU: 0.000427167+-0.000241504 s
GPU: 0 millions/s
______________________________________________
n=16384 values in range: [0; 1023]
CPU: 1.01667e-05+-3.72678e-07 s
CPU: 1611.54 millions/s
GPU: 0.0005975+-0.000281523 s
GPU: 0 millions/s
______________________________________________
n=65536 values in range: [0; 1023]
CPU: 4.21667e-05+-6.87184e-07 s
CPU: 1554.21 millions/s
GPU: 0.00200283+-0.000394004 s
GPU: 0 millions/s
______________________________________________
n=262144 values in range: [0; 1023]
CPU: 0.000162667+-7.45356e-07 s
CPU: 1611.54 millions/s
GPU: 0.00509217+-0.000591347 s
GPU: 0 millions/s
______________________________________________
n=1048576 values in range: [0; 1023]
CPU: 0.000649667+-7.45356e-07 s
CPU: 1614.02 millions/s
GPU: 0.0113512+-2.83515e-05 s
GPU: 88.0967 millions/s
______________________________________________
n=4194304 values in range: [0; 511]
CPU: 0.00261767+-5.31246e-06 s
CPU: 1602.31 millions/s
GPU: 0.0467825+-0.000148021 s
GPU: 85.5021 millions/s
______________________________________________
n=16777216 values in range: [0; 127]
CPU: 0.0121123+-1.36829e-05 s
CPU: 1385.13 millions/s
GPU: 0.197631+-0.000218898 s
GPU: 80.959 millions/s
</pre>

</p></details>