### PR TITLE
Task04 Илья Калганов ITMO

### DIFF
--- a/src/cl/matrix_multiplication.cl
+++ b/src/cl/matrix_multiplication.cl
@@ -1,4 +1,93 @@
-__kernel void matrix_multiplication(...)
-{
-    // TODO
+#line 2
+
+__kernel void matrix_multiplication_basic(global const float *matrixA, global const float *matrixB, __global float *matrixC, unsigned int rowCountA, unsigned int commonDimension, unsigned int columnCountB) {
+    size_t columnIndex = get_global_id(0);
+    size_t rowIndex = get_global_id(1);
+
+    if (columnIndex >= columnCountB || rowIndex >= rowCountA) {
+        return;
+    }
+
+    float accumulatedValue = 0.0;
+    for (size_t iter = 0; iter < commonDimension; iter++) {
+        accumulatedValue += matrixA[rowIndex * commonDimension + iter] * matrixB[iter * columnCountB + columnIndex];
+    }
+    matrixC[rowIndex * columnCountB + columnIndex] = accumulatedValue;
+}
+
+
+__kernel void matrix_multiplication_local(global const float *matrixA, global const float *matrixB, __global float *resultMatrix, unsigned int rowCountA, unsigned int commonDimension, unsigned int columnCountB) {
+    size_t globalColumnIndex = get_global_id(0);
+    size_t globalRowIndex = get_global_id(1);
+    size_t localColumnIndex = get_local_id(0);
+    size_t localRowIndex = get_local_id(1);
+    __local float localTileA[TILE_SIZE][TILE_SIZE + 1];
+    __local float localTileB[TILE_SIZE][TILE_SIZE + 1];
+
+    float accumulatedValue = 0.0f;
+    for (size_t tileIndex = 0; tileIndex * TILE_SIZE < commonDimension; tileIndex++) {
+        const size_t offset = tileIndex * TILE_SIZE;
+        if (globalRowIndex < rowCountA && (tileIndex * TILE_SIZE + localColumnIndex) < commonDimension) {
+            localTileA[localRowIndex][localColumnIndex] = matrixA[globalRowIndex * commonDimension + offset + localColumnIndex];
+        }
+
+        if (globalColumnIndex < columnCountB && tileIndex * TILE_SIZE + localRowIndex < commonDimension) {
+            localTileB[localRowIndex][localColumnIndex] = matrixB[(offset + localRowIndex) * columnCountB + globalColumnIndex];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        for (size_t innerIndex = 0; innerIndex < TILE_SIZE; innerIndex++) {
+            accumulatedValue += localTileA[localRowIndex][innerIndex] * localTileB[innerIndex][localColumnIndex];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    if (globalRowIndex < rowCountA && globalColumnIndex < columnCountB) {
+        resultMatrix[globalRowIndex * columnCountB + globalColumnIndex] = accumulatedValue;
+    }
+}
+
+__kernel void matrix_multiplication_local_work(global const float *matrixA, global const float *matrixB, __global float *resultMatrix, unsigned int rowCountA, unsigned int commonDimension, unsigned int columnCountB) {
+    size_t localRowIndex = get_local_id(0);
+    size_t localColumnIndex = get_local_id(1);
+    size_t globalRowIndex = get_global_id(0);
+    size_t globalColumnIndex = get_group_id(1) * TILE_SIZE + localColumnIndex;
+
+    __local float localTileA[TILE_SIZE][TILE_SIZE + 1];
+    __local float localTileB[TILE_SIZE][TILE_SIZE + 1];
+    const size_t WORK_STEP = TILE_SIZE / THREAD_WORK;
+
+    float accumulatedValues[THREAD_WORK] = { 0 };
+
+    for (size_t tileIndex = 0; tileIndex * TILE_SIZE < commonDimension; tileIndex++) {
+        const size_t offset = tileIndex * TILE_SIZE;
+        for (size_t workIndex = 0; workIndex * WORK_STEP < TILE_SIZE; workIndex++) {
+            const size_t workOffset = workIndex * WORK_STEP;
+            if (globalColumnIndex + workOffset < rowCountA && offset + localRowIndex < commonDimension) {
+                localTileA[localColumnIndex + workOffset][localRowIndex] = matrixA[(globalColumnIndex + workOffset) * commonDimension + offset + localRowIndex];
+            }
+
+            if (globalRowIndex < columnCountB && offset + localColumnIndex + workOffset < commonDimension) {
+                localTileB[localColumnIndex + workOffset][localRowIndex] = matrixB[(offset + localColumnIndex + workOffset) * columnCountB + globalRowIndex];
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        const size_t end = (TILE_SIZE < (commonDimension - offset)) ? TILE_SIZE : (commonDimension - offset);
+        for (size_t innerIndex = 0; innerIndex < end; innerIndex++) {
+            const float elementB = localTileB[innerIndex][localRowIndex];
+            for (size_t workIndex = 0; workIndex < THREAD_WORK; workIndex++) {
+                if (globalRowIndex < columnCountB && globalColumnIndex + workIndex * WORK_STEP < rowCountA) {
+                    accumulatedValues[workIndex] += elementB * localTileA[localColumnIndex + workIndex * WORK_STEP][innerIndex];
+                }
+            }
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    for (size_t workIndex = 0; workIndex < THREAD_WORK; workIndex++) {
+        if (globalRowIndex < columnCountB && globalColumnIndex + WORK_STEP * workIndex < rowCountA) {
+            resultMatrix[(globalColumnIndex + WORK_STEP * workIndex) * columnCountB + globalRowIndex] = accumulatedValues[workIndex];
+        }
+    }
 }

--- a/src/cl/matrix_transpose.cl
+++ b/src/cl/matrix_transpose.cl
@@ -1,4 +1,40 @@
-__kernel void matrix_transpose(...)
+#line 2
+
+#define TILE_SIZE 16
+__kernel void matrix_transpose(global const float *inputMatrix, global float *transposedMatrix, unsigned int rows, unsigned int columns) {
+    int columnIndex = get_global_id(0);
+    int rowIndex = get_global_id(1);
+
+    __local float localTile[TILE_SIZE][TILE_SIZE];
+    int localColumnIndex = get_local_id(0);
+    int localRowIndex = get_local_id(1);
+
+    if (columnIndex < columns && rowIndex < rows) {
+        localTile[localRowIndex][localColumnIndex] = inputMatrix[rowIndex * columns + columnIndex];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (columnIndex < columns && rowIndex < rows) {
+        transposedMatrix[columnIndex * rows + rowIndex] = localTile[localRowIndex][localColumnIndex];
+    }
+}
+
+
+__kernel void matrix_transpose_banks(global const float *inputMatrix, global float *transposedMatrix, unsigned int rowCount, unsigned int columnCount)
 {
-    // TODO
+    int columnIndex = get_global_id(0);
+    int rowIndex = get_global_id(1);
+
+    __local float localTile[TILE_SIZE][TILE_SIZE + 1];
+    int localColumnIndex = get_local_id(0);
+    int localRowIndex = get_local_id(1);
+
+    if (columnIndex < columnCount && rowIndex < rowCount) {
+        localTile[localRowIndex][localColumnIndex] = inputMatrix[rowIndex * columnCount + columnIndex];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (columnIndex < columnCount && rowIndex < rowCount) {
+        transposedMatrix[columnIndex * rowCount + rowIndex] = localTile[localRowIndex][localColumnIndex];
+    }
 }

--- a/src/main_matrix_multiplication.cpp
+++ b/src/main_matrix_multiplication.cpp
@@ -11,8 +11,7 @@
 #include <stdexcept>
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
@@ -58,52 +57,77 @@ int main(int argc, char **argv)
 
     const std::vector<float> cs_cpu_reference = cs;
 
-    /*
-    gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
-    as_gpu.resizeN(M*K);
-    bs_gpu.resizeN(K*N);
-    cs_gpu.resizeN(M*N);
+    struct KernelConfig {
+        std::string name;
+        size_t thread_work;
+    };
 
-    as_gpu.writeN(as.data(), M*K);
-    bs_gpu.writeN(bs.data(), K*N);
+    std::vector<KernelConfig> kernels =
+            {
+                    { "matrix_multiplication_basic", 1 },
+                    { "matrix_multiplication_local", 1 },
+                    { "matrix_multiplication_local_work", 2 },
+                    { "matrix_multiplication_local_work", 4 },
+                    { "matrix_multiplication_local_work", 8 },
+            };
 
-    ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length, "matrix_multiplication");
-    matrix_multiplication_kernel.compile();
-
+    for (const KernelConfig& config : kernels)
     {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            matrix_multiplication_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, bs_gpu, cs_gpu, M, K, N);
+        gpu::gpu_mem_32f as_gpu, bs_gpu, cs_gpu;
+        as_gpu.resizeN(M* K);
+        bs_gpu.resizeN(K* N);
+        cs_gpu.resizeN(M* N);
 
-            t.nextLap();
+        as_gpu.writeN(as.data(), M* K);
+        bs_gpu.writeN(bs.data(), K* N);
+
+        const unsigned int tile_size = 16;
+        const unsigned int thread_work_size = config.thread_work;
+
+        std::string param_string = "-DTILE_SIZE=" + std::to_string(tile_size)
+                                   + " -DTHREAD_WORK=" + std::to_string(thread_work_size);
+        ocl::Kernel matrix_multiplication_kernel(matrix_multiplication, matrix_multiplication_length,
+                                                 config.name, param_string);
+        matrix_multiplication_kernel.compile();
+
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                gpu::WorkSize ws
+                        (
+                                tile_size,
+                                tile_size / thread_work_size,
+                                M, gpu::divup(N, thread_work_size)
+                        );
+                matrix_multiplication_kernel.exec(ws, as_gpu, bs_gpu, cs_gpu, M, K, N);
+
+                t.nextLap();
+            }
+            std::cout << "GPU " << config.name << ", thread_work_size = " << thread_work_size << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU " << config.name << ", thread_work_size = " << thread_work_size << ": " << gflops / t.lapAvg() << " GFlops" << std::endl;
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << gflops / t.lapAvg() << " GFlops" << std::endl;
-    }
 
-    cs_gpu.readN(cs.data(), M*N);
-    */
+        cs_gpu.readN(cs.data(), M * N);
 
-    // Проверяем корректность результатов
-    double diff_sum = 0;
-    for (int i = 0; i < M * N; ++i) {
-        double a = cs[i];
-        double b = cs_cpu_reference[i];
-        if (a != 0.0 || b != 0.0) {
-            double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
-            diff_sum += diff;
+        // Проверяем корректность результатов
+        double diff_sum = 0;
+        for (int i = 0; i < M * N; ++i) {
+            double a = cs[i];
+            double b = cs_cpu_reference[i];
+            if (a != 0.0 || b != 0.0) {
+                double diff = fabs(a - b) / std::max(fabs(a), fabs(b));
+                diff_sum += diff;
+            }
         }
-    }
 
-    double diff_avg = diff_sum / (M * N);
-    std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
-    if (diff_avg > 0.01) {
-        std::cerr << "Too big difference!" << std::endl;
-        return 1;
+        double diff_avg = diff_sum / (M * N);
+        std::cout << "Average difference: " << diff_avg * 100.0 << "%" << std::endl;
+        if (diff_avg > 0.01) {
+            std::cerr << "Too big difference!" << std::endl;
+            return 1;
+        }
     }
 
     return 0;
 }
+

--- a/src/main_matrix_transpose.cpp
+++ b/src/main_matrix_transpose.cpp
@@ -11,8 +11,7 @@
 #include <stdexcept>
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
 
     gpu::Context context;
@@ -32,49 +31,58 @@ int main(int argc, char **argv)
     }
     std::cout << "Data generated for M=" << M << ", K=" << K << std::endl;
 
-    /*
     gpu::gpu_mem_32f as_gpu, as_t_gpu;
     as_gpu.resizeN(M*K);
     as_t_gpu.resizeN(K*M);
 
     as_gpu.writeN(as.data(), M*K);
 
-    ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, "matrix_transpose");
-    matrix_transpose_kernel.compile();
+    std::vector<std::string> kernel_names =
+            {
+                    "matrix_transpose",
+                    "matrix_transpose_banks",
+            };
 
-    {
-        timer t;
-        for (int iter = 0; iter < benchmarkingIters; ++iter) {
-            // TODO
-            unsigned int work_group_size = 128;
-            unsigned int global_work_size = ...;
-            // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
-            // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
-            // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
-            // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
-            // - для 1D, 2D и 3D рабочего пространства соответственно
-            matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), as_gpu, as_t_gpu, M, K);
+    for (const std::string& kernel_name : kernel_names) {
+        ocl::Kernel matrix_transpose_kernel(matrix_transpose, matrix_transpose_length, kernel_name);
+        matrix_transpose_kernel.compile();
 
-            t.nextLap();
+        {
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter)
+            {
+                // TODO
+                unsigned int work_group_size = 16;
+                // Для этой задачи естественнее использовать двухмерный NDRange. Чтобы это сформулировать
+                // в терминологии библиотеки - нужно вызвать другую вариацию конструктора WorkSize.
+                // В CLion удобно смотреть какие есть вариант аргументов в конструкторах:
+                // поставьте каретку редактирования кода внутри скобок конструктора WorkSize -> Ctrl+P -> заметьте что есть 2, 4 и 6 параметров
+                // - для 1D, 2D и 3D рабочего пространства соответственно
+                matrix_transpose_kernel.exec(gpu::WorkSize(work_group_size, work_group_size, K, M), as_gpu, as_t_gpu, M, K);
+
+                t.nextLap();
+            }
+            std::cout << "GPU " << kernel_name << ": " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU " << kernel_name << ": " << M * K / 1000.0 / 1000.0 / t.lapAvg() << " millions/s" << std::endl;
         }
-        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "GPU: " << M*K/1000.0/1000.0 / t.lapAvg() << " millions/s" << std::endl;
-    }
 
-    as_t_gpu.readN(as_t.data(), M*K);
+        as_t_gpu.readN(as_t.data(), M * K);
 
-    // Проверяем корректность результатов
-    for (int j = 0; j < M; ++j) {
-        for (int i = 0; i < K; ++i) {
-            float a = as[j * K + i];
-            float b = as_t[i * M + j];
-            if (a != b) {
-                std::cerr << "Not the same!" << std::endl;
-                return 1;
+        //Проверяем корректность результатов
+        for (int j = 0; j < M; ++j) {
+            for (int i = 0; i < K; ++i)
+            {
+                float a = as[j * K + i];
+                float b = as_t[i * M + j];
+                if (abs(a - b) > 1e-6)
+                {
+                    std::cerr << "Not the same!" << std::endl;
+                    return 1;
+                }
             }
         }
     }
-    */
 
     return 0;
 }
+


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
- multiplication - 
OpenCL devices:
  Device #0: GPU. Apple M2. Total memory: 5461 Mb
Using device #0: GPU. Apple M2. Total memory: 5461 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 3.86046+-0.0219549 s
CPU: 0.518072 GFlops
GPU matrix_multiplication_basic, thread_work_size = 1: 0.0347533+-0.000787859 s
GPU matrix_multiplication_basic, thread_work_size = 1: 57.5484 GFlops
Average difference: 0%
GPU matrix_multiplication_local, thread_work_size = 1: 0.00757583+-0.000269079 s
GPU matrix_multiplication_local, thread_work_size = 1: 263.997 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 2: 0.0192093+-0.000247837 s
GPU matrix_multiplication_local_work, thread_work_size = 2: 104.116 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 4: 0.0180792+-0.000586892 s
GPU matrix_multiplication_local_work, thread_work_size = 4: 110.625 GFlops
Average difference: 0%
GPU matrix_multiplication_local_work, thread_work_size = 8: 0.0267975+-0.000184287 s
GPU matrix_multiplication_local_work, thread_work_size = 8: 74.6338 GFlops
Average difference: 0%

- transpose - 
OpenCL devices:
  Device #0: GPU. Apple M2. Total memory: 5461 Mb
Using device #0: GPU. Apple M2. Total memory: 5461 Mb
Data generated for M=1024, K=1024
GPU matrix_transpose: 0.000471667+-7.06061e-05 s
GPU matrix_transpose: 2223.13 millions/s
GPU matrix_transpose_banks: 0.0004215+-2.28528e-05 s
GPU matrix_transpose_banks: 2487.72 millions/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
- multiplication - 
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024, N=1024
CPU: 5.62591+-0.000535725 s
CPU: 0.355498 GFlops
GPU matrix_multiplication_basic, thread_work_size = 1: 0.277498+-0.00542007 s
GPU matrix_multiplication_basic, thread_work_size = 1: 7.20725 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local, thread_work_size = 1: 0.0919882+-0.000271631 s
GPU matrix_multiplication_local, thread_work_size = 1: 21.7419 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 2: 0.190411+-0.000933463 s
GPU matrix_multiplication_local_work, thread_work_size = 2: 10.5036 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 4: 0.265629+-0.00103229 s
GPU matrix_multiplication_local_work, thread_work_size = 4: 7.52931 GFlops
Average difference: 0.000149043%
GPU matrix_multiplication_local_work, thread_work_size = 8: 0.181421+-0.00104882 s
GPU matrix_multiplication_local_work, thread_work_size = 8: 11.0241 GFlops
Average difference: 0.000149043%

- transpose - 
OpenCL devices:
  Device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Using device #0: CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15991 Mb
Data generated for M=1024, K=1024
GPU matrix_transpose: 0.00150767+-2.09099e-05 s
GPU matrix_transpose: 695.496 millions/s
GPU matrix_transpose_banks: 0.00184633+-0.000190823 s
GPU matrix_transpose_banks: 567.923 millions/s
</pre>

</p></details>